### PR TITLE
order by key for environment key/value pairs

### DIFF
--- a/spring-boot-admin-server-ui/app/views/apps/environment.html
+++ b/spring-boot-admin-server-ui/app/views/apps/environment.html
@@ -71,7 +71,7 @@
 			<col width="62%">
 			<thead><tr><th colspan="2">{{item.key}}</th></tr></thead>
 			<tbody>
-				<tr ng-repeat="property in item.value | filter:searchFilter track by property.key" >
+				<tr ng-repeat="property in item.value | orderBy:'key' | filter:searchFilter track by property.key" >
 					<td style="word-break: break-all;" >{{ property.key }}</td>
 					<td style="word-break: break-all;" >{{ property.value }}</td>
 				</tr>


### PR DESCRIPTION
added orderBy:’key’ to environment.html to enable alphabetical ordering by key for easier user readability.

![env_snippet](https://cloud.githubusercontent.com/assets/13953116/10114551/50bb8dc4-63a7-11e5-9bbd-21f1a7601445.png)
