### PR TITLE
Add mail notification and event journal

### DIFF
--- a/spring-boot-admin-server-ui/app/index.html
+++ b/spring-boot-admin-server-ui/app/index.html
@@ -30,6 +30,7 @@
 					</div>
 					<ul class="nav pull-right">
 						<li class="navbar-link" ng-class="{active: $state.includes('apps') ||  $state.includes('overview')  }"><a ui-sref="overview">Applications</a></li>
+						<li class="navbar-link" ng-class="{active: $state.includes('journal')}"><a ui-sref="journal">Journal</a></li>
 						<li class="navbar-link" ng-class="{active: $state.includes('about')}"><a ui-sref="about">About</a></li>
 					</ul>
 				</div>

--- a/spring-boot-admin-server-ui/app/js/app.js
+++ b/spring-boot-admin-server-ui/app/js/app.js
@@ -112,6 +112,11 @@ springBootAdmin.config(function ($stateProvider, $urlRouterProvider) {
             url: '/trace',
             templateUrl: 'views/apps/trace.html',
             controller: 'traceCtrl'
+        })
+       .state('journal', {
+            url: '/journal',
+            templateUrl: 'views/journal.html',
+            controller: 'journalCtrl'
         });
 });
 springBootAdmin.run(function ($rootScope, $state) {

--- a/spring-boot-admin-server-ui/app/js/controller/index.js
+++ b/spring-boot-admin-server-ui/app/js/controller/index.js
@@ -14,3 +14,4 @@ springBootAdmin.controller('loggingCtrl', require('./apps/loggingCtrl'));
 springBootAdmin.controller('jmxCtrl', require('./apps/jmxCtrl'));
 springBootAdmin.controller('threadsCtrl', require('./apps/threadsCtrl'));
 springBootAdmin.controller('traceCtrl', require('./apps/traceCtrl'));
+springBootAdmin.controller('journalCtrl', require('./journalCtrl'));

--- a/spring-boot-admin-server-ui/app/js/controller/journalCtrl.js
+++ b/spring-boot-admin-server-ui/app/js/controller/journalCtrl.js
@@ -13,20 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package de.codecentric.boot.admin.event;
+'use strict';
 
-import de.codecentric.boot.admin.model.Application;
-
-/**
- * This event gets emitted when an application is registered.
- *
- * @author Johannes Stelzer
- */
-public class ClientApplicationRegisteredEvent extends ClientApplicationEvent {
-	public ClientApplicationRegisteredEvent(Object source, Application application) {
-		super(source, application);
-	}
-
-	private static final long serialVersionUID = 1L;
-
-}
+module.exports = function ($scope, $http) {
+    $http.get('/api/journal').success(function(journal) {
+        $scope.journal = journal;
+    }).error(function(error) {
+        $scope.error = error;
+    });
+};

--- a/spring-boot-admin-server-ui/app/views/about.html
+++ b/spring-boot-admin-server-ui/app/views/about.html
@@ -2,7 +2,7 @@
 	<h2 >About Spring-Boot Admin</h2>
 	<p>
 		This is an administration GUI for Spring-Boot applications. All applications have to register themselves at this application.
-		This is done by including <a href="">spring-boot-starters-admin-client</a> as dependency. This will
-		auto-configure a registrator that registers the application.
+		This is done by including <a href="https://github.com/codecentric/spring-boot-admin/tree/master/spring-boot-admin-starter-client">spring-boot-adminstarter-client</a> as dependency.
+		This will auto-configure a registrator that registers the application.
 	</p>
 </div>

--- a/spring-boot-admin-server-ui/app/views/about.html
+++ b/spring-boot-admin-server-ui/app/views/about.html
@@ -1,4 +1,5 @@
 <div class="container content">
+	<h2 >About Spring-Boot Admin</h2>
 	<p>
 		This is an administration GUI for Spring-Boot applications. All applications have to register themselves at this application.
 		This is done by including <a href="">spring-boot-starters-admin-client</a> as dependency. This will

--- a/spring-boot-admin-server-ui/app/views/apps.html
+++ b/spring-boot-admin-server-ui/app/views/apps.html
@@ -1,7 +1,7 @@
 <div class="navbar header--application" style="margin-bottom: 0px;">
 	<div class="navbar-inner">
 			<div class="container-fluid">
-				<div class="application--name">{{ application.name }}</div>
+				<div class="application--name">{{ application.name }} <small><span class="status-{{application.statusInfo.status}}">{{ application.statusInfo.status }}</span></small></div>
 				<ul class="nav pull-right">
 					<li class="navbar-link" ng-class="{active: $state.includes('apps.details')}"> <a ui-sref="apps.details.metrics({id: application.id})"><span>Details</span></a></li>
 					<li class="navbar-link" ui-sref-active="active" ><a ui-sref="apps.env({id: application.id})" ><span>Environment<span></a></li>

--- a/spring-boot-admin-server-ui/app/views/journal.html
+++ b/spring-boot-admin-server-ui/app/views/journal.html
@@ -1,0 +1,31 @@
+<div class="container content">
+	<h2 >Journal</h2>
+	<div class="alert alert-error" ng-if="error">
+		<b>Error:</b> {{ error }}
+	</div>
+	<div class="row">
+		<table class="table table-striped">
+			<thead>
+				<tr>
+					<th>Time</th>
+					<th>Application</th>
+					<th>Event</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr ng-repeat="event in journal | orderBy:'timestamp':true" >
+					<td>{{ event.timestamp | date:'yyyy-MM-dd-HH.mm.ss.sss' }}</td>
+					<td>{{ event.application.name }} ({{ event.application.id }})<br/>
+						<span class="muted">{{ event.application.serviceUrl || event.application.managementUrl || event.application.healthUrl }}</span>
+					</td>
+					<td>{{ event.type }}<br/>
+						<span ng-if="event.type == 'STATUS_CHANGE'">
+							<span class="status-{{event.data.from}}">{{ event.data.from }}</span>
+							-&gt; 	<span class="status-{{event.data.to}}">{{ event.data.to }}</span>
+						</span>
+					</td>
+				</tr>
+			</tbody>
+		</table>
+	</div>
+</div>

--- a/spring-boot-admin-server-ui/app/views/overview.html
+++ b/spring-boot-admin-server-ui/app/views/overview.html
@@ -3,42 +3,49 @@
 	<small>Here you'll find all Spring-Boot applications that registered themselves at this admin application.</small>
 	</h2>
 	<table class="table table-striped">
+		<col>
+		<col>
+		<col>
+		<col>
+		<col style="width: 250px;">
 		<thead>
 			<tr>
 				<th><span class="sortable" ng-class="orderByCssClass('name')" ng-click="orderBy('name')">Application</span>
 					/
-					<span class="sortable" ng-class="orderByCssClass('url')" ng-click="orderBy('url')">URL</span>
+					<span class="sortable" ng-class="orderByCssClass('healthUrl')" ng-click="orderBy('healthUrl')">URL</span>
 				</th>
-				<th><span class="sortable" ng-class="orderByCssClass('version')" ng-click="orderBy('version')">Version</span></th>
+				<th><span class="sortable" ng-class="orderByCssClass('info.version')" ng-click="orderBy('info.version')">Version</span></th>
 				<th>Info</th>
 				<th colspan="2">Status</th>
 			</tr>
 		</thead>
 		<tbody>
-			<tr ng-repeat="application in applications|orderBy:order.column:order.descending|orderBy:'status':false track by application.id">
+			<tr ng-repeat="application in applications|orderBy:order.column:order.descending|orderBy:'statusInfo.status':false track by application.id">
 				<td>{{ application.name }}<br/><span class="muted">{{ application.serviceUrl || application.managementUrl || application.healthUrl }}</span></td>
-				<td>{{ application.version }}</td>
-				<td><span ng-repeat="(name, value) in application.info track by name">{{name}}: {{value}}<br></span></td>
-				<td><span class="status-{{application.status}}">{{ application.status }}</span>
+				<td>{{ application.info.version }}</td>
+				<td><span ng-repeat="(name, value) in application.info track by name" ng-if="name != 'version'">{{name}}: {{value}}<br></span></td>
+				<td><span class="status-{{application.statusInfo.status}}" title="{{application.statusInfo.timestamp  | date:'dd.MM.yyyy HH:mm:ss' }}">{{ application.statusInfo.status }}</span>
 				<span ng-show="application.refreshing" class="refresh"></span></td>
-				<td style="text-align: right;">
-					<div class="btn-group" ng-hide="application.managementUrl == null || application.status == null || application.status == 'OFFLINE'">
-						<a ng-disabled="!application.capabilities.logfile" target="_self" class="btn btn-success" ng-href="{{application.capabilities.logfile ? 'api/applications/' + application.id + '/logfile' :''}}"><i class="icon-file icon-white"></i>Log</a>
-						<a ui-sref="apps.details.metrics({id: application.id})" class="btn btn-success">Details</a>
-						<a class="btn btn-success dropdown-toggle" data-toggle="dropdown">
-							<span class="caret"></span>
-						</a>
-						<ul class="dropdown-menu">
-							<li><a ui-sref="apps.env({id: application.id})" >Environment</a></li>
-							<li><a ui-sref="apps.logging({id: application.id})" >Logging</a></li>
-							<li><a ui-sref="apps.jmx({id: application.id})" >JMX</a></li>
-							<li><a ui-sref="apps.threads({id: application.id})" >Threads</a></li>
-							<li><a ui-sref="apps.trace({id: application.id})" >Trace</a></li>
-							<li ng-show="application.capabilities.activiti"><a ui-sref="apps.activiti({id: application.id})" >Activiti</a></li>
-						</ul>
-					</div>
-					<div class="btn-group" title="remove">
-						<a class="btn btn-danger" ng-click="remove(application)"><i class="icon-remove icon-white"></i></a>
+				<td>
+					<div class="pull-right">
+						<div class="btn-group" ng-hide="application.managementUrl == null || application.statusInfo.status == null || application.statusInfo.status == 'OFFLINE'">
+							<a ng-disabled="!application.capabilities.logfile" target="_self" class="btn btn-success" ng-href="{{application.capabilities.logfile ? 'api/applications/' + application.id + '/logfile' :''}}"><i class="icon-file icon-white"></i>Log</a>
+							<a ui-sref="apps.details.metrics({id: application.id})" class="btn btn-success">Details</a>
+							<a class="btn btn-success dropdown-toggle" data-toggle="dropdown">
+								<span class="caret"></span>
+							</a>
+							<ul class="dropdown-menu">
+								<li><a ui-sref="apps.env({id: application.id})" >Environment</a></li>
+								<li><a ui-sref="apps.logging({id: application.id})" >Logging</a></li>
+								<li><a ui-sref="apps.jmx({id: application.id})" >JMX</a></li>
+								<li><a ui-sref="apps.threads({id: application.id})" >Threads</a></li>
+								<li><a ui-sref="apps.trace({id: application.id})" >Trace</a></li>
+								<li ng-show="application.capabilities.activiti"><a ui-sref="apps.activiti({id: application.id})" >Activiti</a></li>
+							</ul>
+						</div>
+						<div class="btn-group" title="remove">
+							<a class="btn btn-danger" ng-click="remove(application)"><i class="icon-remove icon-white"></i></a>
+						</div>
 					</div>
 				</td>
 			</tr>

--- a/spring-boot-admin-server/pom.xml
+++ b/spring-boot-admin-server/pom.xml
@@ -18,6 +18,10 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-mail</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
 		</dependency>

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/config/AdminServerWebConfiguration.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/config/AdminServerWebConfiguration.java
@@ -48,7 +48,9 @@ import de.codecentric.boot.admin.registry.StatusUpdater;
 import de.codecentric.boot.admin.registry.store.ApplicationStore;
 
 @Configuration
-@Import({RevereseZuulProxyConfiguration.class, HazelcastStoreConfiguration.class, SimpleStoreConfig.class, DiscoveryClientConfiguration.class})
+@Import({ RevereseZuulProxyConfiguration.class, MailNotifierConfiguration.class,
+		HazelcastStoreConfiguration.class, SimpleStoreConfig.class,
+		DiscoveryClientConfiguration.class })
 public class AdminServerWebConfiguration extends WebMvcConfigurerAdapter implements ApplicationContextAware {
 
 

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/config/AdminServerWebConfiguration.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/config/AdminServerWebConfiguration.java
@@ -16,72 +16,28 @@
 package de.codecentric.boot.admin.config;
 
 import java.util.List;
-import java.util.Map;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.actuate.endpoint.Endpoint;
-import org.springframework.boot.actuate.trace.TraceRepository;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
-import org.springframework.boot.autoconfigure.AutoConfigureBefore;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.autoconfigure.web.ServerProperties;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.cloud.client.discovery.DiscoveryClient;
-import org.springframework.cloud.client.discovery.noop.NoopDiscoveryClientAutoConfiguration;
-import org.springframework.cloud.netflix.zuul.RoutesEndpoint;
-import org.springframework.cloud.netflix.zuul.ZuulFilterInitializer;
-import org.springframework.cloud.netflix.zuul.filters.ProxyRequestHelper;
-import org.springframework.cloud.netflix.zuul.filters.ProxyRouteLocator;
-import org.springframework.cloud.netflix.zuul.filters.RouteLocator;
-import org.springframework.cloud.netflix.zuul.filters.ZuulProperties;
-import org.springframework.cloud.netflix.zuul.filters.post.SendErrorFilter;
-import org.springframework.cloud.netflix.zuul.filters.post.SendResponseFilter;
-import org.springframework.cloud.netflix.zuul.filters.pre.DebugFilter;
-import org.springframework.cloud.netflix.zuul.filters.pre.FormBodyWrapperFilter;
-import org.springframework.cloud.netflix.zuul.filters.pre.PreDecorationFilter;
-import org.springframework.cloud.netflix.zuul.filters.pre.Servlet30WrapperFilter;
-import org.springframework.cloud.netflix.zuul.filters.route.SimpleHostRoutingFilter;
-import org.springframework.cloud.netflix.zuul.web.ZuulController;
-import org.springframework.cloud.netflix.zuul.web.ZuulHandlerMapping;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
-import org.springframework.context.ApplicationEvent;
-import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.hazelcast.config.Config;
-import com.hazelcast.core.EntryEvent;
-import com.hazelcast.core.EntryListener;
-import com.hazelcast.core.Hazelcast;
-import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IMap;
-import com.hazelcast.core.MapEvent;
-import com.netflix.zuul.ZuulFilter;
 
 import de.codecentric.boot.admin.controller.RegistryController;
-import de.codecentric.boot.admin.discovery.ApplicationDiscoveryListener;
-import de.codecentric.boot.admin.event.ClientApplicationRegisteredEvent;
-import de.codecentric.boot.admin.event.ClientApplicationUnregisteredEvent;
-import de.codecentric.boot.admin.model.Application;
 import de.codecentric.boot.admin.registry.ApplicationIdGenerator;
 import de.codecentric.boot.admin.registry.ApplicationRegistry;
 import de.codecentric.boot.admin.registry.HashingApplicationUrlIdGenerator;
 import de.codecentric.boot.admin.registry.store.ApplicationStore;
-import de.codecentric.boot.admin.registry.store.HazelcastApplicationStore;
-import de.codecentric.boot.admin.registry.store.SimpleApplicationStore;
-import de.codecentric.boot.admin.zuul.ApplicationRouteLocator;
-import de.codecentric.boot.admin.zuul.ApplicationRouteRefreshListener;
 
 @Configuration
+@Import({RevereseZuulProxyConfiguration.class, HazelcastStoreConfiguration.class, SimpleStoreConfig.class, DiscoveryClientConfiguration.class})
 public class AdminServerWebConfiguration extends WebMvcConfigurerAdapter implements ApplicationContextAware {
 
 	private ApplicationContext applicationContext;
@@ -137,218 +93,6 @@ public class AdminServerWebConfiguration extends WebMvcConfigurerAdapter impleme
 	@ConditionalOnMissingBean
 	public ApplicationIdGenerator applicationIdGenerator() {
 		return new HashingApplicationUrlIdGenerator();
-	}
-
-	@Configuration
-	public static class SimpleStoreConfig {
-		@Bean
-		@ConditionalOnMissingBean
-		public ApplicationStore applicationStore() {
-			return new SimpleApplicationStore();
-		}
-	}
-
-	@Configuration
-	@EnableConfigurationProperties(ZuulProperties.class)
-	public static class RevereseZuulProxyConfiguration {
-
-		@Autowired(required = false)
-		private TraceRepository traces;
-
-		@Autowired
-		private ZuulProperties zuulProperties;
-
-		@Autowired
-		private ServerProperties server;
-
-		@Autowired
-		private ApplicationRegistry registry;
-
-		@Bean
-		public ApplicationRouteLocator routeLocator() {
-			return new ApplicationRouteLocator(this.server.getServletPrefix(), registry, this.zuulProperties,
-					RegistryController.PATH);
-		}
-
-		@Bean
-		public PreDecorationFilter preDecorationFilter() {
-			return new PreDecorationFilter(routeLocator(), this.zuulProperties.isAddProxyHeaders());
-		}
-
-		@Bean
-		public SimpleHostRoutingFilter simpleHostRoutingFilter() {
-			ProxyRequestHelper helper = new ProxyRequestHelper();
-			if (this.traces != null) {
-				helper.setTraces(this.traces);
-			}
-			return new SimpleHostRoutingFilter(helper);
-		}
-
-		@Bean
-		public ZuulController zuulController() {
-			return new ZuulController();
-		}
-
-		@Bean
-		public ZuulHandlerMapping zuulHandlerMapping(RouteLocator routes) {
-			return new ZuulHandlerMapping(routes, zuulController());
-		}
-
-		// pre filters
-
-		@Bean
-		public FormBodyWrapperFilter formBodyWrapperFilter() {
-			return new FormBodyWrapperFilter();
-		}
-
-		@Bean
-		public DebugFilter debugFilter() {
-			return new DebugFilter();
-		}
-
-		@Bean
-		public Servlet30WrapperFilter servlet30WrapperFilter() {
-			return new Servlet30WrapperFilter();
-		}
-
-		// post filters
-
-		@Bean
-		public SendResponseFilter sendResponseFilter() {
-			return new SendResponseFilter();
-		}
-
-		@Bean
-		public SendErrorFilter sendErrorFilter() {
-			return new SendErrorFilter();
-		}
-
-		@Configuration
-		protected static class ZuulFilterConfiguration {
-
-			@Autowired
-			private Map<String, ZuulFilter> filters;
-
-			@Bean
-			public ZuulFilterInitializer zuulFilterInitializer() {
-				return new ZuulFilterInitializer(this.filters);
-			}
-
-		}
-
-		@Bean
-		public ApplicationRouteRefreshListener applicationRouteRefreshListener() {
-			return new ApplicationRouteRefreshListener(routeLocator(), zuulHandlerMapping(routeLocator()));
-		}
-
-		@Configuration
-		@ConditionalOnClass(Endpoint.class)
-		protected static class RoutesEndpointConfiguration {
-
-			@Autowired
-			private ProxyRouteLocator routeLocator;
-
-			@Bean
-			public RoutesEndpoint zuulEndpoint() {
-				return new RoutesEndpoint(this.routeLocator);
-			}
-
-		}
-
-	}
-
-	@Configuration
-	@ConditionalOnClass({ Hazelcast.class })
-	@ConditionalOnProperty(prefix = "spring.boot.admin.hazelcast", name = "enabled", matchIfMissing = true)
-	@AutoConfigureBefore(SimpleStoreConfig.class)
-	public static class HazelcastStoreConfiguration {
-
-		@Value("${spring.boot.admin.hazelcast.map:spring-boot-admin-application-store}")
-		private String hazelcastMapName;
-
-		@Bean
-		@ConditionalOnMissingBean
-		public Config hazelcastConfig() {
-			return new Config();
-		}
-
-		@Bean(destroyMethod = "shutdown")
-		@ConditionalOnMissingBean
-		public HazelcastInstance hazelcastInstance(Config hazelcastConfig) {
-			return Hazelcast.newHazelcastInstance(hazelcastConfig);
-		}
-
-		@Bean
-		@ConditionalOnMissingBean
-		public ApplicationStore applicationStore(HazelcastInstance hazelcast) {
-			IMap<String, Application> map = hazelcast.<String, Application> getMap(hazelcastMapName);
-			map.addIndex("name", false);
-			map.addEntryListener(entryListener(), false);
-			return new HazelcastApplicationStore(map);
-		}
-
-		@Bean
-		public EntryListener<String, Application> entryListener() {
-			return new ApplicationEntryListener();
-		}
-
-		private static class ApplicationEntryListener implements EntryListener<String, Application> {
-			@Autowired
-			ApplicationContext context;
-
-			@Override
-			public void entryAdded(EntryEvent<String, Application> event) {
-				context.publishEvent(new ClientApplicationRegisteredEvent(this,event.getValue()));
-			}
-
-			@Override
-			public void entryRemoved(EntryEvent<String, Application> event) {
-				context.publishEvent(new ClientApplicationUnregisteredEvent(this,event.getValue()));
-			}
-
-			@Override
-			public void entryUpdated(EntryEvent<String, Application> event) {
-				context.publishEvent(new ClientApplicationRegisteredEvent(this,event.getValue()));
-			}
-
-			@Override
-			public void entryEvicted(EntryEvent<String, Application> event) {
-				context.publishEvent(new ClientApplicationRegisteredEvent(this,null));
-			}
-
-			@Override
-			public void mapEvicted(MapEvent event) {
-				context.publishEvent(new ClientApplicationRegisteredEvent(this,null));
-			}
-
-			@Override
-			public void mapCleared(MapEvent event) {
-				context.publishEvent(new ClientApplicationRegisteredEvent(this,null));
-			}
-		}
-	}
-
-	@Configuration
-	@ConditionalOnClass({ DiscoveryClient.class })
-	@ConditionalOnProperty(prefix = "spring.boot.admin.discovery", name = "enabled", matchIfMissing = true)
-	@AutoConfigureAfter({ NoopDiscoveryClientAutoConfiguration.class })
-	public static class DiscoveryClientConfiguration {
-
-		@Value("${spring.boot.admin.discovery.management.context-path:}")
-		private String managementPath;
-
-		@Autowired
-		private DiscoveryClient discoveryClient;
-
-		@Autowired
-		private ApplicationRegistry registry;
-
-		@Bean
-		ApplicationListener<ApplicationEvent> applicationDiscoveryListener() {
-			ApplicationDiscoveryListener listener = new ApplicationDiscoveryListener(discoveryClient, registry);
-			listener.setManagementContextPath(managementPath);
-			return listener;
-		}
 	}
 
 }

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/config/AdminServerWebConfiguration.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/config/AdminServerWebConfiguration.java
@@ -35,8 +35,12 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import de.codecentric.boot.admin.controller.JournalController;
 import de.codecentric.boot.admin.controller.RegistryController;
 import de.codecentric.boot.admin.event.ClientApplicationRegisteredEvent;
+import de.codecentric.boot.admin.journal.ApplicationEventJournal;
+import de.codecentric.boot.admin.journal.store.JournaledEventStore;
+import de.codecentric.boot.admin.journal.store.SimpleJournaledEventStore;
 import de.codecentric.boot.admin.registry.ApplicationIdGenerator;
 import de.codecentric.boot.admin.registry.ApplicationRegistry;
 import de.codecentric.boot.admin.registry.HashingApplicationUrlIdGenerator;
@@ -139,6 +143,26 @@ public class AdminServerWebConfiguration extends WebMvcConfigurerAdapter impleme
 
 		registrar.addFixedRateTask(registratorTask, monitorPeriod);
 		return registrar;
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public ApplicationEventJournal applicationEventJournal(
+			JournaledEventStore store) {
+		return new ApplicationEventJournal(store);
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public JournaledEventStore journaledEventStore() {
+		return new SimpleJournaledEventStore();
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public JournalController journalController(
+			ApplicationEventJournal eventJournal) {
+		return new JournalController(eventJournal);
 	}
 
 }

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/config/DiscoveryClientConfiguration.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/config/DiscoveryClientConfiguration.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.codecentric.boot.admin.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.cloud.client.discovery.noop.NoopDiscoveryClientAutoConfiguration;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import de.codecentric.boot.admin.discovery.ApplicationDiscoveryListener;
+import de.codecentric.boot.admin.registry.ApplicationRegistry;
+
+@Configuration
+@ConditionalOnClass({ DiscoveryClient.class })
+@ConditionalOnProperty(prefix = "spring.boot.admin.discovery", name = "enabled", matchIfMissing = true)
+@AutoConfigureAfter({ NoopDiscoveryClientAutoConfiguration.class })
+public  class DiscoveryClientConfiguration {
+
+	@Value("${spring.boot.admin.discovery.management.context-path:}")
+	private String managementPath;
+
+	@Autowired
+	private DiscoveryClient discoveryClient;
+
+	@Autowired
+	private ApplicationRegistry registry;
+
+	@Bean
+	ApplicationListener<ApplicationEvent> applicationDiscoveryListener() {
+		ApplicationDiscoveryListener listener = new ApplicationDiscoveryListener(discoveryClient, registry);
+		listener.setManagementContextPath(managementPath);
+		return listener;
+	}
+}

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/config/HazelcastStoreConfiguration.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/config/HazelcastStoreConfiguration.java
@@ -33,7 +33,7 @@ import com.hazelcast.core.IMap;
 import com.hazelcast.core.MapEvent;
 
 import de.codecentric.boot.admin.event.ClientApplicationRegisteredEvent;
-import de.codecentric.boot.admin.event.ClientApplicationUnregisteredEvent;
+import de.codecentric.boot.admin.event.ClientApplicationDeregisteredEvent;
 import de.codecentric.boot.admin.model.Application;
 import de.codecentric.boot.admin.registry.store.ApplicationStore;
 import de.codecentric.boot.admin.registry.store.HazelcastApplicationStore;
@@ -83,7 +83,7 @@ public  class HazelcastStoreConfiguration {
 
 		@Override
 		public void entryRemoved(EntryEvent<String, Application> event) {
-			publisher.publishEvent(new ClientApplicationUnregisteredEvent(this,event.getValue()));
+			publisher.publishEvent(new ClientApplicationDeregisteredEvent(this,event.getValue()));
 		}
 
 		@Override

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/config/HazelcastStoreConfiguration.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/config/HazelcastStoreConfiguration.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.codecentric.boot.admin.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.EntryEvent;
+import com.hazelcast.core.EntryListener;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.core.MapEvent;
+
+import de.codecentric.boot.admin.event.ClientApplicationRegisteredEvent;
+import de.codecentric.boot.admin.event.ClientApplicationUnregisteredEvent;
+import de.codecentric.boot.admin.model.Application;
+import de.codecentric.boot.admin.registry.store.ApplicationStore;
+import de.codecentric.boot.admin.registry.store.HazelcastApplicationStore;
+
+@Configuration
+@ConditionalOnClass({ Hazelcast.class })
+@ConditionalOnProperty(prefix = "spring.boot.admin.hazelcast", name = "enabled", matchIfMissing = true)
+public  class HazelcastStoreConfiguration {
+
+	@Value("${spring.boot.admin.hazelcast.map:spring-boot-admin-application-store}")
+	private String hazelcastMapName;
+
+	@Bean
+	@ConditionalOnMissingBean
+	public Config hazelcastConfig() {
+		return new Config();
+	}
+
+	@Bean(destroyMethod = "shutdown")
+	@ConditionalOnMissingBean
+	public HazelcastInstance hazelcastInstance(Config hazelcastConfig) {
+		return Hazelcast.newHazelcastInstance(hazelcastConfig);
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public ApplicationStore applicationStore(HazelcastInstance hazelcast) {
+		IMap<String, Application> map = hazelcast.<String, Application> getMap(hazelcastMapName);
+		map.addIndex("name", false);
+		map.addEntryListener(entryListener(), false);
+		return new HazelcastApplicationStore(map);
+	}
+
+	@Bean
+	public EntryListener<String, Application> entryListener() {
+		return new ApplicationEntryListener();
+	}
+
+	private static class ApplicationEntryListener implements EntryListener<String, Application> {
+		@Autowired
+		ApplicationEventPublisher publisher;
+
+		@Override
+		public void entryAdded(EntryEvent<String, Application> event) {
+			publisher.publishEvent(new ClientApplicationRegisteredEvent(this,event.getValue()));
+		}
+
+		@Override
+		public void entryRemoved(EntryEvent<String, Application> event) {
+			publisher.publishEvent(new ClientApplicationUnregisteredEvent(this,event.getValue()));
+		}
+
+		@Override
+		public void entryUpdated(EntryEvent<String, Application> event) {
+			publisher.publishEvent(new ClientApplicationRegisteredEvent(this,event.getValue()));
+		}
+
+		@Override
+		public void entryEvicted(EntryEvent<String, Application> event) {
+			publisher.publishEvent(new ClientApplicationRegisteredEvent(this,null));
+		}
+
+		@Override
+		public void mapEvicted(MapEvent event) {
+			publisher.publishEvent(new ClientApplicationRegisteredEvent(this,null));
+		}
+
+		@Override
+		public void mapCleared(MapEvent event) {
+			publisher.publishEvent(new ClientApplicationRegisteredEvent(this,null));
+		}
+	}
+}

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/config/MailNotifierConfiguration.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/config/MailNotifierConfiguration.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.codecentric.boot.admin.config;
+
+import javax.activation.MimeType;
+import javax.mail.internet.MimeMessage;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.mail.MailProperties;
+import org.springframework.boot.autoconfigure.mail.MailSenderAutoConfiguration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.MailSender;
+
+import de.codecentric.boot.admin.notify.MailNotifier;
+
+@Configuration
+@ConditionalOnClass({ MimeMessage.class, MimeType.class })
+@ConditionalOnProperty(prefix = "spring.mail", value = "host")
+@ConditionalOnMissingBean(MailSender.class)
+@EnableConfigurationProperties(MailProperties.class)
+public class MailNotifierConfiguration extends MailSenderAutoConfiguration {
+
+
+	@Bean
+	@ConditionalOnMissingBean
+	@ConditionalOnProperty(prefix = "spring.boot.admin.notify", name = "enabled", matchIfMissing = true)
+	@ConfigurationProperties("spring.boot.admin.notify")
+	public MailNotifier mailNotifier() {
+		return new MailNotifier(mailSender());
+	}
+
+}

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/config/RevereseZuulProxyConfiguration.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/config/RevereseZuulProxyConfiguration.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.codecentric.boot.admin.config;
+
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.endpoint.Endpoint;
+import org.springframework.boot.actuate.trace.TraceRepository;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.web.ServerProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.netflix.zuul.RoutesEndpoint;
+import org.springframework.cloud.netflix.zuul.ZuulFilterInitializer;
+import org.springframework.cloud.netflix.zuul.filters.ProxyRequestHelper;
+import org.springframework.cloud.netflix.zuul.filters.ProxyRouteLocator;
+import org.springframework.cloud.netflix.zuul.filters.RouteLocator;
+import org.springframework.cloud.netflix.zuul.filters.ZuulProperties;
+import org.springframework.cloud.netflix.zuul.filters.post.SendErrorFilter;
+import org.springframework.cloud.netflix.zuul.filters.post.SendResponseFilter;
+import org.springframework.cloud.netflix.zuul.filters.pre.DebugFilter;
+import org.springframework.cloud.netflix.zuul.filters.pre.FormBodyWrapperFilter;
+import org.springframework.cloud.netflix.zuul.filters.pre.PreDecorationFilter;
+import org.springframework.cloud.netflix.zuul.filters.pre.Servlet30WrapperFilter;
+import org.springframework.cloud.netflix.zuul.filters.route.SimpleHostRoutingFilter;
+import org.springframework.cloud.netflix.zuul.web.ZuulController;
+import org.springframework.cloud.netflix.zuul.web.ZuulHandlerMapping;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.netflix.zuul.ZuulFilter;
+
+import de.codecentric.boot.admin.controller.RegistryController;
+import de.codecentric.boot.admin.registry.ApplicationRegistry;
+import de.codecentric.boot.admin.zuul.ApplicationRouteLocator;
+import de.codecentric.boot.admin.zuul.ApplicationRouteRefreshListener;
+
+@Configuration
+@EnableConfigurationProperties(ZuulProperties.class)
+public class RevereseZuulProxyConfiguration {
+
+	@Autowired(required = false)
+	private TraceRepository traces;
+
+	@Autowired
+	private ZuulProperties zuulProperties;
+
+	@Autowired
+	private ServerProperties server;
+
+	@Autowired
+	private ApplicationRegistry registry;
+
+	@Bean
+	public ApplicationRouteLocator routeLocator() {
+		return new ApplicationRouteLocator(this.server.getServletPrefix(), registry, this.zuulProperties,
+				RegistryController.PATH);
+	}
+
+	@Bean
+	public PreDecorationFilter preDecorationFilter() {
+		return new PreDecorationFilter(routeLocator(), this.zuulProperties.isAddProxyHeaders());
+	}
+
+	@Bean
+	public SimpleHostRoutingFilter simpleHostRoutingFilter() {
+		ProxyRequestHelper helper = new ProxyRequestHelper();
+		if (this.traces != null) {
+			helper.setTraces(this.traces);
+		}
+		return new SimpleHostRoutingFilter(helper);
+	}
+
+	@Bean
+	public ZuulController zuulController() {
+		return new ZuulController();
+	}
+
+	@Bean
+	public ZuulHandlerMapping zuulHandlerMapping(RouteLocator routes) {
+		return new ZuulHandlerMapping(routes, zuulController());
+	}
+
+	// pre filters
+
+	@Bean
+	public FormBodyWrapperFilter formBodyWrapperFilter() {
+		return new FormBodyWrapperFilter();
+	}
+
+	@Bean
+	public DebugFilter debugFilter() {
+		return new DebugFilter();
+	}
+
+	@Bean
+	public Servlet30WrapperFilter servlet30WrapperFilter() {
+		return new Servlet30WrapperFilter();
+	}
+
+	// post filters
+
+	@Bean
+	public SendResponseFilter sendResponseFilter() {
+		return new SendResponseFilter();
+	}
+
+	@Bean
+	public SendErrorFilter sendErrorFilter() {
+		return new SendErrorFilter();
+	}
+
+	@Configuration
+	protected static class ZuulFilterConfiguration {
+
+		@Autowired
+		private Map<String, ZuulFilter> filters;
+
+		@Bean
+		public ZuulFilterInitializer zuulFilterInitializer() {
+			return new ZuulFilterInitializer(this.filters);
+		}
+
+	}
+
+	@Bean
+	public ApplicationRouteRefreshListener applicationRouteRefreshListener() {
+		return new ApplicationRouteRefreshListener(routeLocator(), zuulHandlerMapping(routeLocator()));
+	}
+
+	@Configuration
+	@ConditionalOnClass(Endpoint.class)
+	protected static class RoutesEndpointConfiguration {
+
+		@Autowired
+		private ProxyRouteLocator routeLocator;
+
+		@Bean
+		public RoutesEndpoint zuulEndpoint() {
+			return new RoutesEndpoint(this.routeLocator);
+		}
+
+	}
+
+}

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/config/SimpleStoreConfig.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/config/SimpleStoreConfig.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.codecentric.boot.admin.config;
+
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import de.codecentric.boot.admin.registry.store.ApplicationStore;
+import de.codecentric.boot.admin.registry.store.SimpleApplicationStore;
+
+@Configuration
+@AutoConfigureAfter({HazelcastStoreConfiguration.class})
+public  class SimpleStoreConfig {
+	@Bean
+	@ConditionalOnMissingBean
+	public ApplicationStore applicationStore() {
+		return new SimpleApplicationStore();
+	}
+}

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/controller/JournalController.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/controller/JournalController.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.codecentric.boot.admin.controller;
+
+import java.util.Collection;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import de.codecentric.boot.admin.journal.ApplicationEventJournal;
+import de.codecentric.boot.admin.journal.JournaledEvent;
+
+/**
+ * REST-Controller for querying all client application events.
+ *
+ * @author Johannes Stelzer
+ *
+ */
+@RestController
+@RequestMapping("/api/journal")
+public class JournalController {
+
+	private ApplicationEventJournal eventJournal;
+
+	public JournalController(ApplicationEventJournal eventJournal) {
+		this.eventJournal = eventJournal;
+	}
+
+	@RequestMapping
+	public Collection<JournaledEvent> getJournal() {
+		return eventJournal.getEvents();
+	}
+
+}

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/controller/RegistryController.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/controller/RegistryController.java
@@ -102,7 +102,7 @@ public class RegistryController {
 	@RequestMapping(value = "/{id}", method = RequestMethod.DELETE)
 	public ResponseEntity<Application> unregister(@PathVariable String id) {
 		LOGGER.debug("Unregister application with ID '{}'", id);
-		Application app = registry.unregister(id);
+		Application app = registry.deregister(id);
 		if (app != null) {
 			return new ResponseEntity<Application>(app, HttpStatus.NO_CONTENT);
 		} else {

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/discovery/ApplicationDiscoveryListener.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/discovery/ApplicationDiscoveryListener.java
@@ -86,7 +86,9 @@ public class ApplicationDiscoveryListener implements ApplicationListener<Applica
 		String managementUrl = append(instance.getUri().toString(), managementContextPath);
 		String healthUrl = append(managementUrl, healthEndpoint);
 
-		return new Application(healthUrl, managementUrl, serviceUrl, instance.getServiceId());
+		return Application.create(instance.getServiceId())
+				.withHealthUrl(healthUrl).withManagementUrl(managementUrl)
+				.withServiceUrl(serviceUrl).build();
 	}
 
 	public void setManagementContextPath(String managementContextPath) {

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/event/ClientApplicationDeregisteredEvent.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/event/ClientApplicationDeregisteredEvent.java
@@ -21,8 +21,8 @@ import de.codecentric.boot.admin.model.Application;
  * This event gets emitted when an application is unregistered.
  * @author Johannes Stelzer
  */
-public class ClientApplicationUnregisteredEvent extends ClientApplicationEvent {
-	public ClientApplicationUnregisteredEvent(Object source, Application application) {
+public class ClientApplicationDeregisteredEvent extends ClientApplicationEvent {
+	public ClientApplicationDeregisteredEvent(Object source, Application application) {
 		super(source, application);
 	}
 

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/event/ClientApplicationStatusChangedEvent.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/event/ClientApplicationStatusChangedEvent.java
@@ -1,0 +1,26 @@
+package de.codecentric.boot.admin.event;
+
+import de.codecentric.boot.admin.model.Application;
+import de.codecentric.boot.admin.model.StatusInfo;
+
+public class ClientApplicationStatusChangedEvent extends ClientApplicationEvent {
+	private static final long serialVersionUID = 1L;
+	private final StatusInfo from;
+	private final StatusInfo to;
+
+	public ClientApplicationStatusChangedEvent(Object source,
+			Application application, StatusInfo from, StatusInfo to) {
+		super(source, application);
+		this.from = from;
+		this.to = to;
+	}
+
+	public StatusInfo getFrom() {
+		return from;
+	}
+
+	public StatusInfo getTo() {
+		return to;
+	}
+
+}

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/journal/ApplicationEventJournal.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/journal/ApplicationEventJournal.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.codecentric.boot.admin.journal;
+
+import java.util.Collection;
+
+import org.springframework.context.ApplicationListener;
+
+import de.codecentric.boot.admin.event.ClientApplicationEvent;
+import de.codecentric.boot.admin.journal.store.JournaledEventStore;
+
+/**
+ * Listens for all ClientApplicationEvents and stores them as JournaledEvents in
+ * a store.
+ *
+ * @author Johannes Stelzer
+ *
+ */
+public class ApplicationEventJournal implements
+		ApplicationListener<ClientApplicationEvent> {
+
+	private final JournaledEventStore store;
+
+	public ApplicationEventJournal(JournaledEventStore store) {
+		this.store = store;
+	}
+
+	@Override
+	public void onApplicationEvent(ClientApplicationEvent event) {
+		store.store(JournaledEvent.fromEvent(event));
+	}
+
+	public Collection<JournaledEvent> getEvents() {
+		return store.findAll();
+	}
+}

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/journal/JournaledEvent.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/journal/JournaledEvent.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.codecentric.boot.admin.journal;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+import de.codecentric.boot.admin.event.ClientApplicationDeregisteredEvent;
+import de.codecentric.boot.admin.event.ClientApplicationEvent;
+import de.codecentric.boot.admin.event.ClientApplicationRegisteredEvent;
+import de.codecentric.boot.admin.event.ClientApplicationStatusChangedEvent;
+import de.codecentric.boot.admin.model.Application;
+
+/**
+ *
+ * Journal-representation of ClientApplicationEvents. In opposite to the
+ * ClientApplicationEvent.class this Class has no reference to the event-source.
+ *
+ * @author Johannes Stelzer
+ *
+ */
+@JsonInclude(Include.NON_EMPTY)
+public class JournaledEvent {
+
+	public enum Type {
+		REGISTRATION, DEREGISTRATION, STATUS_CHANGE
+	}
+
+	private final Type type;
+	private final long timestamp;
+	private final Application application;
+	private final Map<String, Object> data;
+
+	private JournaledEvent(Type type, long timestamp, Application application,
+			Map<String, Object> data) {
+		this.type = type;
+		this.timestamp = timestamp;
+		this.application = application;
+		if (data != null) {
+			this.data = Collections.unmodifiableMap(new HashMap<String, Object>(
+					data));
+		} else {
+			this.data = Collections.emptyMap();
+		}
+	}
+
+	public static JournaledEvent fromEvent(ClientApplicationEvent event) {
+		long timestamp = event.getTimestamp();
+		Application application = event.getApplication();
+
+		if (event instanceof ClientApplicationRegisteredEvent) {
+			return new JournaledEvent(Type.REGISTRATION, timestamp, application,
+					null);
+
+		} else if (event instanceof ClientApplicationDeregisteredEvent) {
+			return new JournaledEvent(Type.DEREGISTRATION, timestamp,
+					application, null);
+
+		} else if (event instanceof ClientApplicationStatusChangedEvent) {
+			ClientApplicationStatusChangedEvent changeEvent = (ClientApplicationStatusChangedEvent) event;
+			Map<String, Object> data = new HashMap<String, Object>();
+			data.put("from", changeEvent.getFrom().getStatus());
+			data.put("to", changeEvent.getTo().getStatus());
+
+			return new JournaledEvent(Type.STATUS_CHANGE, timestamp, application,
+					data);
+		}
+
+		throw new IllegalArgumentException(
+				"Couldn't convert event to JournaledEvent: " + event.toString());
+	}
+
+	public Application getApplication() {
+		return application;
+	}
+
+	public Map<String, Object> getData() {
+		return data;
+	}
+
+	public long getTimestamp() {
+		return timestamp;
+	}
+
+	public Type getType() {
+		return type;
+	}
+
+	@Override
+	public String toString() {
+		return "JournaledEvent [type=" + type + ", timestamp=" + timestamp
+				+ ", application=" + application + ", data=" + data + "]";
+	}
+
+}

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/journal/store/JournaledEventStore.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/journal/store/JournaledEventStore.java
@@ -13,20 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package de.codecentric.boot.admin.event;
+package de.codecentric.boot.admin.journal.store;
 
-import de.codecentric.boot.admin.model.Application;
+import java.util.Collection;
+
+import de.codecentric.boot.admin.journal.JournaledEvent;
 
 /**
- * This event gets emitted when an application is registered.
+ * Interface for storing JournaledEvent
  *
  * @author Johannes Stelzer
+ *
  */
-public class ClientApplicationRegisteredEvent extends ClientApplicationEvent {
-	public ClientApplicationRegisteredEvent(Object source, Application application) {
-		super(source, application);
-	}
+public interface JournaledEventStore {
 
-	private static final long serialVersionUID = 1L;
+	Collection<JournaledEvent> findAll();
 
+	void store(JournaledEvent event);
 }

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/journal/store/SimpleJournaledEventStore.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/journal/store/SimpleJournaledEventStore.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.codecentric.boot.admin.journal.store;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import de.codecentric.boot.admin.journal.JournaledEvent;
+
+/**
+ * Simple, non-persistent Store for JournaledEvent
+ *
+ * @author Johannes Stelzer
+ *
+ */
+public class SimpleJournaledEventStore implements JournaledEventStore {
+
+	private final List<JournaledEvent> store = Collections
+			.synchronizedList(new ArrayList<JournaledEvent>(1000));
+
+	@Override
+	public Collection<JournaledEvent> findAll() {
+		ArrayList<JournaledEvent> list = new ArrayList<JournaledEvent>(
+				store);
+		Collections.reverse(list);
+		return list;
+	}
+
+	@Override
+	public void store(JournaledEvent event) {
+		store.add(event);
+	}
+
+}

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/notify/MailNotifier.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/notify/MailNotifier.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2013-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.codecentric.boot.admin.notify;
+
+import java.util.Arrays;
+
+import javax.mail.MessagingException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationListener;
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.Expression;
+import org.springframework.expression.ParserContext;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.mail.MailSender;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+
+import de.codecentric.boot.admin.event.ClientApplicationStatusChangedEvent;
+
+public class MailNotifier implements ApplicationListener<ClientApplicationStatusChangedEvent> {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(MailNotifier.class);
+	private final String DEFAULT_SUBJECT = "#{application.name} (#{application.id}) is #{to.status}";
+	private final String DEFAULT_TEXT = "#{application.name} (#{application.id})\nstatus changed from #{from.status} to #{to.status}\n\n#{application.healthUrl}";
+
+	private final SpelExpressionParser parser = new SpelExpressionParser();
+
+	private MailSender sender;
+
+	/**
+	 * recipients of the mail
+	 */
+	private String to[] = { "root@localhost" };
+
+	/**
+	 * cc-recipients of the mail
+	 */
+	private String cc[];
+
+	/**
+	 * sender of the change
+	 */
+	private String from = null;
+
+	/**
+	 * Mail Text. SpEL template using event as root;
+	 */
+	private Expression text;
+
+	/**
+	 * Mail Subject. SpEL template using event as root;
+	 */
+	private Expression subject;
+
+	/**
+	 * List of changes to ignore. Must be in Format OLD:NEW, for any status use
+	 * * as wildcard, e.g. *:UP or OFFLINE:*
+	 */
+	private String[] ignoreChanges = { "UNKNOWN:UP" };
+
+	/**
+	 * Enables the mail notification.
+	 */
+	private boolean enabled = true;
+
+	public MailNotifier(MailSender sender) {
+		this.sender = sender;
+		this.subject = parser.parseExpression(DEFAULT_SUBJECT, ParserContext.TEMPLATE_EXPRESSION);
+		this.text = parser.parseExpression(DEFAULT_TEXT, ParserContext.TEMPLATE_EXPRESSION);
+	}
+
+	@Override
+	public void onApplicationEvent(ClientApplicationStatusChangedEvent event) {
+		if (enabled && shouldSendMail(event.getFrom().getStatus(), event.getTo().getStatus())) {
+			try {
+				sendMail(event);
+			} catch (Exception ex) {
+				LOGGER.error("Couldn't send mail for Statuschange {} ", event, ex);
+			}
+		}
+	}
+
+	private void sendMail(ClientApplicationStatusChangedEvent event) throws MessagingException {
+		EvaluationContext context = new StandardEvaluationContext(event);
+
+		SimpleMailMessage message = new SimpleMailMessage();
+		message.setTo(to);
+		message.setFrom(from);
+		message.setSubject(subject.getValue(context, String.class));
+		message.setText(text.getValue(context, String.class));
+		message.setCc(cc);
+
+		sender.send(message);
+	}
+
+	private boolean shouldSendMail(String from, String to) {
+		return Arrays.binarySearch(ignoreChanges, (from + ":" + to)) < 0
+				&& Arrays.binarySearch(ignoreChanges, ("*:" + to)) < 0
+				&& Arrays.binarySearch(ignoreChanges, (from + ":*")) < 0;
+	}
+
+	public void setSender(JavaMailSender sender) {
+		this.sender = sender;
+	}
+
+	public void setTo(String[] to) {
+		this.to = to;
+	}
+
+	public void setCc(String[] cc) {
+		this.cc = cc;
+	}
+
+	public void setFrom(String from) {
+		this.from = from;
+	}
+
+	public void setSubject(String subject) {
+		this.subject = parser.parseExpression(subject, ParserContext.TEMPLATE_EXPRESSION);
+	}
+
+	public void setText(String text) {
+		this.text = parser.parseExpression(text, ParserContext.TEMPLATE_EXPRESSION);
+	}
+
+	public void setIgnoreChanges(String[] ignoreChanges) {
+		String[] copy = Arrays.copyOf(ignoreChanges, ignoreChanges.length);
+		Arrays.sort(copy);
+		this.ignoreChanges = copy;
+	}
+
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
+
+}

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/registry/StatusUpdater.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/registry/StatusUpdater.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2013-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.codecentric.boot.admin.registry;
+
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.ApplicationEventPublisherAware;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import de.codecentric.boot.admin.event.ClientApplicationStatusChangedEvent;
+import de.codecentric.boot.admin.model.Application;
+import de.codecentric.boot.admin.model.StatusInfo;
+import de.codecentric.boot.admin.registry.store.ApplicationStore;
+
+/**
+ * The StatusUpdater is responsible for updatig the status of all or a single
+ * application querying the healthUrl.
+ *
+ * @author Johannes Stelzer
+ *
+ */
+public class StatusUpdater implements ApplicationEventPublisherAware {
+	private static final Logger LOGGER = LoggerFactory.getLogger(StatusUpdater.class);
+
+	private final ApplicationStore store;
+	private final RestTemplate restTemplate;
+	private ApplicationEventPublisher publisher;
+
+	/**
+	 * Lifetime of status in ms. The status won't be updated as long the last
+	 * status isn't expired.
+	 */
+	private long statusLifetime = 30_000L;
+
+
+	public StatusUpdater(RestTemplate restTemplate, ApplicationStore store) {
+		this.restTemplate = restTemplate;
+		this.store = store;
+	}
+
+	public void updateStatusForAllApplications() {
+		long now = System.currentTimeMillis();
+		for (Application application : store.findAll()) {
+			if ( now - statusLifetime > application.getStatusInfo().getTimestamp()) {
+				updateStatus(application);
+			}
+		}
+	}
+
+	public void updateStatus(Application application) {
+		StatusInfo oldStatus = application.getStatusInfo();
+		StatusInfo newStatus = queryStatus(application);
+
+		Application newState = Application.create(application)
+				.withStatusInfo(newStatus)
+				.build();
+		store.save(newState);
+
+		if (!newStatus.equals(oldStatus)) {
+			publisher.publishEvent(new ClientApplicationStatusChangedEvent(
+					this, newState, oldStatus, newStatus));
+		}
+	}
+
+	private StatusInfo queryStatus(Application application) {
+		LOGGER.trace("Updating status for {}", application);
+
+		try {
+			@SuppressWarnings("unchecked")
+			ResponseEntity<Map<String, String>> response = restTemplate.getForEntity(application.getHealthUrl(), (Class<Map<String, String>>)(Class<?>) Map.class);
+			LOGGER.debug("/health for {} responded with {}", application, response);
+
+			if (response.hasBody() && response.getBody().get("status") != null ) {
+				return StatusInfo.valueOf(response.getBody().get("status"));
+			} else if (response.getStatusCode().is2xxSuccessful()) {
+				return StatusInfo.ofUp();
+			} else {
+				return StatusInfo.ofDown();
+			}
+
+		} catch (RestClientException ex){
+			LOGGER.warn("Couldn't retrieve status for {}", application, ex);
+			return StatusInfo.ofOffline();
+		}
+	}
+
+	public void setStatusLifetime(long statusLifetime) {
+		this.statusLifetime = statusLifetime;
+	}
+
+	@Override
+	public void setApplicationEventPublisher(ApplicationEventPublisher publisher) {
+		this.publisher = publisher;
+	}
+
+
+}

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/registry/store/ApplicationStore.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/registry/store/ApplicationStore.java
@@ -25,7 +25,7 @@ import de.codecentric.boot.admin.model.Application;
 public interface ApplicationStore {
 
 	/**
-	 * Inserts a new Application into the store. If the Id is already present in the store the Application is NOT stored.
+	 * Inserts a new Application into the store. If the Id is already present in the store the old Application is replaced.
 	 * 
 	 * @param app Application to store
 	 * @return the Application associated previosly with the applications id.

--- a/spring-boot-admin-server/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-admin-server/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -6,6 +6,10 @@
   {
     "name": "spring.boot.admin.discovery",
     "sourceType": "de.codecentric.boot.admin.config.DiscoveryClientConfiguration"
+  },
+  {
+    "name": "spring.boot.admin.monitor",
+    "sourceType": "de.codecentric.boot.admin.config.AdminServerWebConfiguration"
   }
 ],"properties": [
   {
@@ -31,5 +35,11 @@
     "type": "java.lang.String",
     "description": "management-path suffix for discovered applications",
     "defaultValue": ""
+  },
+  {
+    "name": "spring.boot.admin.discovery.monitor.period",
+    "type": "long",
+    "description": "time interval in ms to update the status of applications with expired statusInfo",
+    "defaultValue": "10000"
   }
 ]

--- a/spring-boot-admin-server/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-admin-server/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -6,10 +6,6 @@
   {
     "name": "spring.boot.admin.discovery",
     "sourceType": "de.codecentric.boot.admin.config.DiscoveryClientConfiguration"
-  },
-  {
-    "name": "spring.boot.admin.monitor",
-    "sourceType": "de.codecentric.boot.admin.config.AdminServerWebConfiguration"
   }
 ],"properties": [
   {

--- a/spring-boot-admin-server/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-admin-server/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,11 +1,11 @@
 {"groups": [
   {
     "name": "spring.boot.admin.hazelcast",
-    "sourceType": "de.codecentric.boot.admin.config.AdminServerWebConfiguration.HazelcastStoreConfiguration"
+    "sourceType": "de.codecentric.boot.admin.config.HazelcastStoreConfiguration"
   },
   {
     "name": "spring.boot.admin.discovery",
-    "sourceType": "de.codecentric.boot.admin.config.AdminServerWebConfiguration.DiscoveryClientConfiguration"
+    "sourceType": "de.codecentric.boot.admin.config.DiscoveryClientConfiguration"
   }
 ],"properties": [
   {

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/AdminApplicationHazelcastTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/AdminApplicationHazelcastTest.java
@@ -76,12 +76,12 @@ public class AdminApplicationHazelcastTest {
 
 	@Test
 	public void test() {
-		Application app = new Application("http://127.0.0.1/health", "", "",
-				"Hazelcast Test");
-		Application app2 = new Application("http://127.0.0.1:2/health", "", "",
-				"Hazelcast Test");
-		Application app3 = new Application("http://127.0.0.1:3/health", "", "",
-				"Do not find");
+		Application app = Application.create("Hazelcast Test")
+				.withHealthUrl("http://127.0.0.1/health").build();
+		Application app2 = Application.create("Hazelcast Test")
+				.withHealthUrl("http://127.0.0.1:2/health").build();
+		Application app3 = Application.create("Do not find")
+				.withHealthUrl("http://127.0.0.1:3/health").build();
 
 		// publish app on instance1
 		ResponseEntity<Application> postResponse = registerApp(app, instance1);

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/AdminApplicationTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/AdminApplicationTest.java
@@ -62,9 +62,11 @@ public class AdminApplicationTest {
 	public void testReverseProxy() {
 		String apiBaseUrl = "http://localhost:" + port + "/api/applications";
 
-		ResponseEntity<Application> entity = new TestRestTemplate().postForEntity(
-				apiBaseUrl, new Application("http://localhost:" + port + "/health",
-						"http://localhost:" + port, "", "TestApp"), Application.class);
+		ResponseEntity<Application> entity = new TestRestTemplate()
+				.postForEntity(apiBaseUrl, Application.create("TestApp")
+				.withHealthUrl("http://localhost:" + port + "/health")
+				.withManagementUrl("http://localhost:" + port).build(),
+				Application.class);
 
 		@SuppressWarnings("rawtypes")
 		ResponseEntity<Map> info = new TestRestTemplate().getForEntity(apiBaseUrl + "/"

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/config/AdminServerWebConfigurationTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/config/AdminServerWebConfigurationTest.java
@@ -20,6 +20,7 @@ import org.springframework.http.converter.json.MappingJackson2HttpMessageConvert
 import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
 
 import de.codecentric.boot.admin.discovery.ApplicationDiscoveryListener;
+import de.codecentric.boot.admin.notify.MailNotifier;
 import de.codecentric.boot.admin.registry.store.ApplicationStore;
 import de.codecentric.boot.admin.registry.store.HazelcastApplicationStore;
 import de.codecentric.boot.admin.registry.store.SimpleApplicationStore;
@@ -65,6 +66,14 @@ public class AdminServerWebConfigurationTest {
 		load("spring.boot.admin.hazelcast.enabled:false", "spring.boot.admin.discovery.enabled:false");
 		assertTrue(context.getBean(ApplicationStore.class) instanceof SimpleApplicationStore);
 		assertTrue(context.getBeansOfType(ApplicationDiscoveryListener.class).isEmpty());
+		assertTrue(context.getBeansOfType(MailNotifier.class).isEmpty());
+	}
+
+	@Test
+	public void simpleConfig_mail() {
+		load("spring.mail.host:localhost", "spring.boot.admin.hazelcast.enabled:false",
+				"spring.boot.admin.discovery.enabled:false");
+		assertTrue(context.getBean(MailNotifier.class) instanceof MailNotifier);
 	}
 
 	@Test

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/config/AdminServerWebConfigurationTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/config/AdminServerWebConfigurationTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 import org.junit.After;
 import org.junit.Test;
+import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.ServerPropertiesAutoConfiguration;
 import org.springframework.boot.test.EnvironmentTestUtils;
 import org.springframework.cloud.client.discovery.noop.NoopDiscoveryClientAutoConfiguration;
@@ -82,6 +83,7 @@ public class AdminServerWebConfigurationTest {
 
 	private void load(String... environment) {
 		AnnotationConfigWebApplicationContext applicationContext = new AnnotationConfigWebApplicationContext();
+		applicationContext.register(PropertyPlaceholderAutoConfiguration.class);
 		applicationContext.register(ServerPropertiesAutoConfiguration.class);
 		applicationContext.register(NoopDiscoveryClientAutoConfiguration.class);
 		applicationContext.register(AdminServerWebConfiguration.class);

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/controller/JournalControllerTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/controller/JournalControllerTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.codecentric.boot.admin.controller;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.Collection;
+
+import org.junit.Test;
+
+import de.codecentric.boot.admin.event.ClientApplicationRegisteredEvent;
+import de.codecentric.boot.admin.journal.ApplicationEventJournal;
+import de.codecentric.boot.admin.journal.JournaledEvent;
+import de.codecentric.boot.admin.journal.store.SimpleJournaledEventStore;
+import de.codecentric.boot.admin.model.Application;
+
+public class JournalControllerTest {
+
+	private ApplicationEventJournal journal = new ApplicationEventJournal(
+			new SimpleJournaledEventStore());
+	private JournalController controller = new JournalController(journal);
+
+	@Test
+	public void test_getJournal() {
+		journal.onApplicationEvent(new ClientApplicationRegisteredEvent(
+				new Object(), Application.create("foo").withId("bar").build()));
+
+		Collection<JournaledEvent> history = controller.getJournal();
+
+		assertThat(history.size(), is(1));
+
+		JournaledEvent event = history.iterator().next();
+		assertThat(event.getType(), is(JournaledEvent.Type.REGISTRATION));
+
+	}
+}

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/controller/RegistryControllerTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/controller/RegistryControllerTest.java
@@ -24,7 +24,7 @@ import java.util.Collection;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
-import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
@@ -42,7 +42,7 @@ public class RegistryControllerTest {
 	public void setup() {
 		registry = new ApplicationRegistry(new SimpleApplicationStore(),
 				new HashingApplicationUrlIdGenerator());
-		registry.setApplicationContext(Mockito.mock(ApplicationContext.class));
+		registry.setApplicationEventPublisher(Mockito.mock(ApplicationEventPublisher.class));
 		controller = new RegistryController(registry);
 	}
 

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/controller/RegistryControllerTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/controller/RegistryControllerTest.java
@@ -48,9 +48,10 @@ public class RegistryControllerTest {
 
 	@Test
 	public void register() {
-		ResponseEntity<Application> response = controller.register(new Application(
-				"http://localhost/mgmt/health", "http://localhost/mgmt",
-				"http://localhost/", "test"));
+		ResponseEntity<Application> response = controller.register(Application
+				.create("test").withHealthUrl("http://localhost/mgmt/health")
+				.withManagementUrl("http://localhost/mgmt")
+				.withServiceUrl("http://localhost/").build());
 		assertEquals(HttpStatus.CREATED, response.getStatusCode());
 		assertEquals("http://localhost/mgmt/health", response.getBody().getHealthUrl());
 		assertEquals("http://localhost/mgmt", response.getBody().getManagementUrl());
@@ -60,7 +61,8 @@ public class RegistryControllerTest {
 
 	@Test
 	public void register_twice() {
-		Application app = new Application("http://localhost/health", "", "", "test");
+		Application app = Application.create("test")
+				.withHealthUrl("http://localhost/health").build();
 		controller.register(app);
 		ResponseEntity<Application> response = controller.register(app);
 
@@ -71,16 +73,20 @@ public class RegistryControllerTest {
 
 	@Test
 	public void register_sameUrl() {
-		controller.register(new Application("http://localhost/health", "", "", "FOO"));
-		ResponseEntity<?> response = controller.register(new Application(
-				"http://localhost/health", "", "", "BAR"));
+		controller.register(Application.create("FOO")
+				.withHealthUrl("http://localhost/mgmt/health").build());
+		ResponseEntity<?> response = controller.register(Application
+				.create("BAR").withHealthUrl("http://localhost/mgmt/health")
+				.build());
 		assertEquals(HttpStatus.CREATED, response.getStatusCode());
 	}
 
 	@Test
 	public void get() {
 		Application app = controller.register(
-				new Application("http://localhost/health", "", "", "FOO")).getBody();
+				Application.create("FOO")
+						.withHealthUrl("http://localhost/health").build())
+				.getBody();
 
 		ResponseEntity<Application> response = controller.get(app.getId());
 		assertEquals(HttpStatus.OK, response.getStatusCode());
@@ -90,7 +96,8 @@ public class RegistryControllerTest {
 
 	@Test
 	public void get_notFound() {
-		controller.register(new Application("http://localhost/health", "", "", "FOO"));
+		controller.register(Application.create("FOO")
+				.withHealthUrl("http://localhost/mgmt/health").build());
 
 		ResponseEntity<?> response = controller.get("unknown");
 		assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
@@ -99,7 +106,9 @@ public class RegistryControllerTest {
 	@Test
 	public void unregister() {
 		Application app = controller.register(
-				new Application("http://localhost/health", "", "", "FOO")).getBody();
+				Application.create("FOO")
+				.withHealthUrl("http://localhost/mgmt/health").build())
+				.getBody();
 
 		ResponseEntity<?> response = controller.unregister(app.getId());
 		assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
@@ -110,7 +119,8 @@ public class RegistryControllerTest {
 
 	@Test
 	public void unregister_notFound() {
-		controller.register(new Application("http://localhost/health", "", "", "FOO"));
+		controller.register(Application.create("FOO")
+				.withHealthUrl("http://localhost/mgmt/health").build());
 
 		ResponseEntity<?> response = controller.unregister("unknown");
 		assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
@@ -119,7 +129,9 @@ public class RegistryControllerTest {
 	@Test
 	public void applications() {
 		Application app = controller.register(
-				new Application("http://localhost/health", "", "", "FOO")).getBody();
+				Application.create("FOO")
+				.withHealthUrl("http://localhost/mgmt/health").build())
+				.getBody();
 
 		Collection<Application> applications = controller.applications(null);
 		assertEquals(1, applications.size());
@@ -129,11 +141,17 @@ public class RegistryControllerTest {
 	@Test
 	public void applicationsByName() {
 		Application app = controller.register(
-				new Application("http://localhost:2/health", "", "", "FOO")).getBody();
+				Application.create("FOO")
+				.withHealthUrl("http://localhost1/mgmt/health")
+				.build()).getBody();
 		Application app2 = controller.register(
-				new Application("http://localhost:1/health", "", "", "FOO")).getBody();
+				Application.create("FOO")
+				.withHealthUrl("http://localhost2/mgmt/health")
+				.build()).getBody();
 		Application app3 = controller.register(
-				new Application("http://localhost:3/health", "", "", "BAR")).getBody();
+				Application.create("BAR")
+				.withHealthUrl("http://localhost3/mgmt/health")
+				.build()).getBody();
 
 		Collection<Application> applications = controller.applications("FOO");
 		assertEquals(2, applications.size());

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/discovery/ApplicationDiscoveryListenerTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/discovery/ApplicationDiscoveryListenerTest.java
@@ -29,7 +29,7 @@ import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.cloud.client.discovery.event.HeartbeatEvent;
 import org.springframework.cloud.client.discovery.event.InstanceRegisteredEvent;
 import org.springframework.cloud.client.discovery.event.ParentHeartbeatEvent;
-import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationEventPublisher;
 
 import de.codecentric.boot.admin.model.Application;
 import de.codecentric.boot.admin.registry.ApplicationRegistry;
@@ -44,8 +44,9 @@ public class ApplicationDiscoveryListenerTest {
 
 	@Before
 	public void setup() {
-		registry = new ApplicationRegistry(new SimpleApplicationStore(), new HashingApplicationUrlIdGenerator());
-		registry.setApplicationContext(mock(ApplicationContext.class));
+		registry = new ApplicationRegistry(new SimpleApplicationStore(),
+				new HashingApplicationUrlIdGenerator());
+		registry.setApplicationEventPublisher(mock(ApplicationEventPublisher.class));
 		discovery = mock(DiscoveryClient.class);
 		listener = new ApplicationDiscoveryListener(discovery, registry);
 	}

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/journal/ApplicationEventJournalTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/journal/ApplicationEventJournalTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.codecentric.boot.admin.journal;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.Collection;
+
+import org.junit.Test;
+
+import de.codecentric.boot.admin.event.ClientApplicationRegisteredEvent;
+import de.codecentric.boot.admin.journal.ApplicationEventJournal;
+import de.codecentric.boot.admin.journal.JournaledEvent;
+import de.codecentric.boot.admin.journal.store.SimpleJournaledEventStore;
+import de.codecentric.boot.admin.model.Application;
+
+public class ApplicationEventJournalTest {
+	private ApplicationEventJournal journal = new ApplicationEventJournal(
+			new SimpleJournaledEventStore());
+
+	@Test
+	public void test_registration() {
+		journal.onApplicationEvent(new ClientApplicationRegisteredEvent(
+				new Object(), Application.create("foo").withId("bar").build()));
+
+		Collection<JournaledEvent> events = journal.getEvents();
+		assertThat(events.size(), is(1));
+
+		JournaledEvent event = events.iterator().next();
+		assertThat(event.getType(), is(JournaledEvent.Type.REGISTRATION));
+	}
+
+}

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/journal/JournaledEventTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/journal/JournaledEventTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.codecentric.boot.admin.journal;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+
+import org.junit.Test;
+
+import de.codecentric.boot.admin.event.ClientApplicationDeregisteredEvent;
+import de.codecentric.boot.admin.event.ClientApplicationRegisteredEvent;
+import de.codecentric.boot.admin.event.ClientApplicationStatusChangedEvent;
+import de.codecentric.boot.admin.journal.JournaledEvent;
+import de.codecentric.boot.admin.model.Application;
+import de.codecentric.boot.admin.model.StatusInfo;
+
+public class JournaledEventTest {
+
+	@Test
+	public void test_from_event_registration() {
+		JournaledEvent event = JournaledEvent
+				.fromEvent(new ClientApplicationRegisteredEvent(new Object(),
+						Application.create("foo").withId("bar").build()));
+
+		assertThat(event.getApplication(),
+				is(Application.create("foo").withId("bar").build()));
+		assertThat(event.getData(), is(Collections.<String, Object> emptyMap()));
+		assertThat(event.getType(), is(JournaledEvent.Type.REGISTRATION));
+		assertTrue(event.getTimestamp() > 0);
+	}
+
+	@Test
+	public void test_from_event_deregistration() {
+		JournaledEvent event = JournaledEvent
+				.fromEvent(new ClientApplicationDeregisteredEvent(new Object(),
+						Application.create("foo").withId("bar").build()));
+
+		assertThat(event.getApplication(),
+				is(Application.create("foo").withId("bar").build()));
+		assertThat(event.getData(), is(Collections.<String, Object> emptyMap()));
+		assertThat(event.getType(), is(JournaledEvent.Type.DEREGISTRATION));
+		assertTrue(event.getTimestamp() > 0);
+	}
+
+	@Test
+	public void test_from_event_status_change() {
+		JournaledEvent event = JournaledEvent
+				.fromEvent(new ClientApplicationStatusChangedEvent(
+						new Object(),
+						Application.create("foo").withId("bar").build(),
+						StatusInfo.ofUnknown(), StatusInfo.ofUp()));
+
+		assertThat(event.getApplication(),
+				is(Application.create("foo").withId("bar").build()));
+		assertThat(event.getData().get("from"), is((Object) StatusInfo
+				.ofUnknown()
+				.getStatus()));
+		assertThat(event.getData().get("to"), is((Object) StatusInfo.ofUp()
+				.getStatus()));
+		assertThat(event.getType(), is(JournaledEvent.Type.STATUS_CHANGE));
+		assertTrue(event.getTimestamp() > 0);
+	}
+
+}

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/journal/store/SimpleJournaledEventStoreTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/journal/store/SimpleJournaledEventStoreTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.codecentric.boot.admin.journal.store;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+import de.codecentric.boot.admin.event.ClientApplicationDeregisteredEvent;
+import de.codecentric.boot.admin.event.ClientApplicationRegisteredEvent;
+import de.codecentric.boot.admin.journal.JournaledEvent;
+import de.codecentric.boot.admin.journal.store.SimpleJournaledEventStore;
+import de.codecentric.boot.admin.model.Application;
+
+public class SimpleJournaledEventStoreTest {
+
+	private SimpleJournaledEventStore store = new SimpleJournaledEventStore();
+
+	@Test
+	public void test_store() {
+		List<JournaledEvent> events = Arrays.asList(JournaledEvent
+				.fromEvent(new ClientApplicationRegisteredEvent(new Object(),
+						Application.create("foo").withId("bar").build())),
+						JournaledEvent
+						.fromEvent(new ClientApplicationDeregisteredEvent(
+								new Object(), Application.create("foo")
+								.withId("bar").build()))
+				);
+
+		for (JournaledEvent event : events) {
+			store.store(event);
+		}
+
+		// Items are stored in reverse order
+		List<JournaledEvent> reversed = new ArrayList<JournaledEvent>(
+				events);
+		Collections.reverse(reversed);
+
+		assertThat(store.findAll(),
+				is((Collection<JournaledEvent>) reversed));
+	}
+}

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/notify/MailNotifierTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/notify/MailNotifierTest.java
@@ -1,0 +1,78 @@
+package de.codecentric.boot.admin.notify;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.mail.MailSender;
+import org.springframework.mail.SimpleMailMessage;
+
+import de.codecentric.boot.admin.event.ClientApplicationStatusChangedEvent;
+import de.codecentric.boot.admin.model.Application;
+import de.codecentric.boot.admin.model.StatusInfo;
+
+public class MailNotifierTest {
+
+	private MailSender sender;
+	private MailNotifier notifier;
+
+	@Before
+	public void setup() {
+		sender = mock(MailSender.class);
+
+		notifier = new MailNotifier(sender);
+		notifier.setTo(new String[] { "foo@bar.com" });
+		notifier.setCc(new String[] { "bar@foo.com" });
+		notifier.setFrom("SBA <no-reply@example.com>");
+	}
+
+	@Test
+	public void test_onApplicationEvent() {
+		notifier.onApplicationEvent(new ClientApplicationStatusChangedEvent(new Object(),
+				Application.create("App").withId("-id-").withHealthUrl("http://health").build(),
+				StatusInfo.ofDown(), StatusInfo.ofUp()));
+
+		SimpleMailMessage expected = new SimpleMailMessage();
+		expected.setTo(new String[] { "foo@bar.com" });
+		expected.setCc(new String[] { "bar@foo.com" });
+		expected.setFrom("SBA <no-reply@example.com>");
+		expected.setText("App (-id-)\nstatus changed from DOWN to UP\n\nhttp://health");
+		expected.setSubject("App (-id-) is UP");
+
+		verify(sender).send(eq(expected));
+	}
+
+	@Test
+	public void test_onApplicationEvent_disbaled() {
+		notifier.setEnabled(false);
+		notifier.onApplicationEvent(new ClientApplicationStatusChangedEvent(new Object(),
+				Application.create("App").withId("-id-").withHealthUrl("http://health").build(),
+				StatusInfo.ofDown(), StatusInfo.ofUp()));
+
+		verify(sender, never()).send(isA(SimpleMailMessage.class));
+	}
+
+	@Test
+	public void test_onApplicationEvent_noSend() {
+		notifier.onApplicationEvent(new ClientApplicationStatusChangedEvent(new Object(),
+				Application.create("App").withId("-id-").withHealthUrl("http://health").build(),
+				StatusInfo.ofUnknown(), StatusInfo.ofUp()));
+
+		verify(sender, never()).send(isA(SimpleMailMessage.class));
+	}
+
+	@Test
+	public void test_onApplicationEvent_noSend_wildcard() {
+		notifier.setIgnoreChanges(new String[] { "*:UP" });
+
+		notifier.onApplicationEvent(new ClientApplicationStatusChangedEvent(new Object(),
+				Application.create("App").withId("-id-").withHealthUrl("http://health").build(),
+				StatusInfo.ofOffline(), StatusInfo.ofUp()));
+
+		verify(sender, never()).send(isA(SimpleMailMessage.class));
+	}
+}

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/registry/ApplicationRegistryTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/registry/ApplicationRegistryTest.java
@@ -45,35 +45,39 @@ public class ApplicationRegistryTest {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void registerFailed_no_name() throws Exception {
-		registry.register(new Application("http://localhost/health", "", "", ""));
+		registry.register(Application.create("")
+				.withHealthUrl("http://localhost/health").build());
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void registerFailed_no_healthUrl() throws Exception {
-		registry.register(new Application("", "", "", "name"));
+		registry.register(Application.create("name").build());
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void registerFailed_invalid_healthUrl() throws Exception {
-		registry.register(new Application("not-an-url", "", "", "name"));
+		registry.register(Application.create("name").withHealthUrl("not-a-url")
+				.build());
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void registerFailed_invalid_mgmtUrl() throws Exception {
-		registry.register(new Application("http://localhost/health", "not-a-url", "",
-				"name"));
+		registry.register(Application.create("")
+				.withHealthUrl("http://localhost/health")
+				.withManagementUrl("not-a-url").build());
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void registerFailed_invalid_svcUrl() throws Exception {
-		registry.register(new Application("http://localhost/health", "", "not-a-url",
-				"name"));
+		registry.register(Application.create("")
+				.withHealthUrl("http://localhost/health")
+				.withServiceUrl("not-a-url").build());
 	}
 
 	@Test
 	public void register() throws Exception {
-		Application app = registry.register(new Application(
-				"http://localhost:8080/health", "", "", "abc"));
+		Application app = registry.register(Application.create("abc")
+				.withHealthUrl("http://localhost:8080/health").build());
 
 		assertEquals("http://localhost:8080/health", app.getHealthUrl());
 		assertEquals("abc", app.getName());
@@ -82,16 +86,17 @@ public class ApplicationRegistryTest {
 
 	@Test
 	public void getApplication() throws Exception {
-		Application app = registry.register(new Application(
-				"http://localhost:8080/health", "http://localhost:8080/", "", "abc"));
+		Application app = registry.register(Application.create("abc")
+				.withHealthUrl("http://localhost/health")
+				.withManagementUrl("http://localhost:8080/").build());
 		assertEquals(app, registry.getApplication(app.getId()));
 		assertEquals("http://localhost:8080/", app.getManagementUrl());
 	}
 
 	@Test
 	public void getApplications() throws Exception {
-		Application app = registry.register(new Application(
-				"http://localhost:8080/health", "", "", "abc"));
+		Application app = registry.register(Application.create("abc")
+				.withHealthUrl("http://localhost/health").build());
 
 		Collection<Application> applications = registry.getApplications();
 		assertEquals(1, applications.size());
@@ -100,12 +105,12 @@ public class ApplicationRegistryTest {
 
 	@Test
 	public void getApplicationsByName() throws Exception {
-		Application app = registry.register(new Application(
-				"http://localhost:8080/health", "", "", "abc"));
-		Application app2 = registry.register(new Application(
-				"http://localhost:8081/health", "", "", "abc"));
-		Application app3 = registry.register(new Application(
-				"http://localhost:8082/health", "", "", "cba"));
+		Application app = registry.register(Application.create("abc")
+				.withHealthUrl("http://localhost/health").build());
+		Application app2 = registry.register(Application.create("abc")
+				.withHealthUrl("http://localhost:8081/health").build());
+		Application app3 = registry.register(Application.create("zzz")
+				.withHealthUrl("http://localhost:8082/health").build());
 
 		Collection<Application> applications = registry.getApplicationsByName("abc");
 		assertEquals(2, applications.size());

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/registry/ApplicationRegistryTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/registry/ApplicationRegistryTest.java
@@ -24,7 +24,7 @@ import java.util.Collection;
 
 import org.junit.Test;
 import org.mockito.Mockito;
-import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationEventPublisher;
 
 import de.codecentric.boot.admin.model.Application;
 import de.codecentric.boot.admin.registry.store.SimpleApplicationStore;
@@ -35,7 +35,7 @@ public class ApplicationRegistryTest {
 			new HashingApplicationUrlIdGenerator());
 
 	public ApplicationRegistryTest() {
-		registry.setApplicationContext(Mockito.mock(ApplicationContext.class));
+		registry.setApplicationEventPublisher(Mockito.mock(ApplicationEventPublisher.class));
 	}
 
 	@Test(expected = IllegalArgumentException.class)

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/registry/StatusUpdaterTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/registry/StatusUpdaterTest.java
@@ -1,0 +1,126 @@
+package de.codecentric.boot.admin.registry;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.isA;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+import de.codecentric.boot.admin.event.ClientApplicationStatusChangedEvent;
+import de.codecentric.boot.admin.model.Application;
+import de.codecentric.boot.admin.model.StatusInfo;
+import de.codecentric.boot.admin.registry.store.SimpleApplicationStore;
+
+@SuppressWarnings("rawtypes")
+public class StatusUpdaterTest {
+
+	private StatusUpdater updater;
+	private SimpleApplicationStore store;
+	private RestTemplate template;
+	private ApplicationEventPublisher publisher;
+
+	@Before
+	public void setup() {
+		store = new SimpleApplicationStore();
+		template = mock(RestTemplate.class);
+		updater = new StatusUpdater(template, store);
+		publisher = mock(ApplicationEventPublisher.class);
+		updater.setApplicationEventPublisher(publisher);
+	}
+
+	@Test
+	public void test_update_statusChanged() {
+		when(template.getForEntity("health", Map.class)).thenReturn(
+				ResponseEntity.ok().<Map> body(
+						Collections.singletonMap("status", "UP")));
+
+		updater.updateStatus(Application.create("foo").withId("id")
+				.withHealthUrl("health").build());
+
+		Application app = store.find("id");
+
+		assertThat(app.getStatusInfo().getStatus(), is("UP"));
+		verify(publisher).publishEvent(
+				argThat(isA(ClientApplicationStatusChangedEvent.class)));
+	}
+
+	@Test
+	public void test_update_statusUnchanged() {
+		when(template.getForEntity("health", Map.class))
+		.thenReturn(
+				ResponseEntity.<Map> ok(Collections.singletonMap("status",
+						"UNKNOWN")));
+
+		updater.updateStatus(Application.create("foo").withId("id")
+				.withHealthUrl("health").build());
+
+		verify(publisher, never()).publishEvent(
+				argThat(isA(ClientApplicationStatusChangedEvent.class)));
+	}
+
+	@Test
+	public void test_update_noBody() {
+		// HTTP 200 - UP
+		when(template.getForEntity("health", Map.class)).thenReturn(
+				ResponseEntity.<Map> ok(null));
+
+		updater.updateStatus(Application.create("foo").withId("id")
+				.withHealthUrl("health").build());
+
+		assertThat(store.find("id").getStatusInfo().getStatus(), is("UP"));
+
+		// HTTP != 200 - DOWN
+		when(template.getForEntity("health", Map.class)).thenReturn(
+				ResponseEntity.status(500).<Map> body(null));
+
+		updater.updateStatus(Application.create("foo").withId("id")
+				.withHealthUrl("health").build());
+
+		assertThat(store.find("id").getStatusInfo().getStatus(), is("DOWN"));
+	}
+
+	@Test
+	public void test_update_offline() {
+		when(template.getForEntity("health", Map.class)).thenThrow(
+				new ResourceAccessException("error"));
+
+		updater.updateStatus(Application.create("foo").withId("id")
+				.withHealthUrl("health").build());
+
+		assertThat(store.find("id").getStatusInfo().getStatus(), is("OFFLINE"));
+	}
+
+	@Test
+	public void test_updateStatusForApplications() {
+		Application app1 = Application.create("foo").withId("id-1")
+				.withHealthUrl("health-1").build();
+		store.save(app1);
+
+		Application app2 = Application.create("foo").withId("id-2")
+				.withHealthUrl("health-2")
+				.withStatusInfo(StatusInfo.valueOf("UP", 0L)).build();
+		store.save(app2);
+
+		when(template.getForEntity("health-2", Map.class)).thenReturn(
+				ResponseEntity.<Map> ok(null));
+
+
+		updater.updateStatusForAllApplications();
+
+		verify(template, never()).getForEntity("health-1", Map.class);
+	}
+
+}

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/zuul/ApplicationRouteLocatorTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/zuul/ApplicationRouteLocatorTest.java
@@ -46,8 +46,9 @@ public class ApplicationRouteLocatorTest {
 	@Test
 	public void locateRoutes_healthOnly() {
 		when(registry.getApplications()).thenReturn(
-				Collections.singletonList(new Application("http://localhost/health", "",
-						"", "app1", "1234")));
+				Collections.singletonList(Application.create("app1")
+						.withHealthUrl("http://localhost/health")
+						.withId("1234").build()));
 
 		locator.resetRoutes();
 
@@ -65,8 +66,10 @@ public class ApplicationRouteLocatorTest {
 	@Test
 	public void locateRoutes() {
 		when(registry.getApplications()).thenReturn(
-				Collections.singletonList(new Application("http://localhost/health",
-						"http://localhost", "", "app1", "1234")));
+				Collections.singletonList(Application.create("app1")
+						.withHealthUrl("http://localhost/health")
+						.withManagementUrl("http://localhost").withId("1234")
+						.build()));
 
 		locator.resetRoutes();
 

--- a/spring-boot-admin-starter-client/src/main/java/de/codecentric/boot/admin/model/Application.java
+++ b/spring-boot-admin-starter-client/src/main/java/de/codecentric/boot/admin/model/Application.java
@@ -34,19 +34,17 @@ public class Application implements Serializable {
 	private final String managementUrl;
 	private final String healthUrl;
 	private final String serviceUrl;
+	private final StatusInfo statusInfo;
 
-	public Application(String healthUrl, String managementUrl, String serviceUrl,
-			String name) {
-		this(healthUrl, managementUrl, serviceUrl, name, null);
-	}
-
-	public Application(String healthUrl, String managementUrl, String serviceUrl,
-			String name, String id) {
+	private Application(String healthUrl, String managementUrl,
+			String serviceUrl, String name, String id, StatusInfo statusInfo) {
 		this.healthUrl = healthUrl;
 		this.managementUrl = managementUrl;
 		this.serviceUrl = serviceUrl;
 		this.name = name;
 		this.id = id;
+		this.statusInfo = statusInfo != null ? statusInfo : StatusInfo
+				.ofUnknown();
 	}
 
 	@JsonCreator
@@ -54,18 +52,84 @@ public class Application implements Serializable {
 			@JsonProperty("managementUrl") String managementUrl,
 			@JsonProperty("healthUrl") String healthUrl,
 			@JsonProperty("serviceUrl") String serviceUrl,
-			@JsonProperty("name") String name,
-			@JsonProperty("id") String id) {
+			@JsonProperty("name") String name, @JsonProperty("id") String id,
+			@JsonProperty("statusInfo") StatusInfo statusInfo) {
 
 		Assert.hasText(name, "name must not be empty!");
 		if (StringUtils.hasText(url)) {
 			// old format
 			return new Application(url.replaceFirst("/+$", "") + "/health", url, null,
-					name, id);
+					name, id, statusInfo);
 		}
 		else {
 			Assert.hasText(healthUrl, "healthUrl must not be empty!");
-			return new Application(healthUrl, managementUrl, serviceUrl, name, id);
+			return new Application(healthUrl, managementUrl, serviceUrl, name,
+					id, statusInfo);
+		}
+	}
+
+	public static Builder create(String name) {
+		return new Builder(name);
+	}
+
+	public static Builder create(Application application) {
+		return new Builder(application);
+	}
+
+	public static class Builder {
+		private String id;
+		private String name;
+		private String managementUrl;
+		private String healthUrl;
+		private String serviceUrl;
+		private StatusInfo statusInfo;
+
+		private Builder(String name) {
+			this.name = name;
+		}
+
+		private Builder(Application application) {
+			this.healthUrl = application.healthUrl;
+			this.managementUrl = application.managementUrl;
+			this.serviceUrl = application.serviceUrl;
+			this.name = application.name;
+			this.id = application.id;
+			this.statusInfo = application.statusInfo;
+		}
+
+		public Builder withName(String name) {
+			this.name = name;
+			return this;
+		}
+
+		public Builder withId(String id) {
+			this.id = id;
+			return this;
+		}
+
+		public Builder withServiceUrl(String serviceUrl) {
+			this.serviceUrl = serviceUrl;
+			return this;
+		}
+
+		public Builder withHealthUrl(String healthUrl) {
+			this.healthUrl = healthUrl;
+			return this;
+		}
+
+		public Builder withManagementUrl(String managementUrl) {
+			this.managementUrl = managementUrl;
+			return this;
+		}
+
+		public Builder withStatusInfo(StatusInfo statusInfo) {
+			this.statusInfo = statusInfo;
+			return this;
+		}
+
+		public Application build() {
+			return new Application(healthUrl, managementUrl, serviceUrl, name,
+					id, statusInfo);
 		}
 	}
 
@@ -87,6 +151,10 @@ public class Application implements Serializable {
 
 	public String getServiceUrl() {
 		return serviceUrl;
+	}
+
+	public StatusInfo getStatusInfo() {
+		return statusInfo;
 	}
 
 	@Override

--- a/spring-boot-admin-starter-client/src/main/java/de/codecentric/boot/admin/model/StatusInfo.java
+++ b/spring-boot-admin-starter-client/src/main/java/de/codecentric/boot/admin/model/StatusInfo.java
@@ -1,0 +1,88 @@
+package de.codecentric.boot.admin.model;
+
+import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents a certain status a certain time.
+ *
+ * @author Johannes Stelzer
+ *
+ */
+public class StatusInfo implements Serializable {
+	private static final long serialVersionUID = 1L;
+
+	private final String status;
+	private final long timestamp;
+
+	protected StatusInfo(String status, long timestamp) {
+		this.status= status.toUpperCase();
+		this.timestamp = timestamp;
+	}
+
+	public static StatusInfo valueOf(String statusCode) {
+		return new StatusInfo(statusCode, System.currentTimeMillis());
+	}
+
+	@JsonCreator
+	public static StatusInfo valueOf(@JsonProperty("status") String statusCode, @JsonProperty("timestamp") long timestamp) {
+		return new StatusInfo(statusCode, timestamp);
+	}
+
+	public static StatusInfo ofUnknown() {
+		return valueOf("UNKNOWN");
+	}
+
+	public static StatusInfo ofUp() {
+		return valueOf("UP");
+	}
+
+	public static StatusInfo ofDown() {
+		return valueOf("DOWN");
+	}
+
+	public static StatusInfo ofOffline() {
+		return valueOf("OFFLINE");
+	}
+
+	public String getStatus() {
+		return status;
+	}
+
+	public long getTimestamp() {
+		return timestamp;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((status == null) ? 0 : status.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+		StatusInfo other = (StatusInfo) obj;
+		if (status == null) {
+			if (other.status != null) {
+				return false;
+			}
+		} else if (!status.equals(other.status)) {
+			return false;
+		}
+		return true;
+	}
+
+}

--- a/spring-boot-admin-starter-client/src/main/java/de/codecentric/boot/admin/services/ApplicationRegistrator.java
+++ b/spring-boot-admin-starter-client/src/main/java/de/codecentric/boot/admin/services/ApplicationRegistrator.java
@@ -122,8 +122,10 @@ public class ApplicationRegistrator {
 	}
 
 	protected Application createApplication() {
-		return new Application(client.getHealthUrl(),
-				client.getManagementUrl(), client.getServiceUrl(), client.getName());
+		return Application.create(client.getName())
+				.withHealthUrl(client.getHealthUrl())
+				.withManagementUrl(client.getManagementUrl())
+				.withServiceUrl(client.getServiceUrl()).build();
 	}
 }
 

--- a/spring-boot-admin-starter-client/src/test/java/de/codecentric/boot/admin/model/ApplicationTest.java
+++ b/spring-boot-admin-starter-client/src/test/java/de/codecentric/boot/admin/model/ApplicationTest.java
@@ -45,29 +45,40 @@ public class ApplicationTest {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void test_name_expected() throws JsonProcessingException, IOException {
-		Application.create("http://url", "", "", "", "",
-				null);
+		Application.create("http://url", "", "", "", "", null, null);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void test_healthUrl_expected() throws JsonProcessingException, IOException {
-		Application.create("", "", "", "", "name", null);
+		Application.create("", "", "", "", "name", null, null);
 	}
 
 	@Test
 	public void test_equals_hashCode() {
-		Application a1 = new Application("healthUrl", "managementUrl", "serviceUrl",
-				"name", "id");
-		Application a2 = new Application("healthUrl", "managementUrl", "serviceUrl",
-				"name", "id");
+		Application a1 = Application.create("foo").withHealthUrl("healthUrl")
+				.withManagementUrl("mgmt").withServiceUrl("svc").withId("id")
+				.build();
+		Application a2 = Application.create("foo").withHealthUrl("healthUrl")
+				.withManagementUrl("mgmt").withServiceUrl("svc").withId("id")
+				.build();
 
 		assertThat(a1, is(a2));
 		assertThat(a1.hashCode(), is(a2.hashCode()));
 
-		Application a3 = new Application("healthUrl2", "managementUrl", "serviceUrl",
-				"name", "id");
+		Application a3 = Application.create("foo").withHealthUrl("healthUrl2")
+				.withManagementUrl("mgmt").withServiceUrl("svc")
+				.withId("other").build();
+
 		assertThat(a1, not(is(a3)));
 		assertThat(a2, not(is(a3)));
 	}
 
+	@Test
+	public void test_builder_copy() {
+		Application app = Application.create("App").withId("-id-").withHealthUrl("http://health")
+				.withManagementUrl("http://mgmgt").withServiceUrl("http://svc")
+				.withStatusInfo(StatusInfo.ofUp()).build();
+		Application copy = Application.create(app).build();
+		assertThat(app, is(copy));
+	}
 }

--- a/spring-boot-admin-starter-client/src/test/java/de/codecentric/boot/admin/model/StatusInfoTest.java
+++ b/spring-boot-admin-starter-client/src/test/java/de/codecentric/boot/admin/model/StatusInfoTest.java
@@ -1,0 +1,22 @@
+package de.codecentric.boot.admin.model;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+public class StatusInfoTest {
+
+	@Test
+	public void test_equals_hashcode() {
+		StatusInfo up = StatusInfo.ofUp();
+		StatusInfo up2 = StatusInfo.valueOf("UP", 0L);
+		StatusInfo down = StatusInfo.valueOf("DOWN");
+
+		assertThat(up, is(up2));
+		assertThat(up, not(is(down)));
+		assertThat(up.hashCode(), is(up2.hashCode()));
+	}
+
+}

--- a/spring-boot-admin-starter-client/src/test/java/de/codecentric/boot/admin/services/ApplicationRegistratorTest.java
+++ b/spring-boot-admin-starter-client/src/test/java/de/codecentric/boot/admin/services/ApplicationRegistratorTest.java
@@ -53,7 +53,7 @@ public class ApplicationRegistratorTest {
 		adminProps.setUrl("http://sba:8080");
 
 		AdminClientProperties clientProps = new AdminClientProperties();
-		clientProps.setManagementUrl("http://localhost:8080");
+		clientProps.setManagementUrl("http://localhost:8080/mgmt");
 		clientProps.setHealthUrl("http://localhost:8080/health");
 		clientProps.setServiceUrl("http://localhost:8080");
 		clientProps.setName("AppName");
@@ -75,10 +75,13 @@ public class ApplicationRegistratorTest {
 		boolean result = registrator.register();
 
 		assertTrue(result);
-		verify(restTemplate).postForEntity("http://sba:8080/api/applications",
-				new HttpEntity<Application>(new Application(
-						"http://localhost:8080/health", "http://localhost:8080",
-						"http://localhost:8080", "AppName"), headers), Application.class);
+		verify(restTemplate).postForEntity(
+				"http://sba:8080/api/applications",
+				new HttpEntity<Application>(Application.create("AppName")
+						.withHealthUrl("http://localhost:8080/health")
+						.withManagementUrl("http://localhost:8080/mgmt")
+						.withServiceUrl("http://localhost:8080").build(),
+						headers), Application.class);
 	}
 
 	@Test
@@ -96,10 +99,12 @@ public class ApplicationRegistratorTest {
 	@Test
 	public void deregister() {
 		when(
-				restTemplate.postForEntity(isA(String.class), isA(HttpEntity.class),
-						eq(Application.class))).thenReturn(
-				new ResponseEntity<Application>(new Application("", "", "", "name",
-						"-id-"), HttpStatus.CREATED));
+				restTemplate.postForEntity(isA(String.class),
+						isA(HttpEntity.class), eq(Application.class)))
+						.thenReturn(
+								new ResponseEntity<Application>(Application
+										.create("foo").withId("-id-").build(),
+										HttpStatus.CREATED));
 		registrator.register();
 		registrator.deregister();
 


### PR DESCRIPTION
In order to send mails on status change, a serverside health-check is implemented.
The registration and status-change events are journaled and viewable in UI. The journal is non-persistent.
To enable mail notification a mailSender must be supplied via the `spring.mail.*`-properties.
On default the mails are sent to root@localhost. The mail can be customized via `spring.boot.admin.notify.*`-properties.

Comments on this feature are welcome.
