### PR TITLE
Logfile endpoint available when not using spring.boot.admin.url

### DIFF
--- a/spring-boot-admin-starter-client/src/test/java/de/codecentric/boot/admin/config/SpringBootAdminClientAutoConfigurationTest.java
+++ b/spring-boot-admin-starter-client/src/test/java/de/codecentric/boot/admin/config/SpringBootAdminClientAutoConfigurationTest.java
@@ -27,6 +27,13 @@ public class SpringBootAdminClientAutoConfigurationTest {
 	public void not_active() {
 		load();
 		assertTrue(context.getBeansOfType(ApplicationRegistrator.class).isEmpty());
+		assertTrue(context.getBeansOfType(LogfileMvcEndpoint.class).isEmpty());
+	}
+
+	public void not_active_logfile() {
+		load();
+		assertTrue(context.getBeansOfType(ApplicationRegistrator.class).isEmpty());
+		context.getBean(LogfileMvcEndpoint.class);
 	}
 
 	@Test


### PR DESCRIPTION
Added inner-class for admin client registration configuration which is conditional on spring.boot.admin.url. Logfile endpoint is now available when just using Spring Cloud Discovery.

Addresses gh-84