### PR TITLE
Added HTTPS/SSL Support

### DIFF
--- a/spring-boot-admin-starter-client/.gitignore
+++ b/spring-boot-admin-starter-client/.gitignore
@@ -3,3 +3,5 @@
 /.classpath
 /.project
 /bin
+/.apt_generated
+/.factorypath

--- a/spring-boot-admin-starter-client/pom.xml
+++ b/spring-boot-admin-starter-client/pom.xml
@@ -15,6 +15,11 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
 		<dependency>

--- a/spring-boot-admin-starter-client/src/main/java/de/codecentric/boot/admin/config/AdminClientProperties.java
+++ b/spring-boot-admin-starter-client/src/main/java/de/codecentric/boot/admin/config/AdminClientProperties.java
@@ -175,7 +175,8 @@ public class AdminClientProperties implements ApplicationListener<ApplicationEve
 	}
 
 	private String createLocalUri(int port, String path) {
-		return append("http://" + getHostname() + ":" + port + "/", path);
+		String scheme = server.getSsl() != null && server.getSsl().isEnabled() ? "https" : "http";
+	    return append(scheme + "://" + getHostname() + ":" + port + "/", path);
 	}
 
 	private String append(String uri, String path) {

--- a/spring-boot-admin-starter-client/src/test/java/de/codecentric/boot/admin/config/AdminClientPropertiesTest.java
+++ b/spring-boot-admin-starter-client/src/test/java/de/codecentric/boot/admin/config/AdminClientPropertiesTest.java
@@ -145,6 +145,22 @@ public class AdminClientPropertiesTest {
 		assertThat(clientProperties.getServiceUrl(), is("http://" + getHostname()
 				+ ":8080/"));
 	}
+	
+	@Test
+	public void testSsl() {
+		load("server.ssl.key-store=somefile.jks", "server.ssl.key-store-password=password");
+		AdminClientProperties clientProperties = new AdminClientProperties();
+		context.getAutowireCapableBeanFactory().autowireBean(clientProperties);
+
+		publishServletContainerInitializedEvent(clientProperties, 8080, null);
+
+		assertThat(clientProperties.getManagementUrl(), is("https://" + getHostname()
+				+ ":8080/"));
+		assertThat(clientProperties.getHealthUrl(), is("https://" + getHostname()
+				+ ":8080/health/"));
+		assertThat(clientProperties.getServiceUrl(), is("https://" + getHostname()
+				+ ":8080/"));
+	}
 
 	private String getHostname() {
 		try {


### PR DESCRIPTION
I had the requirement to use with application with SSL Client Authentication.
The SimpleHostRoutingFilter was not able to provide this, nor was
it extensible to allow a proper subclass. I provided an implementation
which uses most aspects of SimpleHostRoutingFilter, but builds the
HTTP client using current API as well as building a correct SSLContext
based on the javax.net.ssl JVM properties.

The client auto-configuration now provides a RestTemplate bean that builds
an SSLContext if SSL is enabled for the client application. If not, the 
original RestTemplate is used.

A modification was needed to the AdminClientProperties to determine if
the connection requires https instead of http (checks ServerProperties
for an instance of Ssl).

I also added spring-configuration-processor as a dependency as to generate
property file metadata.