### PR TITLE
Fix AdminClientProperties not obtaining hostname from server.address if set

### DIFF
--- a/spring-boot-admin-starter-client/src/main/java/de/codecentric/boot/admin/config/AdminClientProperties.java
+++ b/spring-boot-admin-starter-client/src/main/java/de/codecentric/boot/admin/config/AdminClientProperties.java
@@ -137,10 +137,7 @@ public class AdminClientProperties {
 		}
 
 		if (preferIp) {
-			InetAddress address = server.getAddress();
-			if (address == null) {
-				address = getHostAddress();
-			}
+			InetAddress address = getHostAddress();
 			return append(createLocalUri(address.getHostAddress(), serverPort),
 					server.getContextPath());
 
@@ -186,7 +183,8 @@ public class AdminClientProperties {
 
 	private InetAddress getHostAddress() {
 		try {
-			return InetAddress.getLocalHost();
+			InetAddress address = server.getAddress();
+			return address != null ? address : InetAddress.getLocalHost();
 		} catch (UnknownHostException ex) {
 			throw new IllegalArgumentException(ex.getMessage(), ex);
 		}

--- a/spring-boot-admin-starter-client/src/test/java/de/codecentric/boot/admin/config/AdminClientPropertiesTest.java
+++ b/spring-boot-admin-starter-client/src/test/java/de/codecentric/boot/admin/config/AdminClientPropertiesTest.java
@@ -172,8 +172,19 @@ public class AdminClientPropertiesTest {
 		assertThat(clientProperties.getServiceUrl(), is("http://127.0.0.1:8080"));
 	}
 
+	@Test
+	public void test_serveraddress() {
+		load("server.address=127.0.0.2", "local.server.port=8080");
+		AdminClientProperties clientProperties = new AdminClientProperties();
+		context.getAutowireCapableBeanFactory().autowireBean(clientProperties);
+
+		publishApplicationReadyEvent(clientProperties);
+
+		assertThat(clientProperties.getServiceUrl(), is("http://127.0.0.2:8080"));
+	}
+
 	private String getHostname() throws Exception {
-			return InetAddress.getLocalHost().getCanonicalHostName();
+		return InetAddress.getLocalHost().getCanonicalHostName();
 	}
 
 	private void publishApplicationReadyEvent(AdminClientProperties client) {


### PR DESCRIPTION
Fix for #295. Should be merged after #296.