### PR TITLE
fixed the builder setup, when creating he ApplicationRegistrator.

### DIFF
--- a/spring-boot-admin-starter-client/src/main/java/de/codecentric/boot/admin/config/SpringBootAdminClientAutoConfiguration.java
+++ b/spring-boot-admin-starter-client/src/main/java/de/codecentric/boot/admin/config/SpringBootAdminClientAutoConfiguration.java
@@ -47,9 +47,9 @@ public class SpringBootAdminClientAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	public ApplicationRegistrator registrator() {
-		builder.messageConverters(new MappingJackson2HttpMessageConverter());
+		builder = builder.messageConverters(new MappingJackson2HttpMessageConverter());
 		if (admin.getUsername() != null) {
-			builder.basicAuthorization(admin.getUsername(), admin.getPassword());
+			builder = builder.basicAuthorization(admin.getUsername(), admin.getPassword());
 		}
 		return new ApplicationRegistrator(builder.build(), admin, client);
 	}


### PR DESCRIPTION
The RestTamplateBuilder doesn't save the arguments, it returns a new Builder instance, with the saved arguments. So you have to save the builder everytime you call a function on it.