### PR TITLE
Provided host and port informations for use within Docker container.

### DIFF
--- a/spring-boot-starter-admin-client/src/main/java/de/codecentric/boot/admin/services/SpringBootAdminRegistratorTask.java
+++ b/spring-boot-starter-admin-client/src/main/java/de/codecentric/boot/admin/services/SpringBootAdminRegistratorTask.java
@@ -15,7 +15,6 @@
  */
 package de.codecentric.boot.admin.services;
 
-import java.net.InetAddress;
 import java.net.URL;
 import java.util.ArrayList;
 
@@ -56,8 +55,10 @@ public class SpringBootAdminRegistratorTask implements Runnable {
 	public void run() {
 		try {
 			String id = env.getProperty("info.id");
-			int port = env.getProperty("server.port", Integer.class);
+			int port = env.getProperty("spring.boot.admin.port", Integer.class);
 			String adminUrl = env.getProperty("spring.boot.admin.url");
+			String host = env.getProperty("spring.boot.admin.host");
+			
 			RestTemplate template = new RestTemplate();
 			template.getMessageConverters().add(new MappingJackson2HttpMessageConverter());
 			ApplicationList list = template.getForObject(adminUrl + "/api/applications", ApplicationList.class);
@@ -70,7 +71,7 @@ public class SpringBootAdminRegistratorTask implements Runnable {
 			}
 			// register the application with the used URL and port
 			String managementPath = env.getProperty("management.context-path", "");
-			String url = new URL("http", InetAddress.getLocalHost().getCanonicalHostName(), port, managementPath)
+			String url = new URL("http", host, port, managementPath)
 			.toString();
 			Application app = new Application();
 			app.setId(id);


### PR DESCRIPTION
With this modification I can run Spring Boot Admin within a Docker container. I provide host and port of my Docker's host as environment variables.

An example of Docker Run command: 

docker run -d --name myservice -p 8091:8081 -e server.port=8081 -e spring.boot.admin.url='http://192.168.10.139:8091' -e spring.boot.admin.host='192.168.10.139' -e spring.boot.admin.port='8091' myservice:1.0.0

Hope you enjoy...
