### PR TITLE
Enable no argument JMX method invocation when overloaded methods exist

### DIFF
--- a/spring-boot-admin-server-ui/app/js/controller/jmxCtrl.js
+++ b/spring-boot-admin-server-ui/app/js/controller/jmxCtrl.js
@@ -102,24 +102,24 @@ module.exports = function ($scope, $modal, $log, application, ApplicationJMX) {
                     $scope.invocation = null;
                 });
         } else {
+            var signature = '(';
+            for (var i in op.args) {
+                if (i > 0) {
+                    signature += ',';
+                }
+                signature += op.args[i].type;
+                $scope.invocation.args[i] = null;
+            }
+            signature += ')';
+            $scope.invocation.opname = name + signature;
+
             if (op.args.length === 0) {
                 $scope.invoke();
             } else {
-                var signature = '(';
-                for (var i in op.args) {
-                    if (i > 0) {
-                        signature += ',';
-                    }
-                    signature += op.args[i].type;
-                    $scope.invocation.args[i] = null;
-                }
-                signature += ')';
-                $scope.invocation.opname = name + signature;
-
                 $modal.open({
-                        templateUrl: 'invocationPrepareDialog.html',
-                        scope: $scope
-                    })
+                    templateUrl: 'invocationPrepareDialog.html',
+                    scope: $scope
+                })
                     .result.then(function () {
                         $scope.invoke();
                     })


### PR DESCRIPTION
...mplemented in Jolokia Release 0.91 (http://www.jolokia.org/changes-report.html):

Fixed issue with overloaded methods where one variant takes no arguments. This no-arg variant can be specified with the signature "()" after the operation name.