### PR TITLE
changed constructor visibility from private to protected in order to …

### DIFF
--- a/spring-boot-admin-starter-client/src/main/java/de/codecentric/boot/admin/model/Application.java
+++ b/spring-boot-admin-starter-client/src/main/java/de/codecentric/boot/admin/model/Application.java
@@ -36,7 +36,7 @@ public class Application implements Serializable {
 	private final String serviceUrl;
 	private final StatusInfo statusInfo;
 
-	private Application(String healthUrl, String managementUrl,
+	protected Application(String healthUrl, String managementUrl,
 			String serviceUrl, String name, String id, StatusInfo statusInfo) {
 		this.healthUrl = healthUrl;
 		this.managementUrl = managementUrl;


### PR DESCRIPTION
…be able to derive from Application.

In order to add more functionality to the health monitoring we'd appreciate the change coming into the next deliverable. Due to the classes constructor being private that is not possible as of now.