### PR TITLE
removed duplication of endpoint 'trace' in examples and default properties

### DIFF
--- a/spring-boot-admin-docs/src/main/asciidoc/server-ui-modules.adoc
+++ b/spring-boot-admin-docs/src/main/asciidoc/server-ui-modules.adoc
@@ -95,7 +95,7 @@ The Activiti module shows information from the `/activti` endpoint.
 [source,yml]
 .application.yml
 ----
-spring.boot.admin.routes.endpoints: env,metrics,trace,dump,jolokia,info,configprops,trace,logfile,refresh,flyway,liquibase,heapdump,activiti
+spring.boot.admin.routes.endpoints: env,metrics,dump,jolokia,info,configprops,trace,logfile,refresh,flyway,liquibase,heapdump,activiti
 ----
 
 ==== Login UI Module ====

--- a/spring-boot-admin-docs/src/main/asciidoc/server.adoc
+++ b/spring-boot-admin-docs/src/main/asciidoc/server.adoc
@@ -19,7 +19,7 @@
 
 | spring.boot.admin.routes.endpoints
 | The enpoints which will be available via spring boot admin zuul proxy. If you write ui modules using other endpoints you need to add them.
-| `"env, metrics, trace, dump, jolokia, info, configprops, trace, activiti, logfile, refresh, flyway, liquibase, loggers"`
+| `"env, metrics, trace, dump, jolokia, info, configprops, activiti, logfile, refresh, flyway, liquibase, loggers"`
 |===
 
 include::server-discovery.adoc[]

--- a/spring-boot-admin-samples/spring-boot-admin-sample-eureka/src/main/resources/application.yml
+++ b/spring-boot-admin-samples/spring-boot-admin-sample-eureka/src/main/resources/application.yml
@@ -17,7 +17,7 @@ management.security.enabled: false  #<2>
 # end::configuration-eureka[]
 
 # tag::configuration-ui-hystrix[]
-spring.boot.admin.routes.endpoints: env,metrics,trace,dump,jolokia,info,configprops,trace,logfile,refresh,flyway,liquibase,heapdump,loggers,auditevents,hystrix.stream
+spring.boot.admin.routes.endpoints: env,metrics,dump,jolokia,info,configprops,trace,logfile,refresh,flyway,liquibase,heapdump,loggers,auditevents,hystrix.stream
 # end::configuration-ui-hystrix[]
 
 # tag::configuration-ui-turbine[]

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/config/AdminServerProperties.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/config/AdminServerProperties.java
@@ -71,7 +71,7 @@ public class AdminServerProperties {
 		 * Endpoints to be proxified by spring boot admin.
 		 */
 		private String[] endpoints = { "env", "metrics", "trace", "dump", "jolokia", "info",
-				"trace", "logfile", "refresh", "flyway", "liquibase", "heapdump", "loggers", "auditevents" };
+				"logfile", "refresh", "flyway", "liquibase", "heapdump", "loggers", "auditevents" };
 
 		public String[] getEndpoints() {
 			return endpoints;


### PR DESCRIPTION
The documentation mentions the endoint "trace" twice in every example. Also, the default configuration in `AdminServerProperties.java` uses the String twice. While this does not cause problems, I think this is a bit irritating. So I suggest removing the second "trace" entry entirely.