### PR TITLE
management.port can be specified through the metadata map

### DIFF
--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/discovery/DefaultServiceInstanceConverter.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/discovery/DefaultServiceInstanceConverter.java
@@ -29,11 +29,13 @@ import de.codecentric.boot.admin.model.Application;
  * Converts any {@link ServiceInstance}s to {@link Application}s. To customize the health- or
  * management-url for all applications you can set healthEndpointPath or managementContextPath
  * respectively. If you want to influence the url per service you can add
- * <code>management.context-path</code> or <code>health.path</code> to the instances metadata.
+ * <code>management.context-path</code> or <code>management.port</code> or <code>health.path</code>
+ * to the instances metadata.
  *
  * @author Johannes Edmeier
  */
 public class DefaultServiceInstanceConverter implements ServiceInstanceConverter {
+        private static final String KEY_MANAGEMENT_PORT = "management.port";
 	private static final String KEY_MANAGEMENT_PATH = "management.context-path";
 	private static final String KEY_HEALTH_PATH = "health.path";
 	private String managementContextPath = "";
@@ -70,12 +72,16 @@ public class DefaultServiceInstanceConverter implements ServiceInstanceConverter
 	}
 
 	protected URI getManagementUrl(ServiceInstance instance) {
-		String managamentPath = defaultIfEmpty(
-				instance.getMetadata().get(KEY_MANAGEMENT_PATH), managementContextPath);
-		managamentPath = stripStart(managamentPath, "/");
-
-		return UriComponentsBuilder.fromUri(getServiceUrl(instance)).pathSegment(managamentPath)
-				.build().toUri();
+	    String managamentPath = defaultIfEmpty(
+	            instance.getMetadata().get(KEY_MANAGEMENT_PATH), managementContextPath);
+	    managamentPath = stripStart(managamentPath, "/");
+	    
+	    URI serviceUrl = getServiceUrl(instance);
+	    String managamentPort = defaultIfEmpty(
+	            instance.getMetadata().get(KEY_MANAGEMENT_PORT), String.valueOf(serviceUrl.getPort()));
+	    
+	    return UriComponentsBuilder.fromUri(serviceUrl).port(managamentPort).pathSegment(managamentPath)
+	            .build().toUri();
 	}
 
 	protected URI getServiceUrl(ServiceInstance instance) {

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/discovery/DefaultServiceInstanceConverterTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/discovery/DefaultServiceInstanceConverterTest.java
@@ -45,14 +45,15 @@ public class DefaultServiceInstanceConverterTest {
 		ServiceInstance service = new DefaultServiceInstance("test", "localhost", 80, false);
 		service.getMetadata().put("health.path", "ping");
 		service.getMetadata().put("management.context-path", "mgmt");
+                service.getMetadata().put("management.port", "1234");
 
 		Application application = new DefaultServiceInstanceConverter().convert(service);
 
 		assertThat(application.getId(), nullValue());
 		assertThat(application.getName(), is("test"));
 		assertThat(application.getServiceUrl(), is("http://localhost:80"));
-		assertThat(application.getManagementUrl(), is("http://localhost:80/mgmt"));
-		assertThat(application.getHealthUrl(), is("http://localhost:80/mgmt/ping"));
+		assertThat(application.getManagementUrl(), is("http://localhost:1234/mgmt"));
+		assertThat(application.getHealthUrl(), is("http://localhost:1234/mgmt/ping"));
 	}
 
 }


### PR DESCRIPTION
If you specify the management.port on client side and you use Eureka to discover clients the current DefaultServiceInstanceConverter will produce incorrect urls. With this safe modification i want to solve this issue.