### PR TITLE
Remove stale apps from registry.

### DIFF
--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/discovery/ApplicationDiscoveryListener.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/discovery/ApplicationDiscoveryListener.java
@@ -15,8 +15,9 @@
  */
 package de.codecentric.boot.admin.discovery;
 
-import de.codecentric.boot.admin.model.Application;
-import de.codecentric.boot.admin.registry.ApplicationRegistry;
+import java.util.HashSet;
+import java.util.Set;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.cloud.client.ServiceInstance;
@@ -27,8 +28,8 @@ import org.springframework.cloud.client.discovery.event.InstanceRegisteredEvent;
 import org.springframework.cloud.client.discovery.event.ParentHeartbeatEvent;
 import org.springframework.context.event.EventListener;
 
-import java.util.HashSet;
-import java.util.Set;
+import de.codecentric.boot.admin.model.Application;
+import de.codecentric.boot.admin.registry.ApplicationRegistry;
 
 /**
  * Listener for Heartbeats events to publish all services to the application registry.
@@ -37,7 +38,7 @@ import java.util.Set;
  */
 public class ApplicationDiscoveryListener {
 	private static final Logger LOGGER = LoggerFactory
-		.getLogger(ApplicationDiscoveryListener.class);
+			.getLogger(ApplicationDiscoveryListener.class);
 	private final DiscoveryClient discoveryClient;
 	private final ApplicationRegistry registry;
 	private final HeartbeatMonitor monitor = new HeartbeatMonitor();
@@ -49,7 +50,7 @@ public class ApplicationDiscoveryListener {
 	private Set<String> ignoredServices = new HashSet<>();
 
 	public ApplicationDiscoveryListener(DiscoveryClient discoveryClient,
-	                                    ApplicationRegistry registry) {
+			ApplicationRegistry registry) {
 		this.discoveryClient = discoveryClient;
 		this.registry = registry;
 	}

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/discovery/ApplicationDiscoveryListenerTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/discovery/ApplicationDiscoveryListenerTest.java
@@ -19,7 +19,9 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -86,10 +88,30 @@ public class ApplicationDiscoveryListenerTest {
 
 		when(discovery.getServices()).thenReturn(Collections.singletonList("service"));
 		when(discovery.getInstances("service")).thenReturn(Collections.singletonList(
-				(ServiceInstance) new DefaultServiceInstance("service", "localhost", 80, false)));
+			(ServiceInstance) new DefaultServiceInstance("service", "localhost", 80, false)));
 
 		listener.onApplicationEvent(new HeartbeatEvent(new Object(), heartbeat));
 		assertEquals(0, registry.getApplications().size());
+
+		listener.onApplicationEvent(new HeartbeatEvent(new Object(), new Object()));
+		assertEquals(1, registry.getApplications().size());
+	}
+
+	@Test
+	public void deregister_removed_app() {
+		Object heartbeat = new Object();
+
+		List<ServiceInstance> instances = new ArrayList<>();
+		instances.add(new DefaultServiceInstance("service", "localhost", 80, false));
+		instances.add(new DefaultServiceInstance("service", "example.net", 80, false));
+
+		when(discovery.getServices()).thenReturn(Collections.singletonList("service"));
+		when(discovery.getInstances("service")).thenReturn(instances);
+
+		listener.onApplicationEvent(new HeartbeatEvent(new Object(), heartbeat));
+		assertEquals(2, registry.getApplications().size());
+
+		instances.remove(0);
 
 		listener.onApplicationEvent(new HeartbeatEvent(new Object(), new Object()));
 		assertEquals(1, registry.getApplications().size());

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/discovery/ApplicationDiscoveryListenerTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/discovery/ApplicationDiscoveryListenerTest.java
@@ -88,7 +88,7 @@ public class ApplicationDiscoveryListenerTest {
 
 		when(discovery.getServices()).thenReturn(Collections.singletonList("service"));
 		when(discovery.getInstances("service")).thenReturn(Collections.singletonList(
-			(ServiceInstance) new DefaultServiceInstance("service", "localhost", 80, false)));
+				(ServiceInstance) new DefaultServiceInstance("service", "localhost", 80, false)));
 
 		listener.onApplicationEvent(new HeartbeatEvent(new Object(), heartbeat));
 		assertEquals(0, registry.getApplications().size());


### PR DESCRIPTION
Checks the DiscoveryClient's apps on each heartbeat, and removes apps which are no longer in the DiscoveryClient from the registry.

Closes #211 