### PR TITLE
Provide a WAR file for easy deployment by end-users

### DIFF
--- a/spring-boot-admin-samples/spring-boot-admin-sample-war/.gitignore
+++ b/spring-boot-admin-samples/spring-boot-admin-sample-war/.gitignore
@@ -1,0 +1,1 @@
+/.springBeans

--- a/spring-boot-admin-samples/spring-boot-admin-sample-war/pom.xml
+++ b/spring-boot-admin-samples/spring-boot-admin-sample-war/pom.xml
@@ -1,0 +1,60 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>de.codecentric</groupId>
+	<artifactId>spring-boot-admin-samples-war</artifactId>
+	<version>1.2.2-SNAPSHOT</version>
+	<packaging>war</packaging>
+
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>1.2.5.RELEASE</version>
+	</parent>
+
+	<properties>
+		<!-- for maven... -->
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		<java.version>1.7</java.version>
+	</properties>
+
+	<build>
+		<finalName>${project.artifactId}</finalName>
+	</build>
+
+	<dependencies>
+	
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+		
+		<!-- http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#build-tool-plugins-maven-packaging -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-tomcat</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>com.googlecode.json-simple</groupId>
+			<artifactId>json-simple</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>de.codecentric</groupId>
+			<artifactId>spring-boot-admin-server</artifactId>
+			<version>1.2.2</version>
+		</dependency>
+		
+		<dependency>
+			<groupId>de.codecentric</groupId>
+			<artifactId>spring-boot-admin-server-ui</artifactId>
+			<version>1.2.2</version>
+		</dependency>
+		
+	</dependencies>
+
+</project>

--- a/spring-boot-admin-samples/spring-boot-admin-sample-war/src/main/java/de/codecentric/application/Application.java
+++ b/spring-boot-admin-samples/spring-boot-admin-sample-war/src/main/java/de/codecentric/application/Application.java
@@ -1,0 +1,27 @@
+package de.codecentric.application;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.context.web.SpringBootServletInitializer;
+import org.springframework.context.annotation.Configuration;
+
+import de.codecentric.boot.admin.config.EnableAdminServer;
+
+@Configuration
+@EnableAutoConfiguration
+@EnableAdminServer
+@SpringBootApplication
+public class Application extends SpringBootServletInitializer {
+
+  @Override
+  protected SpringApplicationBuilder configure(SpringApplicationBuilder application) {
+    return application.sources(Application.class);
+  }
+
+  public static void main(String[] args) throws Exception {
+    SpringApplication.run(Application.class, args);
+  }
+
+}

--- a/spring-boot-admin-samples/spring-boot-admin-sample-war/src/main/resources/config/application.yml
+++ b/spring-boot-admin-samples/spring-boot-admin-sample-war/src/main/resources/config/application.yml
@@ -1,0 +1,25 @@
+info:
+  version: @pom.version@
+  stage: test
+
+logging:
+  file: @pom.artifactId@.log
+
+spring:
+  application:
+    name: @pom.artifactId@
+  boot:
+    admin:
+      url: http://localhost:8080/@pom.artifactId@
+      client:
+        serviceUrl: http://localhost:8080/@pom.artifactId@
+  cloud:
+    config:
+      enabled: false
+  jackson:
+    serialization:
+      indent_output: true
+
+endpoints:
+  health:
+    sensitive: false

--- a/spring-boot-admin-samples/spring-boot-admin-sample-war/src/main/resources/config/logback.xml
+++ b/spring-boot-admin-samples/spring-boot-admin-sample-war/src/main/resources/config/logback.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+	<include resource="org/springframework/boot/logging/logback/base.xml"/>
+	<jmxConfigurator/>
+</configuration>


### PR DESCRIPTION
Hi,

I think this product is excellent. However, I think it makes even more sense as a central webapp that can be deployed into Tomcat alongside other great monitoring webapps such as Hawtio.

In this pull request, I have added a initial WAR file project which can be deployed into Tomcat. It will register itself a few seconds after deployment. Unfortunately, I was not able to build the 1.2.3-SNAPSHOT UI project, so I have detached from parent and based it on 1.2.2 instead.

There is very little code indeed. It is almost the same as your simple example, but with the small number of changes needed for spring boot WAR file packaging. Hopefully, this will help you provide a standardised WAR release file if you choose to do so!

Kind Regards,
James