### PR TITLE
Adds Liquibase Support

### DIFF
--- a/spring-boot-admin-server-ui/modules/applications-liquibase/controllers/liquibaseCtrl.js
+++ b/spring-boot-admin-server-ui/modules/applications-liquibase/controllers/liquibaseCtrl.js
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+module.exports = function ($scope, $http, application) {
+  'ngInject';
+
+  $scope.migrations = [];
+  $scope.migrationTable = {
+    'ID': 'Id',
+    'AUTHOR': 'Author',
+    'FILENAME': 'File',
+    'DATEEXECUTED': 'Date',
+    'ORDEREXECUTED': 'Order',
+    'EXECTYPE': 'Type',
+    'MD5SUM': 'Checksum',
+    'DESCRIPTION': 'Description',
+    'COMMENTS': 'Comments',
+    'TAG': 'Tag',
+    'LIQUIBASE': 'Liquibase Version',
+    'CONTEXTS': 'Contexts',
+    'LABELS': 'Labels',
+    'DEPLOYMENT_ID': 'Deployment ID'
+  };
+  $scope.searchFilter;
+
+  $scope.refresh = function () {
+    $http.get('/api/applications/' + application.id + '/liquibase').then(function (response) {
+      $scope.migrations = response.data;
+    });
+  };
+  $scope.refresh();
+
+  $scope.isDate = function(column) {
+    return column.indexOf('DATE') !== -1;
+  };
+};

--- a/spring-boot-admin-server-ui/modules/applications-liquibase/module.js
+++ b/spring-boot-admin-server-ui/modules/applications-liquibase/module.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+var angular = require('angular');
+
+var module = angular.module('sba-applications-liquibase', ['sba-applications']);
+global.sbaModules.push(module.name);
+
+module.controller('liquibaseCtrl', require('./controllers/liquibaseCtrl.js'));
+
+module.config(function ($stateProvider) {
+  $stateProvider.state('applications.liquibase', {
+    url: '/liquibase',
+    templateUrl: 'applications-liquibase/views/liquibase.html',
+    controller: 'liquibaseCtrl'
+  });
+});
+
+module.run(function (ApplicationViews, $http, $sce) {
+  ApplicationViews.register({
+    order: 100,
+    title: $sce.trustAsHtml('<i class="fa fa-database fa-fw"></i>Liquibase'),
+    state: 'applications.liquibase',
+    show: function (application) {
+      if (!application.managementUrl || !application.statusInfo.status || application.statusInfo.status === 'OFFLINE') {
+        return false;
+      }
+      return $http.head('api/applications/' + application.id + '/liquibase').then(function () {
+        return true;
+      }).catch(function () {
+        return false;
+      });
+    }
+  });
+});

--- a/spring-boot-admin-server-ui/modules/applications-liquibase/views/liquibase.html
+++ b/spring-boot-admin-server-ui/modules/applications-liquibase/views/liquibase.html
@@ -1,0 +1,24 @@
+<div class="input-append">
+    <input placeholder="Filter" class="input-xxlarge" type="search" ng-model="searchFilter" />
+    <button class="btn" title="reload list" ng-click="refresh()"><i class="fa fa-repeat"></i></button>
+</div>
+<sba-accordion>
+  <sba-accordion-group ng-repeat="migration in migrations | filter:searchFilter">
+    <sba-accordion-heading>
+        <small class="muted" ng-bind="migration.ID"></small> {{migration.FILENAME}}
+        <span class="label label-warning pull-right" ng-bind="migration.EXECTYPE"
+        ng-class="{
+        'label-success':migration.EXECTYPE === 'EXECUTED',
+        'label-danger':migration.EXECTYPE === 'FAILED'}"></span>
+    </sba-accordion-heading>
+    <sba-accordion-body>
+        <table class="table">
+            <col width="40%">
+            <col width="60%">
+                <tr ng-repeat="(column,label) in migrationTable">
+                <td ng-show="migration[column]" ng-bind="label"></td>
+                <td ng-show="migration[column]">{{ isDate(column) ? (migration[column] | date:'medium') : migration[column] }}</td>
+        </table>
+    </sba-accordion-body>
+  </sba-accordion-group>
+</sba-accordion>

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/zuul/ApplicationRouteLocator.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/zuul/ApplicationRouteLocator.java
@@ -49,7 +49,7 @@ public class ApplicationRouteLocator implements RefreshableRouteLocator {
 	private String prefix;
 	private String servletPath;
 	private String[] proxyEndpoints = { "env", "metrics", "trace", "dump", "jolokia", "info",
-			"configprops", "trace", "activiti", "logfile", "refresh", "flyway" };
+			"configprops", "trace", "activiti", "logfile", "refresh", "flyway", "liquibase" };
 
 	public ApplicationRouteLocator(String servletPath, ApplicationRegistry registry,
 			String prefix) {


### PR DESCRIPTION
Similar to the Flyway support, only the Liquibase migrations use an accordion to display their migrations as oppose to a table since there is more data available.

The heading displays the ID, File Name and Type (which is akin to a status, see http://www.liquibase.org/documentation/databasechangelog_table.html). The label colours are green for success, red for failure and yellow for anything else. The fields were derived from what is currently returned from the Actuator endpoint.

Attached screenshot. Let me know if there is any improvements you would prefer. Alter as necessary.

![liquibase-support](https://cloud.githubusercontent.com/assets/3990563/15789092/8285693a-2998-11e6-9275-8b4b985d3f36.png)
