### PR TITLE
Removed confusing '/' at the end of resources path

### DIFF
--- a/spring-boot-admin-server-ui/app/index.html
+++ b/spring-boot-admin-server-ui/app/index.html
@@ -30,6 +30,7 @@
 					</div>
 					<ul class="nav pull-right">
 						<li class="navbar-link" ng-class="{active: $state.includes('apps') ||  $state.includes('overview')  }"><a ui-sref="overview">Applications</a></li>
+						<li class="navbar-link" ng-class="{active: $state.includes('auth')}"><a ui-sref="auth">Auth</a></li>
 						<li class="navbar-link" ng-class="{active: $state.includes('about')}"><a ui-sref="about">About</a></li>
 					</ul>
 				</div>

--- a/spring-boot-admin-server-ui/app/js/app.js
+++ b/spring-boot-admin-server-ui/app/js/app.js
@@ -38,8 +38,10 @@ require('./controller');
 require('./service');
 require('./filter');
 require('./directive');
+require('./interceptor');
 
-springBootAdmin.config(function ($stateProvider, $urlRouterProvider) {
+springBootAdmin.config(function ($stateProvider, $urlRouterProvider, $httpProvider) {
+    $httpProvider.interceptors.push('AuthInterceptor');
     $urlRouterProvider
         .when('/', '/overview')
         .otherwise('/');
@@ -53,6 +55,11 @@ springBootAdmin.config(function ($stateProvider, $urlRouterProvider) {
         .state('about', {
             url: '/about',
             templateUrl: 'views/about.html'
+        })
+        .state('auth', {
+            url: '/auth',
+            templateUrl: 'views/auth.html',
+            controller: 'authCtrl'
         })
         .state('apps', {
             abstract: true,

--- a/spring-boot-admin-server-ui/app/js/controller/authCtrl.js
+++ b/spring-boot-admin-server-ui/app/js/controller/authCtrl.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+module.exports = function ($scope, Auth) {
+    $scope.login = function() {
+        Auth.login($scope.username, $scope.password);
+    };
+};

--- a/spring-boot-admin-server-ui/app/js/controller/index.js
+++ b/spring-boot-admin-server-ui/app/js/controller/index.js
@@ -5,6 +5,7 @@ var springBootAdmin = angular.module('springBootAdmin');
 
 springBootAdmin.controller('overviewCtrl', require('./overviewCtrl'));
 springBootAdmin.controller('appsCtrl', require('./appsCtrl'));
+springBootAdmin.controller('authCtrl', require('./authCtrl'));
 springBootAdmin.controller('detailsCtrl', require('./detailsCtrl'));
 springBootAdmin.controller('detailsMetricsCtrl', require('./detailsMetricsCtrl'));
 springBootAdmin.controller('detailsEnvCtrl', require('./detailsEnvCtrl'));

--- a/spring-boot-admin-server-ui/app/js/interceptor/authInterceptor.js
+++ b/spring-boot-admin-server-ui/app/js/interceptor/authInterceptor.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = function (Auth) {
+
+    var interceptor = {
+        request: function (request) {
+            if (Auth.logged) {
+                request.headers.Authorization = Auth.authorization();
+            }
+            return request;
+        }
+    };
+    return interceptor;
+};
+        

--- a/spring-boot-admin-server-ui/app/js/interceptor/index.js
+++ b/spring-boot-admin-server-ui/app/js/interceptor/index.js
@@ -1,0 +1,6 @@
+'use strict';
+
+var angular = require('angular');
+var springBootAdmin = angular.module('springBootAdmin');
+
+springBootAdmin.factory('AuthInterceptor', require('./authInterceptor'));

--- a/spring-boot-admin-server-ui/app/js/service/applicationDetails.js
+++ b/spring-boot-admin-server-ui/app/js/service/applicationDetails.js
@@ -17,18 +17,18 @@
 
 module.exports = function ($http) {
     this.getInfo = function (app) {
-        return $http.get(app.url + '/info/');
+        return $http.get(app.url + '/info');
     };
 
     this.getMetrics = function (app) {
-        return $http.get(app.url + '/metrics/');
+        return $http.get(app.url + '/metrics');
     };
 
     this.getEnv = function (app) {
-        return $http.get(app.url + '/env/');
+        return $http.get(app.url + '/env');
     };
 
     this.getHealth = function (app) {
-        return $http.get(app.url + '/health/');
+        return $http.get(app.url + '/health');
     };
 };

--- a/spring-boot-admin-server-ui/app/js/service/applicationOverview.js
+++ b/spring-boot-admin-server-ui/app/js/service/applicationOverview.js
@@ -17,7 +17,7 @@
 
 module.exports = function ($http) {
     this.getInfo = function (app) {
-        return $http.get(app.url + '/info/')
+        return $http.get(app.url + '/info')
             .success(function (response) {
                 app.version = response.version;
                 delete response.version;
@@ -28,7 +28,7 @@ module.exports = function ($http) {
             });
     };
     this.getHealth = function (app) {
-        return $http.get(app.url + '/health/')
+        return $http.get(app.url + '/health')
             .success(function (response) {
                 app.status = response.status;
             })
@@ -43,7 +43,7 @@ module.exports = function ($http) {
             });
     };
     this.getLogfile = function (app) {
-        return $http.head(app.url + '/logfile/')
+        return $http.head(app.url + '/logfile')
             .success(function () {
                 app.providesLogfile = true;
             })

--- a/spring-boot-admin-server-ui/app/js/service/applicationThreads.js
+++ b/spring-boot-admin-server-ui/app/js/service/applicationThreads.js
@@ -17,6 +17,6 @@
 
 module.exports = function ($http) {
     this.getDump = function (app) {
-        return $http.get(app.url + '/dump/');
+        return $http.get(app.url + '/dump');
     };
 };

--- a/spring-boot-admin-server-ui/app/js/service/auth.js
+++ b/spring-boot-admin-server-ui/app/js/service/auth.js
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+module.exports = function () {
+    var object = {
+        username: '',
+        password: '',
+        logged: false,
+        login: function (username, password) {
+            this.username = username;
+            this.password = password;
+            this.logged = true;
+        },
+        authorization: function() {
+            return 'Basic ' + btoa(this.username + ":" + this.password);
+        }
+
+    };
+    return object;
+};

--- a/spring-boot-admin-server-ui/app/js/service/index.js
+++ b/spring-boot-admin-server-ui/app/js/service/index.js
@@ -5,6 +5,7 @@ var springBootAdmin = angular.module('springBootAdmin');
 
 springBootAdmin.factory('Applications', require('./applications'));
 springBootAdmin.factory('Application', require('./application'));
+springBootAdmin.factory('Auth', require('./auth'));
 
 springBootAdmin.service('ApplicationOverview', require('./applicationOverview'));
 springBootAdmin.service('ApplicationDetails', require('./applicationDetails'));

--- a/spring-boot-admin-server-ui/app/views/auth.html
+++ b/spring-boot-admin-server-ui/app/views/auth.html
@@ -1,0 +1,20 @@
+<div class="container">
+    <div class="main-template">
+        <p>
+            This is an experimental feature. This username and password will be used in all requests to all client endpoints as basic auth data. 
+        </p>
+        <div class="span12 text-center" >
+            <div class="span4 offset4">
+                <form>
+                    <div class="input-prepend input-append">
+                        <input placeholder="Username" class="span4" type="text" ng-model="username" />
+                    </div>
+                    <div class="input-prepend input-append">
+                        <input placeholder="Password" class="span4" type="password" ng-model="password" />
+                    </div>
+                    <button class="btn" ng-click="login()"><i class="icon-lock"></i> Login</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>

--- a/spring-boot-admin-server-ui/package.json
+++ b/spring-boot-admin-server-ui/package.json
@@ -7,14 +7,12 @@
     "test": "./node_modules/gulp/bin/gulp.js"
   },
   "dependencies": {
-    "angular": "~1.2.27",
+    "es5-shim": "^3.0.2",
+    "jquery": "~2.1.1",
+    "angular-ui-router": "~0.2.11",
     "angular-resource": "~1.2.27",
     "angular-route": "~1.2.27",
-    "angular-ui-router": "~0.2.11",
-    "es5-shim": "^3.0.2",
-    "gulp-cli": "^0.1.5",
-    "gulp-install": "^0.2.0",
-    "jquery": "~2.1.1"
+    "angular": "~1.2.27"
   },
   "devDependencies": {
     "browserify": "^3.44.2",

--- a/spring-boot-admin-server-ui/package.json
+++ b/spring-boot-admin-server-ui/package.json
@@ -7,12 +7,14 @@
     "test": "./node_modules/gulp/bin/gulp.js"
   },
   "dependencies": {
-    "es5-shim": "^3.0.2",
-    "jquery": "~2.1.1",
-    "angular-ui-router": "~0.2.11",
+    "angular": "~1.2.27",
     "angular-resource": "~1.2.27",
     "angular-route": "~1.2.27",
-    "angular": "~1.2.27"
+    "angular-ui-router": "~0.2.11",
+    "es5-shim": "^3.0.2",
+    "gulp-cli": "^0.1.5",
+    "gulp-install": "^0.2.0",
+    "jquery": "~2.1.1"
   },
   "devDependencies": {
     "browserify": "^3.44.2",


### PR DESCRIPTION
Unnecessary trailing '/' in resources enforces unintuitive rules when trying to secure client actuator endpoints.