### PR TITLE
Extend Spring application events support

### DIFF
--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/event/ClientApplicationEvent.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/event/ClientApplicationEvent.java
@@ -15,34 +15,24 @@
  */
 package de.codecentric.boot.admin.event;
 
-import java.io.Serializable;
-
 import de.codecentric.boot.admin.model.Application;
+import org.springframework.context.ApplicationEvent;
 
 /**
- * Abstract Event regearding spring boot admin clients
+ * Abstract Event regarding spring boot admin clients
  *
  * @author Johannes Edmeier
  */
-public abstract class ClientApplicationEvent implements Serializable {
-	private static final long serialVersionUID = 1L;
+public abstract class ClientApplicationEvent extends ApplicationEvent {
 
 	private final Application application;
 
-	private final long timestamp;
 	private final String type;
 
 	protected ClientApplicationEvent(Application application, String type) {
+		super(application);
 		this.application = application;
-		this.timestamp = System.currentTimeMillis();
 		this.type = type;
-	}
-
-	/**
-	 * @return system time in milliseconds when the event happened.
-	 */
-	public final long getTimestamp() {
-		return this.timestamp;
 	}
 
 	/**
@@ -64,7 +54,7 @@ public abstract class ClientApplicationEvent implements Serializable {
 		final int prime = 31;
 		int result = 1;
 		result = prime * result + ((application == null) ? 0 : application.hashCode());
-		result = prime * result + (int) (timestamp ^ (timestamp >>> 32));
+		result = prime * result + (int) (getTimestamp() ^ (getTimestamp() >>> 32));
 		result = prime * result + ((type == null) ? 0 : type.hashCode());
 		return result;
 	}
@@ -88,7 +78,7 @@ public abstract class ClientApplicationEvent implements Serializable {
 		} else if (!application.equals(other.application)) {
 			return false;
 		}
-		if (timestamp != other.timestamp) {
+		if (getTimestamp() != other.getTimestamp()) {
 			return false;
 		}
 		if (type == null) {


### PR DESCRIPTION
@joshiste please review
This change would allow to subscribe to ClientApplicationEvent using additional alternative way:
E.g.

`@Component`
`public class StatusListener implements ApplicationListener<ClientApplicationStatusChangedEvent> {`

    @Override
    public void onApplicationEvent(ClientApplicationStatusChangedEvent event) {
        System.out.println(event.getApplication().getStatusInfo().getStatus());
    }

`}`
