### PR TITLE
separate health, management and service url

### DIFF
--- a/spring-boot-admin-server-ui/app/js/controller/overviewCtrl.js
+++ b/spring-boot-admin-server-ui/app/js/controller/overviewCtrl.js
@@ -30,7 +30,7 @@ module.exports = function ($scope, $location, $interval, $q, Application) {
     var getHealth = function (app) {
         return app.getHealth()
             .success(function (response) {
-                app.status = response.status;
+                app.status = response.status || 'UP';
             })
             .error(function (response, httpStatus) {
                 if (httpStatus === 503) {

--- a/spring-boot-admin-server-ui/app/views/apps.html
+++ b/spring-boot-admin-server-ui/app/views/apps.html
@@ -1,4 +1,4 @@
-<div class="navbar">
+<div class="navbar" style="margin-bottom: 0px;">
 	<div class="navbar-inner">
 		<span class="brand">{{ application.name }}</span>
 		<ul class="nav pull-right">
@@ -8,7 +8,15 @@
 			<li class="navbar-link" ui-sref-active="active" ><a ui-sref="apps.threads({id: application.id})">Threads</a></li>
 			<li class="navbar-link" ui-sref-active="active" ><a ui-sref="apps.trace({id: application.id})">Trace</a></li>
 		</ul>
-		<small class="navbar-text">{{ application.url }}</small>
+	</div>
+</div>
+<div class="navbar">
+	<div class="navbar-inner">
+		<ul class="nav" style="width: 100%;">
+			<li style="width: 33%; text-align: center;"><a href="{{ application.serviceUrl }}" title="Service URL"><i class="icon-home" ></i> {{ application.serviceUrl }}</a></li>
+			<li style="width: 33%; text-align: center;"><a href="{{ application.healthUrl }}" title="Health URL"><i class="icon-heart" ></i> {{ application.healthUrl }}</a></li>
+			<li style="width: 33%; text-align: center;"><a href="{{ application.managementUrl }}"  title="Management URL"><i class="icon-wrench"></i> {{ application.managementUrl }}</a></li>
+		</ul>
 	</div>
 </div>
 <div ui-view></div>

--- a/spring-boot-admin-server-ui/app/views/apps/details.html
+++ b/spring-boot-admin-server-ui/app/views/apps/details.html
@@ -6,7 +6,7 @@
 	<div class="row">
 		<div class="span6">
 			<table class="table">
-				<thead><tr><th colspan="2">Application <small class="pull-right"><a href="{{ application.url }}/info">raw JSON</a></small></th></tr></thead>
+				<thead><tr><th colspan="2">Application <small class="pull-right"><a href="{{ application.managementUrl }}/info">raw JSON</a></small></th></tr></thead>
 				<tbody>
 					<tr ng-repeat="(key, value) in info" >
 						<td>{{ key }}</td><td>{{ value }}</td>
@@ -17,7 +17,7 @@
 		<div class="span6">
 			<table class="table">
 				<thead>
-					<tr><th colspan="2">Health Checks <small class="pull-right"><a href="{{ application.url }}/health">raw JSON</a></small></th></tr>
+					<tr><th colspan="2">Health Checks <small class="pull-right"><a href="{{ application.healthUrl }}">raw JSON</a></small></th></tr>
 				</thead>
 				<tbody>
 					<tr><td ng-init="name= 'Application'" ng-include="'health.html'"></td></tr>
@@ -63,7 +63,7 @@
 
 		<div class="span6">
 			<table class="table">
-				<thead><tr><th colspan="2">JVM <small class="pull-right"><a href="{{ application.url }}/metrics">raw JSON</a></small></th></tr></thead>
+				<thead><tr><th colspan="2">JVM <small class="pull-right"><a href="{{ application.managementUrl }}/metrics">raw JSON</a></small></th></tr></thead>
 				<tbody>
 					<tr ng-if="metrics['systemload.average'] != null && metrics['systemload.average'] >= 0.0">
 						<td>Systemload</td>

--- a/spring-boot-admin-server-ui/app/views/apps/details/classpath.html
+++ b/spring-boot-admin-server-ui/app/views/apps/details/classpath.html
@@ -3,7 +3,7 @@
 	<col style="width:auto">
 	<thead>
 		<tr>
-			<th>Classpath <small class="pull-right"><a href="{{ application.url }}/env">raw JSON</a></small></th>
+			<th>Classpath <small class="pull-right"><a href="{{ application.managementUrl }}/env">raw JSON</a></small></th>
 		</tr>
 	</thead>
 	<tbody>	

--- a/spring-boot-admin-server-ui/app/views/apps/details/env.html
+++ b/spring-boot-admin-server-ui/app/views/apps/details/env.html
@@ -4,7 +4,7 @@
 	<thead>
 		<tr>
 			<th>Property</th>
-			<th>Value <small class="pull-right"><a href="{{ application.url }}/env">raw JSON</a></small></th>
+			<th>Value <small class="pull-right"><a href="{{ application.managementUrl }}/env">raw JSON</a></small></th>
 		</tr>
 	</thead>
 	<tbody>

--- a/spring-boot-admin-server-ui/app/views/apps/details/props.html
+++ b/spring-boot-admin-server-ui/app/views/apps/details/props.html
@@ -4,7 +4,7 @@
 	<thead>
 		<tr>
 			<th>Property</th>
-			<th>Value <small class="pull-right"><a href="{{ application.url }}/env">raw JSON</a></small></th>
+			<th>Value <small class="pull-right"><a href="{{ application.managementUrl }}/env">raw JSON</a></small></th>
 		</tr>
 	</thead>
 	<tbody>	

--- a/spring-boot-admin-server-ui/app/views/overview.html
+++ b/spring-boot-admin-server-ui/app/views/overview.html
@@ -16,13 +16,13 @@
 		</thead>
 		<tbody>
 			<tr ng-repeat="application in applications|orderBy:order.column:order.descending|orderBy:'status':false track by application.id">
-				<td>{{ application.name }}<br/><span class="muted">{{ application.url }}</span></td>
+				<td>{{ application.name }}<br/><span class="muted">{{ application.serviceUrl || application.managementUrl || application.healthUrl }}</span></td>
 				<td>{{ application.version }}</td>
 				<td><span ng-repeat="(name, value) in application.info track by name">{{name}}: {{value}}<br></span></td>
 				<td><span class="status-{{application.status}}">{{ application.status }}</span>
 				<span ng-show="application.refreshing" class="refresh"></span></td>
 				<td style="text-align: right;">
-					<div class="btn-group" ng-hide="application.status == null || application.status == 'OFFLINE'">
+					<div class="btn-group" ng-hide="application.managementUrl == null || application.status == null || application.status == 'OFFLINE'">
 						<a ng-disabled="!application.providesLogfile" target="_self" class="btn btn-success" ng-href="{{application.providesLogfile ? application.url + '/logfile' :''}}"><i class="icon-file icon-white"></i>Log</a>
 						<a ui-sref="apps.details.metrics({id: application.id})" class="btn btn-success">Details</a>
 						<a class="btn btn-success dropdown-toggle" data-toggle="dropdown">

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/discovery/ApplicationDiscoveryListener.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/discovery/ApplicationDiscoveryListener.java
@@ -40,6 +40,10 @@ public class ApplicationDiscoveryListener implements ApplicationListener<Applica
 
 	private String managementContextPath = "";
 
+	private String serviceContextPath = "";
+
+	private String healthEndpoint = "health";
+
 
 	public ApplicationDiscoveryListener(DiscoveryClient discoveryClient, ApplicationRegistry registry) {
 		this.discoveryClient = discoveryClient;
@@ -77,13 +81,28 @@ public class ApplicationDiscoveryListener implements ApplicationListener<Applica
 	}
 
 	private Application convert(ServiceInstance instance) {
-		String url = instance.getUri()
-				.resolve(managementContextPath.startsWith("/") ? managementContextPath : "/" + managementContextPath)
+		String managementUrl = instance.getUri()
+				.resolve(managementContextPath)
 				.toString();
-		return new Application(url, instance.getServiceId());
+		String serviceUrl = instance.getUri()
+				.resolve(serviceContextPath)
+				.toString();
+		String healthUrl = managementUrl + "/" + healthEndpoint;
+
+		return new Application(healthUrl, managementUrl, serviceUrl, instance.getServiceId());
 	}
 
 	public void setManagementContextPath(String managementContextPath) {
-		this.managementContextPath = managementContextPath;
+		this.managementContextPath = managementContextPath.startsWith("/") ? managementContextPath
+				: "/" + managementContextPath;
+	}
+
+	public void setServiceContextPath(String serviceContextPath) {
+		this.serviceContextPath = serviceContextPath.startsWith("/") ? serviceContextPath
+				: "/" + serviceContextPath;
+	}
+
+	public void setHealthEndpoint(String healthEndpoint) {
+		this.healthEndpoint = healthEndpoint;
 	}
 }

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/registry/HashingApplicationUrlIdGenerator.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/registry/HashingApplicationUrlIdGenerator.java
@@ -32,7 +32,8 @@ public class HashingApplicationUrlIdGenerator implements ApplicationIdGenerator 
 	public String generateId(Application a) {
 		try {
 			MessageDigest digest = MessageDigest.getInstance("SHA-1");
-			byte[] bytes = digest.digest(a.getUrl().getBytes(StandardCharsets.UTF_8));
+			byte[] bytes = digest.digest(a.getHealthUrl()
+					.getBytes(StandardCharsets.UTF_8));
 			return new String(encodeHex(bytes, 0, 8));
 		}
 		catch (NoSuchAlgorithmException e) {

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/zuul/ApplicationRouteLocator.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/zuul/ApplicationRouteLocator.java
@@ -20,6 +20,7 @@ import java.util.LinkedHashMap;
 import org.springframework.cloud.netflix.zuul.filters.ProxyRouteLocator;
 import org.springframework.cloud.netflix.zuul.filters.ZuulProperties;
 import org.springframework.cloud.netflix.zuul.filters.ZuulProperties.ZuulRoute;
+import org.springframework.util.StringUtils;
 
 import de.codecentric.boot.admin.model.Application;
 import de.codecentric.boot.admin.registry.ApplicationRegistry;
@@ -46,12 +47,22 @@ public class ApplicationRouteLocator extends ProxyRouteLocator {
 
 		if (registry != null) {
 			for (Application application : registry.getApplications()) {
-				String key = prefix + "/" + application.getId() + "/*/**";
-				locateRoutes.put(key, new ZuulRoute(key, application.getUrl()));
+				addRoute(locateRoutes, prefix + "/" + application.getId() + "/health/**",
+						application.getHealthUrl());
+
+				if (!StringUtils.isEmpty(application.getManagementUrl())) {
+					addRoute(locateRoutes, prefix + "/" + application.getId() + "/*/**",
+							application.getManagementUrl());
+				}
 			}
 		}
 
 		return locateRoutes;
+	}
+
+	private void addRoute(LinkedHashMap<String, ZuulRoute> locateRoutes, String path,
+			String url) {
+		locateRoutes.put(path, new ZuulRoute(path, url));
 	}
 
 }

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/AdminApplicationHazelcastTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/AdminApplicationHazelcastTest.java
@@ -63,9 +63,9 @@ public class AdminApplicationHazelcastTest {
 	public void setup() throws InterruptedException {
 		System.setProperty("hazelcast.wait.seconds.before.join", "0");
 		instance1 = (EmbeddedWebApplicationContext) SpringApplication.run(TestAdminApplication.class, new String[] {
-				"--server.port=0", "--spring.jmx.enabled=false", "--spring.boot.admin.hazelcast.enabled=true" });
+			"--server.port=0", "--spring.jmx.enabled=false", "--spring.boot.admin.hazelcast.enabled=true" });
 		instance2 = (EmbeddedWebApplicationContext) SpringApplication.run(TestAdminApplication.class, new String[] {
-				"--server.port=0", "--spring.jmx.enabled=false", "--spring.boot.admin.hazelcast.enabled=true" });
+			"--server.port=0", "--spring.jmx.enabled=false", "--spring.boot.admin.hazelcast.enabled=true" });
 	}
 
 	@After
@@ -76,9 +76,12 @@ public class AdminApplicationHazelcastTest {
 
 	@Test
 	public void test() {
-		Application app = new Application("http://127.0.0.1", "Hazelcast Test");
-		Application app2 = new Application("http://127.0.0.1:2", "Hazelcast Test");
-		Application app3 = new Application("http://127.0.0.1:3", "Do not find");
+		Application app = new Application("http://127.0.0.1/health", "", "",
+				"Hazelcast Test");
+		Application app2 = new Application("http://127.0.0.1:2/health", "", "",
+				"Hazelcast Test");
+		Application app3 = new Application("http://127.0.0.1:3/health", "", "",
+				"Do not find");
 
 		// publish app on instance1
 		ResponseEntity<Application> postResponse = registerApp(app, instance1);

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/controller/RegistryControllerTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/controller/RegistryControllerTest.java
@@ -48,44 +48,49 @@ public class RegistryControllerTest {
 
 	@Test
 	public void register() {
-		ResponseEntity<Application> response = controller.register(new Application("http://localhost", "test"));
+		ResponseEntity<Application> response = controller.register(new Application(
+				"http://localhost/mgmt/health", "http://localhost/mgmt",
+				"http://localhost/", "test"));
 		assertEquals(HttpStatus.CREATED, response.getStatusCode());
-		assertEquals("http://localhost", response.getBody().getUrl());
+		assertEquals("http://localhost/mgmt/health", response.getBody().getHealthUrl());
+		assertEquals("http://localhost/mgmt", response.getBody().getManagementUrl());
+		assertEquals("http://localhost/", response.getBody().getServiceUrl());
 		assertEquals("test", response.getBody().getName());
 	}
 
 	@Test
 	public void register_twice() {
-		controller.register(new Application("http://localhost", "test"));
-		Application app = new Application("http://localhost", "test");
+		Application app = new Application("http://localhost/health", "", "", "test");
+		controller.register(app);
 		ResponseEntity<Application> response = controller.register(app);
 
 		assertEquals(HttpStatus.CREATED, response.getStatusCode());
-		assertEquals("http://localhost", response.getBody().getUrl());
+		assertEquals("http://localhost/health", response.getBody().getHealthUrl());
 		assertEquals("test", response.getBody().getName());
 	}
 
 	@Test
 	public void register_sameUrl() {
-		controller.register(new Application("http://localhost", "FOO"));
-		ResponseEntity<?> response = controller.register(new Application("http://localhost", "BAR"));
+		controller.register(new Application("http://localhost/health", "", "", "FOO"));
+		ResponseEntity<?> response = controller.register(new Application(
+				"http://localhost/health", "", "", "BAR"));
 		assertEquals(HttpStatus.CREATED, response.getStatusCode());
 	}
 
 	@Test
 	public void get() {
-		Application app = new Application("http://localhost", "FOO");
-		app = controller.register(app).getBody();
+		Application app = controller.register(
+				new Application("http://localhost/health", "", "", "FOO")).getBody();
 
 		ResponseEntity<Application> response = controller.get(app.getId());
 		assertEquals(HttpStatus.OK, response.getStatusCode());
-		assertEquals("http://localhost", response.getBody().getUrl());
+		assertEquals("http://localhost/health", response.getBody().getHealthUrl());
 		assertEquals("FOO", response.getBody().getName());
 	}
 
 	@Test
 	public void get_notFound() {
-		controller.register(new Application("http://localhost", "FOO"));
+		controller.register(new Application("http://localhost/health", "", "", "FOO"));
 
 		ResponseEntity<?> response = controller.get("unknown");
 		assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
@@ -93,8 +98,8 @@ public class RegistryControllerTest {
 
 	@Test
 	public void unregister() {
-		Application app = new Application("http://localhost", "FOO");
-		app = controller.register(app).getBody();
+		Application app = controller.register(
+				new Application("http://localhost/health", "", "", "FOO")).getBody();
 
 		ResponseEntity<?> response = controller.unregister(app.getId());
 		assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
@@ -105,7 +110,7 @@ public class RegistryControllerTest {
 
 	@Test
 	public void unregister_notFound() {
-		controller.register(new Application("http://localhost", "FOO"));
+		controller.register(new Application("http://localhost/health", "", "", "FOO"));
 
 		ResponseEntity<?> response = controller.unregister("unknown");
 		assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
@@ -113,8 +118,8 @@ public class RegistryControllerTest {
 
 	@Test
 	public void applications() {
-		Application app = new Application("http://localhost", "FOO");
-		app = controller.register(app).getBody();
+		Application app = controller.register(
+				new Application("http://localhost/health", "", "", "FOO")).getBody();
 
 		Collection<Application> applications = controller.applications(null);
 		assertEquals(1, applications.size());
@@ -123,12 +128,12 @@ public class RegistryControllerTest {
 
 	@Test
 	public void applicationsByName() {
-		Application app = new Application("http://localhost:2", "FOO");
-		app = controller.register(app).getBody();
-		Application app2 = new Application("http://localhost:1", "FOO");
-		app2 = controller.register(app2).getBody();
-		Application app3 = new Application("http://localhost:3", "BAR");
-		controller.register(app3).getBody();
+		Application app = controller.register(
+				new Application("http://localhost:2/health", "", "", "FOO")).getBody();
+		Application app2 = controller.register(
+				new Application("http://localhost:1/health", "", "", "FOO")).getBody();
+		Application app3 = controller.register(
+				new Application("http://localhost:3/health", "", "", "BAR")).getBody();
 
 		Collection<Application> applications = controller.applications("FOO");
 		assertEquals(2, applications.size());

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/discovery/ApplicationDiscoveryListenerTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/discovery/ApplicationDiscoveryListenerTest.java
@@ -62,7 +62,9 @@ public class ApplicationDiscoveryListenerTest {
 		assertEquals(1, registry.getApplications().size());
 		Application application = registry.getApplications().iterator().next();
 
-		assertEquals("http://localhost:80", application.getUrl());
+		assertEquals("http://localhost:80/health", application.getHealthUrl());
+		assertEquals("http://localhost:80", application.getManagementUrl());
+		assertEquals("http://localhost:80", application.getServiceUrl());
 		assertEquals("service", application.getName());
 	}
 
@@ -74,12 +76,16 @@ public class ApplicationDiscoveryListenerTest {
 						false)));
 
 		listener.setManagementContextPath("/mgmt");
+		listener.setServiceContextPath("/service");
+		listener.setHealthEndpoint("alive");
 		listener.onApplicationEvent(new InstanceRegisteredEvent<>(new Object(), null));
 
 		assertEquals(1, registry.getApplications().size());
 		Application application = registry.getApplications().iterator().next();
 
-		assertEquals("http://localhost:80/mgmt", application.getUrl());
+		assertEquals("http://localhost:80/mgmt/alive", application.getHealthUrl());
+		assertEquals("http://localhost:80/mgmt", application.getManagementUrl());
+		assertEquals("http://localhost:80/service", application.getServiceUrl());
 		assertEquals("service", application.getName());
 	}
 

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/registry/ApplicationRegistryTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/registry/ApplicationRegistryTest.java
@@ -38,45 +38,60 @@ public class ApplicationRegistryTest {
 		registry.setApplicationContext(Mockito.mock(ApplicationContext.class));
 	}
 
-	@Test(expected = NullPointerException.class)
-	public void registerFailed1() throws Exception {
-		registry.register(new Application(null, null));
-	}
-
-	@Test(expected = NullPointerException.class)
-	public void registerFailed2() throws Exception {
-		Application app = new Application(null, "abc");
-		registry.register(app);
+	@Test(expected = IllegalArgumentException.class)
+	public void registerFailed_null() throws Exception {
+		registry.register(null);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
-	public void registerFailed3() throws Exception {
-		Application app = new Application("not-an-url", "abc");
-		registry.register(app);
+	public void registerFailed_no_name() throws Exception {
+		registry.register(new Application("http://localhost/health", "", "", ""));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void registerFailed_no_healthUrl() throws Exception {
+		registry.register(new Application("", "", "", "name"));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void registerFailed_invalid_healthUrl() throws Exception {
+		registry.register(new Application("not-an-url", "", "", "name"));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void registerFailed_invalid_mgmtUrl() throws Exception {
+		registry.register(new Application("http://localhost/health", "not-a-url", "",
+				"name"));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void registerFailed_invalid_svcUrl() throws Exception {
+		registry.register(new Application("http://localhost/health", "", "not-a-url",
+				"name"));
 	}
 
 	@Test
 	public void register() throws Exception {
-		Application app = new Application("http://localhost:8080", "abc");
-		Application response = registry.register(app);
+		Application app = registry.register(new Application(
+				"http://localhost:8080/health", "", "", "abc"));
 
-		assertEquals("http://localhost:8080", response.getUrl());
-		assertEquals("abc", response.getName());
-		assertNotNull(response.getId());
+		assertEquals("http://localhost:8080/health", app.getHealthUrl());
+		assertEquals("abc", app.getName());
+		assertNotNull(app.getId());
 	}
 
 	@Test
 	public void getApplication() throws Exception {
-		Application app = new Application("http://localhost:8080", "abc");
-		app = registry.register(app);
-
+		Application app = registry.register(new Application(
+				"http://localhost:8080/health", "http://localhost:8080/", "", "abc"));
 		assertEquals(app, registry.getApplication(app.getId()));
+		assertEquals("http://localhost:8080/", app.getManagementUrl());
 	}
 
 	@Test
 	public void getApplications() throws Exception {
-		Application app = new Application("http://localhost:8080", "abc");
-		app = registry.register(app);
+		Application app = registry.register(new Application(
+				"http://localhost:8080/health", "", "", "abc"));
 
 		Collection<Application> applications = registry.getApplications();
 		assertEquals(1, applications.size());
@@ -85,12 +100,12 @@ public class ApplicationRegistryTest {
 
 	@Test
 	public void getApplicationsByName() throws Exception {
-		Application app = new Application("http://localhost:8080", "abc");
-		app = registry.register(app);
-		Application app2 = new Application("http://localhost:8081", "abc");
-		app2 = registry.register(app2);
-		Application app3 = new Application("http://localhost:8082", "cba");
-		app3 = registry.register(app3);
+		Application app = registry.register(new Application(
+				"http://localhost:8080/health", "", "", "abc"));
+		Application app2 = registry.register(new Application(
+				"http://localhost:8081/health", "", "", "abc"));
+		Application app3 = registry.register(new Application(
+				"http://localhost:8082/health", "", "", "cba"));
 
 		Collection<Application> applications = registry.getApplicationsByName("abc");
 		assertEquals(2, applications.size());

--- a/spring-boot-admin-starter-client/src/main/java/de/codecentric/boot/admin/config/AdminProperties.java
+++ b/spring-boot-admin-starter-client/src/main/java/de/codecentric/boot/admin/config/AdminProperties.java
@@ -37,7 +37,6 @@ public class AdminProperties {
 	}
 
 	/**
-	 *
 	 * @return the Spring Boot Admin Server's url.
 	 */
 	public String getUrl() {
@@ -56,7 +55,6 @@ public class AdminProperties {
 	}
 
 	/**
-	 *
 	 * @return the time interval (in ms) the registration is repeated.
 	 */
 	public int getPeriod() {
@@ -83,7 +81,6 @@ public class AdminProperties {
 	}
 
 	/**
-	 *
 	 * @return password for basic authentication.
 	 */
 	public String getPassword() {
@@ -91,7 +88,6 @@ public class AdminProperties {
 	}
 
 	/**
-	 *
 	 * @return wether the application deregisters automatically on shutdown.
 	 */
 	public boolean isAutoDeregistration() {
@@ -101,5 +97,4 @@ public class AdminProperties {
 	public void setAutoDeregistration(boolean autoDeregistration) {
 		this.autoDeregistration = autoDeregistration;
 	}
-
 }

--- a/spring-boot-admin-starter-client/src/main/java/de/codecentric/boot/admin/config/SpringBootAdminClientAutoConfiguration.java
+++ b/spring-boot-admin-starter-client/src/main/java/de/codecentric/boot/admin/config/SpringBootAdminClientAutoConfiguration.java
@@ -71,7 +71,6 @@ public class SpringBootAdminClientAutoConfiguration {
 	public ScheduledTaskRegistrar taskRegistrar(final ApplicationRegistrator registrator,
 			AdminProperties admin, final AdminClientProperties client) {
 		ScheduledTaskRegistrar registrar = new ScheduledTaskRegistrar();
-
 		Runnable registratorTask = new Runnable() {
 			@Override
 			public void run() {
@@ -98,6 +97,7 @@ public class SpringBootAdminClientAutoConfiguration {
 	@ConditionalOnExpression("${endpoints.logfile.enabled:true}")
 	@ConditionalOnProperty("logging.file")
 	public static class LogfileEndpointAutoConfiguration {
+
 		/**
 		 * Exposes the logfile as acutator endpoint
 		 */

--- a/spring-boot-admin-starter-client/src/main/java/de/codecentric/boot/admin/model/Application.java
+++ b/spring-boot-admin-starter-client/src/main/java/de/codecentric/boot/admin/model/Application.java
@@ -17,57 +17,95 @@ package de.codecentric.boot.admin.model;
 
 import java.io.Serializable;
 
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * The domain model for all registered application at the spring boot admin application.
  */
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class Application implements Serializable {
 	private static final long serialVersionUID = 1L;
 
 	private final String id;
-	private final String url;
 	private final String name;
+	private final String managementUrl;
+	private final String healthUrl;
+	private final String serviceUrl;
 
-	public Application(String url, String name) {
-		this(url, name, null);
+	public Application(String healthUrl, String managementUrl, String serviceUrl,
+			String name) {
+		this(healthUrl, managementUrl, serviceUrl, name, null);
+	}
+
+	public Application(String healthUrl, String managementUrl, String serviceUrl,
+			String name, String id) {
+		this.healthUrl = healthUrl;
+		this.managementUrl = managementUrl;
+		this.serviceUrl = serviceUrl;
+		this.name = name;
+		this.id = id;
 	}
 
 	@JsonCreator
-	public Application(@JsonProperty(value = "url", required = true) String url,
-			@JsonProperty(value = "name", required = true) String name, @JsonProperty("id") String id) {
-		this.url = url.replaceFirst("/+$", "");
-		this.name = name;
-		this.id = id;
+	public static Application create(@JsonProperty("url") String url,
+			@JsonProperty("managementUrl") String managementUrl,
+			@JsonProperty("healthUrl") String healthUrl,
+			@JsonProperty("serviceUrl") String serviceUrl,
+			@JsonProperty("name") String name,
+			@JsonProperty("id") String id) {
+
+		Assert.hasText(name, "name must not be empty!");
+		if (StringUtils.hasText(url)) {
+			// old format
+			return new Application(url.replaceFirst("/+$", "") + "/health", url, null,
+					name, id);
+		}
+		else {
+			Assert.hasText(healthUrl, "healthUrl must not be empty!");
+			return new Application(healthUrl, managementUrl, serviceUrl, name, id);
+		}
 	}
 
 	public String getId() {
 		return id;
 	}
 
-	public String getUrl() {
-		return url;
+	public String getName() {
+		return name;
+	}
+
+	public String getManagementUrl() {
+		return managementUrl;
+	}
+
+	public String getHealthUrl() {
+		return healthUrl;
+	}
+
+	public String getServiceUrl() {
+		return serviceUrl;
 	}
 
 	@Override
 	public String toString() {
-		return "[id=" + id + ", url=" + url + ", name=" + name + "]";
-	}
-
-	public String getName() {
-		return name;
+		return "Application [id=" + id + ", name=" + name + ", managementUrl="
+				+ managementUrl + ", healthUrl=" + healthUrl + ", serviceUrl="
+				+ serviceUrl + "]";
 	}
 
 	@Override
 	public int hashCode() {
 		final int prime = 31;
 		int result = 1;
+		result = prime * result + ((healthUrl == null) ? 0 : healthUrl.hashCode());
 		result = prime * result + ((id == null) ? 0 : id.hashCode());
+		result = prime * result
+				+ ((managementUrl == null) ? 0 : managementUrl.hashCode());
 		result = prime * result + ((name == null) ? 0 : name.hashCode());
-		result = prime * result + ((url == null) ? 0 : url.hashCode());
+		result = prime * result + ((serviceUrl == null) ? 0 : serviceUrl.hashCode());
 		return result;
 	}
 
@@ -83,25 +121,44 @@ public class Application implements Serializable {
 			return false;
 		}
 		Application other = (Application) obj;
+		if (healthUrl == null) {
+			if (other.healthUrl != null) {
+				return false;
+			}
+		}
+		else if (!healthUrl.equals(other.healthUrl)) {
+			return false;
+		}
 		if (id == null) {
 			if (other.id != null) {
 				return false;
 			}
-		} else if (!id.equals(other.id)) {
+		}
+		else if (!id.equals(other.id)) {
+			return false;
+		}
+		if (managementUrl == null) {
+			if (other.managementUrl != null) {
+				return false;
+			}
+		}
+		else if (!managementUrl.equals(other.managementUrl)) {
 			return false;
 		}
 		if (name == null) {
 			if (other.name != null) {
 				return false;
 			}
-		} else if (!name.equals(other.name)) {
+		}
+		else if (!name.equals(other.name)) {
 			return false;
 		}
-		if (url == null) {
-			if (other.url != null) {
+		if (serviceUrl == null) {
+			if (other.serviceUrl != null) {
 				return false;
 			}
-		} else if (!url.equals(other.url)) {
+		}
+		else if (!serviceUrl.equals(other.serviceUrl)) {
 			return false;
 		}
 		return true;

--- a/spring-boot-admin-starter-client/src/main/java/de/codecentric/boot/admin/services/ApplicationRegistrator.java
+++ b/spring-boot-admin-starter-client/src/main/java/de/codecentric/boot/admin/services/ApplicationRegistrator.java
@@ -122,6 +122,8 @@ public class ApplicationRegistrator {
 	}
 
 	protected Application createApplication() {
-		return new Application(client.getUrl(), client.getName());
+		return new Application(client.getHealthUrl(),
+				client.getManagementUrl(), client.getServiceUrl(), client.getName());
 	}
 }
+

--- a/spring-boot-admin-starter-client/src/test/java/de/codecentric/boot/admin/model/ApplicationTest.java
+++ b/spring-boot-admin-starter-client/src/test/java/de/codecentric/boot/admin/model/ApplicationTest.java
@@ -1,0 +1,73 @@
+package de.codecentric.boot.admin.model;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+
+import org.junit.Test;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class ApplicationTest {
+
+	private ObjectMapper objectMapper = Jackson2ObjectMapperBuilder.json().build();
+
+	@Test
+	public void test_old_json_format() throws JsonProcessingException, IOException {
+		String json = "{ \"name\" : \"test\", \"url\" : \"http://test\" }";
+
+		Application value = objectMapper.readValue(json, Application.class);
+
+		assertThat(value.getId(), nullValue());
+		assertThat(value.getName(), is("test"));
+		assertThat(value.getManagementUrl(), is("http://test"));
+		assertThat(value.getHealthUrl(), is("http://test/health"));
+		assertThat(value.getServiceUrl(), nullValue());
+	}
+
+	@Test
+	public void test_new_json_format() throws JsonProcessingException, IOException {
+		String json = "{ \"name\" : \"test\", \"managementUrl\" : \"http://test\" , \"healthUrl\" : \"http://health\" , \"serviceUrl\" : \"http://service\"}";
+
+		Application value = objectMapper.readValue(json, Application.class);
+
+		assertThat(value.getId(), nullValue());
+		assertThat(value.getName(), is("test"));
+		assertThat(value.getManagementUrl(), is("http://test"));
+		assertThat(value.getHealthUrl(), is("http://health"));
+		assertThat(value.getServiceUrl(), is("http://service"));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void test_name_expected() throws JsonProcessingException, IOException {
+		Application.create("http://url", "", "", "", "",
+				null);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void test_healthUrl_expected() throws JsonProcessingException, IOException {
+		Application.create("", "", "", "", "name", null);
+	}
+
+	@Test
+	public void test_equals_hashCode() {
+		Application a1 = new Application("healthUrl", "managementUrl", "serviceUrl",
+				"name", "id");
+		Application a2 = new Application("healthUrl", "managementUrl", "serviceUrl",
+				"name", "id");
+
+		assertThat(a1, is(a2));
+		assertThat(a1.hashCode(), is(a2.hashCode()));
+
+		Application a3 = new Application("healthUrl2", "managementUrl", "serviceUrl",
+				"name", "id");
+		assertThat(a1, not(is(a3)));
+		assertThat(a2, not(is(a3)));
+	}
+
+}

--- a/spring-boot-admin-starter-client/src/test/java/de/codecentric/boot/admin/services/ApplicationRegistratorTest.java
+++ b/spring-boot-admin-starter-client/src/test/java/de/codecentric/boot/admin/services/ApplicationRegistratorTest.java
@@ -53,7 +53,9 @@ public class ApplicationRegistratorTest {
 		adminProps.setUrl("http://sba:8080");
 
 		AdminClientProperties clientProps = new AdminClientProperties();
-		clientProps.setUrl("http://localhost:8080");
+		clientProps.setManagementUrl("http://localhost:8080");
+		clientProps.setHealthUrl("http://localhost:8080/health");
+		clientProps.setServiceUrl("http://localhost:8080");
 		clientProps.setName("AppName");
 
 		registrator = new ApplicationRegistrator(restTemplate, adminProps, clientProps);
@@ -74,15 +76,17 @@ public class ApplicationRegistratorTest {
 
 		assertTrue(result);
 		verify(restTemplate).postForEntity("http://sba:8080/api/applications",
-				new HttpEntity<Application>(new Application("http://localhost:8080",
-						"AppName"),
-						headers), Application.class);
+				new HttpEntity<Application>(new Application(
+						"http://localhost:8080/health", "http://localhost:8080",
+						"http://localhost:8080", "AppName"), headers), Application.class);
 	}
 
 	@Test
 	public void register_failed() {
-		when(restTemplate.postForEntity(isA(String.class), isA(Application.class), eq(Application.class))).thenThrow(
-				new RestClientException("Error"));
+		when(
+				restTemplate.postForEntity(isA(String.class), isA(HttpEntity.class),
+						eq(Application.class))).thenThrow(
+								new RestClientException("Error"));
 
 		boolean result = registrator.register();
 
@@ -93,14 +97,12 @@ public class ApplicationRegistratorTest {
 	public void deregister() {
 		when(
 				restTemplate.postForEntity(isA(String.class), isA(HttpEntity.class),
-				eq(Application.class))).thenReturn(
-						new ResponseEntity<Application>(new Application("http://test", "url",
-								"-id-"), HttpStatus.CREATED));
-
+						eq(Application.class))).thenReturn(
+				new ResponseEntity<Application>(new Application("", "", "", "name",
+						"-id-"), HttpStatus.CREATED));
 		registrator.register();
 		registrator.deregister();
 
 		verify(restTemplate).delete("http://sba:8080/api/applications/-id-");
 	}
-
 }


### PR DESCRIPTION
I've separated the service, management and health URLs, to resolve issues #52 and #56.

The old single-url format is still supported for registration, inferencing the health-url, so you don't have to update all clients.

To register a non-boot app only a healthUrl and a name is required.

Feedback welcome