### PR TITLE
Add Flyway Support

### DIFF
--- a/spring-boot-admin-server-ui/modules/applications-flyway/controllers/flywayCtrl.js
+++ b/spring-boot-admin-server-ui/modules/applications-flyway/controllers/flywayCtrl.js
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+module.exports = function ($scope, $http, application) {
+  'ngInject';
+  
+  $scope.migrations = [];
+  $scope.successStates = ['BASELINE', 'MISSING_SUCCESS', 'SUCCESS', 'OUT_OF_ORDER', 'FUTURE_SUCCESS'];
+  $scope.warningStates = ['PENDING', 'ABOVE_TARGET', 'PREINIT', 'BELOW_BASELINE', 'IGNORED'];
+  $scope.failedStates = ['MISSING_FAILED', 'FAILED', 'FUTURE_FAILED'];
+  $scope.searchFilter;
+  
+  $http.get('/api/applications/' + application.id + '/flyway').then(function(response) {
+    $scope.migrations = response.data;
+  });
+  
+  $scope.inArray = function(migrationStatus, statusArray) {
+    return statusArray.indexOf(migrationStatus) !== -1;
+  };
+};

--- a/spring-boot-admin-server-ui/modules/applications-flyway/module.js
+++ b/spring-boot-admin-server-ui/modules/applications-flyway/module.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+var angular = require('angular');
+
+var module = angular.module('sba-applications-flyway', ['sba-applications']);
+global.sbaModules.push(module.name);
+
+module.controller('flywayCtrl', require('./controllers/flywayCtrl.js'));
+
+module.config(function ($stateProvider) {
+  $stateProvider.state('applications.flyway', {
+    url: '/flyway',
+    templateUrl: 'applications-flyway/views/flyway.html',
+    controller: 'flywayCtrl'
+  });
+});
+
+module.run(function (ApplicationViews, $http, $sce) {
+  ApplicationViews.register({
+    order: 100,
+    title: $sce.trustAsHtml('<i class="fa fa-database fa-fw"></i>Flyway'),
+    state: 'applications.flyway',
+    show: function (application) {
+      if (!application.managementUrl || !application.statusInfo.status || application.statusInfo.status === 'OFFLINE') {
+        return false;
+      }
+      
+      return $http.get('api/applications/' + application.id + '/configprops').then(
+        function(response) {
+          return response.data.flywayEndpoint !== undefined;
+        }).catch(function() {
+          return false;
+        });
+    }
+  });
+});

--- a/spring-boot-admin-server-ui/modules/applications-flyway/views/flyway.html
+++ b/spring-boot-admin-server-ui/modules/applications-flyway/views/flyway.html
@@ -1,0 +1,33 @@
+<div class="input-append">
+    <input placeholder="Filter" class="input-xxlarge" type="search" ng-model="searchFilter" />
+</div>
+<sba-info-panel title="Flyway Migrations" raw="api/applications/{{ application.id }}/flyway">
+    <table class="table table-hover">
+        <thead>
+            <th>Type</th>
+            <th>Checksum</th>
+            <th>Version</th>
+            <th>Description</th>
+            <th>Script</th>
+            <th>State</th>
+            <th>Installed</th>
+            <th>Execution Time</th>
+        </thead>
+        <tbody>
+            <tr ng-repeat="migration in migrations | filter:searchFilter">
+                <td>{{migration.type}}</td>
+                <td>{{migration.checksum}}</td>
+                <td>{{migration.version}}</td>
+                <td>{{migration.description}}</td>
+                <td>{{migration.script}}</td>
+                <td><span class="label" 
+                    ng-class="{
+                    'label-success': inArray(migration.state, successStates), 
+                    'label-warning': inArray(migration.state, warningStates),
+                    'label-danger': inArray(migration.state, failedStates)}">{{migration.state}}</span></td>
+                <td>{{migration.installedOn | date:'medium'}}</td>
+                <td>{{migration.executionTime}} ms</td>
+            </tr>
+        </tbody>
+    </table>
+</sba-info-panel>

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/zuul/ApplicationRouteLocator.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/zuul/ApplicationRouteLocator.java
@@ -49,7 +49,7 @@ public class ApplicationRouteLocator implements RefreshableRouteLocator {
 	private String prefix;
 	private String servletPath;
 	private String[] proxyEndpoints = { "env", "metrics", "trace", "dump", "jolokia", "info",
-			"configprops", "trace", "activiti", "logfile", "refresh" };
+			"configprops", "trace", "activiti", "logfile", "refresh", "flyway" };
 
 	public ApplicationRouteLocator(String servletPath, ApplicationRegistry registry,
 			String prefix) {


### PR DESCRIPTION
Adds an application view that displays a table of Flyway migrations as retrieved from the /flyway Actuator endpoint. The module is conditional on this endpoint being available.

The labels for the migration state are based on the descriptions of the [MigrationState](https://github.com/flyway/flyway/blob/flyway-3.2.1/flyway-core/src/main/java/org/flywaydb/core/api/MigrationState.java) source code (Flyway 3.2.1 is the managed version for Spring Boot 1.3 and this enum is the same for Flyway 4.x)

I included the module in this location since the `/flyway` endpoint is part of the Spring Boot Actuator as of 1.3. I have provided a screen shot with the pull request as a demonstration. The quickest way for me to develop this was to just use the Spring Boot Flyway sample, modify it locally to make it an admin server and use it as the back-end during development. I can include a sample project with your repository if you wish.

Please let me know if there is anything else I am missing.

Fixes gh-206

![flyway-support](https://cloud.githubusercontent.com/assets/3990563/15696580/c3f542f2-277f-11e6-94ff-e0017dc2a422.png)

