### PR TITLE
Add matching services property on discovery part

### DIFF
--- a/spring-boot-admin-docs/src/main/asciidoc/server-discovery.adoc
+++ b/spring-boot-admin-docs/src/main/asciidoc/server-discovery.adoc
@@ -31,6 +31,10 @@ NOTE: When using Eureka, the `healthCheckUrl` known to Eureka is used for health
 | spring.boot.admin.discovery.ignored-services
 | This services will be ignored when using discovery and not registered as application. Supports simple patterns (e.g. "foo*", "*bar", "foo*bar*").
 |
+
+| spring.boot.admin.discovery.matching-services
+| This services will be included when using discovery and registered as application. Supports simple patterns (e.g. "foo*", "*bar", "foo*bar*").
+| `"*"`
 |===
 
 .Instance metadata options


### PR DESCRIPTION
Add ability to set a matching-services property for discovery part. The main goal is to be able to get only services matching the pattern. The implementation is the same as the ignore-services one.