### PR TITLE
Upgraded to Spring Boot 1.1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.1.6.RELEASE</version>
+		<version>1.1.7.RELEASE</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>de.codecentric</groupId>
@@ -16,7 +16,7 @@
 	<description>Spring Boot Admin</description>
 	<url>https://github.com/codecentric/spring-boot-admin/</url>
 	<properties>
-		<spring-boot.version>1.1.6.RELEASE</spring-boot.version>
+		<spring-boot.version>1.1.7.RELEASE</spring-boot.version>
 		<spring.version>4.0.7.RELEASE</spring.version>
 		<bootstrap.version>2.3.2</bootstrap.version>
 		<jquery.version>1.11.0</jquery.version>

--- a/spring-boot-admin-example/pom.xml
+++ b/spring-boot-admin-example/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>de.codecentric</groupId>
 		<artifactId>spring-boot-admin</artifactId>
-		<version>1.0.2-SNAPSHOT</version>
+		<version>1.0.3-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>	
 	<artifactId>spring-boot-admin-example</artifactId>
@@ -32,7 +32,8 @@
 					</execution>
 				</executions>
 				<configuration>
-					<mainClass>de.codecentric.SpringBootAdminApplication</mainClass>
+					<mainClass>de.codecentric.boot.admin.SpringBootAdminApplication</mainClass>
+                    <addResources>false</addResources>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/spring-boot-admin-server/pom.xml
+++ b/spring-boot-admin-server/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>de.codecentric</groupId>
 		<artifactId>spring-boot-admin</artifactId>
-		<version>1.0.2-SNAPSHOT</version>
+		<version>1.0.3-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<artifactId>spring-boot-admin-server</artifactId>

--- a/spring-boot-starter-admin-client/pom.xml
+++ b/spring-boot-starter-admin-client/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>de.codecentric</groupId>
 		<artifactId>spring-boot-admin</artifactId>
-		<version>1.0.2-SNAPSHOT</version>
+		<version>1.0.3-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>	
 	<artifactId>spring-boot-starter-admin-client</artifactId>


### PR DESCRIPTION
also includes:
- Fixed wrong parent-version
- Fixed wrong mainClass in example
- Made 'mvn spring-boot:run' work with resource filtering in example
