### PR TITLE
Trace-item color based on http status

### DIFF
--- a/spring-boot-admin-server-ui/app/css/main.css
+++ b/spring-boot-admin-server-ui/app/css/main.css
@@ -344,6 +344,18 @@ dl.health-status td {
   margin-left: -15px;
 }
 
+.event.warn:before {
+  border-color: #e0ba2d;
+}
+
+.event.error:before {
+  border-color: #b30000;
+}
+
+.event.ok:before {
+  border-color: #6db33f;
+}
+
 .timeline .event:hover:before {
   background: #ccc;
 }

--- a/spring-boot-admin-server-ui/app/js/controller/apps/traceCtrl.js
+++ b/spring-boot-admin-server-ui/app/js/controller/apps/traceCtrl.js
@@ -50,5 +50,28 @@ module.exports = function ($scope, application, $interval) {
         }
     };
 
+    /**
+     * Determines the css class for a trace-item.
+     *
+     * @param trace current item
+     */
+    $scope.getStatusClass = function (trace) {
+
+        // only if the response part is available
+        if (trace.info.headers.response) {
+            var status = parseInt(trace.info.headers.response.status);
+
+            if (Math.floor(status / 500) === 1) {
+                return 'error';
+            }
+
+            else if (Math.floor(status / 400) === 1) {
+                return 'warn';
+            }
+        }
+
+        return 'ok';
+    };
+
     $scope.refresh();
 };

--- a/spring-boot-admin-server-ui/app/views/apps/trace.html
+++ b/spring-boot-admin-server-ui/app/views/apps/trace.html
@@ -5,19 +5,25 @@
 	<div class="form-inline">
 		<button title="refresh" class="btn" ng-click="refresh()"><i class="icon-refresh"></i></button>
 		<div class="input-prepend input-append">
-			<button title="auto refresh" class="btn" ng-click="toggleAutoRefresh()" ng-class="{'active':refresher != null}"><i ng-class="{'icon-play':refresher == null, 'icon-pause':refresher != null}"></i></button>
-			<input class="input-mini" type="number" min="1" ng-model="refreshInterval" ng-disabled="refresher != null"></input>
+			<button title="auto refresh" class="btn" ng-click="toggleAutoRefresh()" ng-class="{'active':refresher != null}">
+				<i ng-class="{'icon-play':refresher == null, 'icon-pause':refresher != null}"></i>
+			</button>
+			<input class="input-mini" type="number" min="1" ng-model="refreshInterval" ng-disabled="refresher != null" />
 			<span class="add-on">sec</span>
 		</div>
 	</div>
 	<ul class="timeline">
 		<li ng-repeat="trace in traces | orderBy:'timestamp':true" >
-			<div class="event" ng-click="trace.show = !trace.show">
+			<div class="event" ng-class="getStatusClass(trace)" ng-click="trace.show = !trace.show">
 				<div class="time">
 					{{trace.timestamp | date:'HH:mm:ss.sss'}}
 					<small class="muted">{{trace.timestamp | date:'dd.MM.yyyy'}}</small><br/>
 				</div>
-				<div class="title"><span class="muted">{{trace.info.method}}</span> {{trace.info.path}}</div>
+				<div class="title">
+					<span class="muted">{{trace.info.headers.response.status}}</span>
+					<span class="muted" ng-hide="trace.info.headers.response == null"> - </span>
+					<span class="muted">{{trace.info.method}}</span>
+					{{trace.info.path}}</div>
 				<pre class="content" ng-show="trace.show">{{trace.info | json}}</pre>
 			</div>
 		</li>


### PR DESCRIPTION
If you use the trace for debugging it might be useful to see quickly which status codes are returned.
* 4xx codes will be displayed with a yellow border
* 5xx codes will be display with a red border
* all others are green

![trace](https://cloud.githubusercontent.com/assets/5363619/13473860/93d3151e-e0bb-11e5-9778-6d81a159223e.png)

Greets from muc