### PR TITLE
point to overview when clicking on the spring-logos 

### DIFF
--- a/spring-boot-admin-server-ui/app/index.html
+++ b/spring-boot-admin-server-ui/app/index.html
@@ -23,10 +23,10 @@
 			<div class="navbar-inner">
 				<div class="container-fluid" >
 					<div class="spring-logo--container">
-						<a class="spring-logo" href="/"><span></span></a>
+						<a class="spring-logo" ui-sref="overview"><span></span></a>
 					</div>
 					<div class="spring-logo--container">
-						<a class="spring-boot-logo" href="/"><span></span></a>
+						<a class="spring-boot-logo" ui-sref="overview"><span></span></a>
 					</div>
 					<ul class="nav pull-right">
 						<li class="navbar-link" ng-class="{active: $state.includes('apps') ||  $state.includes('overview')  }"><a ui-sref="overview">Applications</a></li>


### PR DESCRIPTION
…to also work correctly when deployed not in the root context,

i.e., when spring boot admin is deployed to:

localhost:8080/spring-boot-admin

then currently the link behind the logo points to localhost:8080/