### PR TITLE
Update jolokia javascript urls to support running behind a http proxy

### DIFF
--- a/spring-boot-admin-server-ui/app/js/service/applicationJmx.js
+++ b/spring-boot-admin-server-ui/app/js/service/applicationJmx.js
@@ -17,7 +17,7 @@
 
 module.exports = function ($rootScope, Abbreviator, jolokia) {
     this.list = function (app) {
-        return jolokia.list('/api/applications/' + app.id + '/jolokia/')
+        return jolokia.list('api/applications/' + app.id + '/jolokia/')
             .then(function (response) {
                 var domains = [];
                 for (var rDomainName in response.value) {
@@ -81,14 +81,14 @@ module.exports = function ($rootScope, Abbreviator, jolokia) {
     };
 
     this.readAllAttr = function (app, bean) {
-        return jolokia.read('/api/applications/' + app.id + '/jolokia/', bean.id);
+        return jolokia.read('api/applications/' + app.id + '/jolokia/', bean.id);
     };
 
     this.writeAttr = function (app, bean, attr, val) {
-        return jolokia.writeAttr('/api/applications/' + app.id + '/jolokia/', bean.id, attr, val);
+        return jolokia.writeAttr('api/applications/' + app.id + '/jolokia/', bean.id, attr, val);
     };
 
     this.invoke = function (app, bean, opname, args) {
-        return jolokia.exec('/api/applications/' + app.id + '/jolokia/', bean.id, opname, args);
+        return jolokia.exec('api/applications/' + app.id + '/jolokia/', bean.id, opname, args);
     };
 };

--- a/spring-boot-admin-server-ui/app/js/service/applicationLogging.js
+++ b/spring-boot-admin-server-ui/app/js/service/applicationLogging.js
@@ -29,16 +29,16 @@ module.exports = function ($http, jolokia) {
                 arguments: [loggers[j].name]
             });
         }
-        return jolokia.bulkRequest('/api/applications/' + app.id + '/jolokia/', requests);
+        return jolokia.bulkRequest('api/applications/' + app.id + '/jolokia/', requests);
     };
 
     this.setLoglevel = function (app, logger, level) {
-        return jolokia.exec('/api/applications/' + app.id + '/jolokia/', LOGBACK_MBEAN, 'setLoggerLevel', [logger,
+        return jolokia.exec('api/applications/' + app.id + '/jolokia/', LOGBACK_MBEAN, 'setLoggerLevel', [logger,
             level
         ]);
     };
 
     this.getAllLoggers = function (app) {
-        return jolokia.readAttr('/api/applications/' + app.id + '/jolokia/', LOGBACK_MBEAN, 'LoggerList');
+        return jolokia.readAttr('api/applications/' + app.id + '/jolokia/', LOGBACK_MBEAN, 'LoggerList');
     };
 };


### PR DESCRIPTION
When running the spring-boot-admin-ui behind a proxy server, the jmx view was not working because the urls being used were relative to the root url '/api/application', rather than the application context. This was not the case for other requests, which used api/application' . This change drops the '/' character from the urls so that the javascript calls can be made relative to the application context and thus work behind a http proxy.