### PR TITLE
File-encoding fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 		<angularjs.version>1.2.12</angularjs.version>
 		<angular-ui-router.version>0.2.10-1</angular-ui-router.version>
 		<angularjs-nvd3-directives.version>0.0.7-1</angularjs-nvd3-directives.version>
-		<d3js.version>3.4.1</d3js.version>
+		<d3js.version>3.4.11</d3js.version>
 		<nvd3.version>1.1.15-beta</nvd3.version>
 		<main.basedir>${basedir}</main.basedir>
 		<passphrase>${gpg.passphrase}</passphrase>

--- a/spring-boot-admin-server/src/main/webapp/public/index.html
+++ b/spring-boot-admin-server/src/main/webapp/public/index.html
@@ -61,8 +61,8 @@
 	<script src="/webjars/angularjs/${angularjs.version}/angular-resource.min.js"></script>
 	<script src="/webjars/angularjs/${angularjs.version}/angular-route.min.js"></script>
 	<script src="/webjars/angular-ui-router/0.2.10/angular-ui-router.min.js"></script>
-	<script src="/webjars/d3js/${d3js.version}/d3.js"></script>
-	<script src="/webjars/nvd3/${nvd3.version}/nv.d3.js"></script>
+	<script src="/webjars/d3js/${d3js.version}/d3.min.js"></script>
+	<script src="/webjars/nvd3/${nvd3.version}/nv.d3.min.js"></script>
 	<script src="/webjars/angularjs-nvd3-directives/0.0.7/angularjs-nvd3-directives.js"></script>
 	<script src="/scripts/app.js"></script>
 	<script src="/scripts/controllers/controllers.js"></script>

--- a/spring-boot-admin-server/src/main/webapp/public/styles/application.css
+++ b/spring-boot-admin-server/src/main/webapp/public/styles/application.css
@@ -23,7 +23,7 @@ ul.chart-legend {
 }
 
 ul.chart-legend li:before {
-	content: "• ";
+	content: '\2022';
 	font-size: 250%;
 	vertical-align: middle;
 }

--- a/spring-boot-admin-server/src/main/webapp/public/views/apps/details/metrics.html
+++ b/spring-boot-admin-server/src/main/webapp/public/views/apps/details/metrics.html
@@ -53,7 +53,7 @@
 		<tr>
 			<td>
 				<h1 style="text-align: center;">Counter</h1>
-				<div class="center-block" style="width: 800px; height:  {{ 50 + counterData[0].values.length * 15 }}px; position:relative;">
+				<div class="center-block" style="width: 800px; height:  {{ 75 + counterData[0].values.length * 15 }}px; position:relative;">
 					<nvd3-multi-bar-horizontal-chart id="counterChart" nodata="not available" 
 									data="counterData"
 									color="colorFunction()" 
@@ -68,7 +68,7 @@
     	<tr>
     		<td>
 				<h1 style="text-align: center;">Gauge</h1>
-				<div class="center-block" style="width: 800px; height: {{ 50 + gaugeData[0].values.length * 15 }}px; position:relative;">
+				<div class="center-block" style="width: 800px; height: {{ 75 + gaugeData[0].values.length * 15 }}px; position:relative;">
 					<nvd3-multi-bar-horizontal-chart id="gaugesChart" nodata="not available" 
 									data="gaugeData"
 									color="colorFunction()"


### PR DESCRIPTION
Changed to minified version of d3.
They really used π (Pi) als variablename; since minifying replaces mnemonics, the unicode encoding is not necessary anymore.
Additionally corrected the encoding of the bullets in css and fixed the dynamic sizing of the metrics chart to consider the margin correctly.

Fixes gh-8
