### PR TITLE
org.apache.tomcat.util.net.URL -> java.net.URL

### DIFF
--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/service/ApplicationRegistry.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/service/ApplicationRegistry.java
@@ -16,13 +16,13 @@
 package de.codecentric.boot.admin.service;
 
 import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang3.Validate;
-import org.apache.tomcat.util.net.URL;
 import org.springframework.stereotype.Service;
 
 import de.codecentric.boot.admin.model.Application;


### PR DESCRIPTION
There is a problem to use with Jetty because `org.apache.tomcat.util.net.URL` is used.
Probably, `java.net.URL` is right.
