### PR TITLE
Disable application tabs in the frontend if backing endpoint is not available

### DIFF
--- a/spring-boot-admin-server-ui/modules/applications-details/module.js
+++ b/spring-boot-admin-server-ui/modules/applications-details/module.js
@@ -43,10 +43,17 @@ module.config(function ($stateProvider) {
   });
 });
 
-module.run(function (ApplicationViews, $sce) {
+module.run(function (ApplicationViews, $http, $sce) {
   ApplicationViews.register({
     order: 0,
     title: $sce.trustAsHtml('<i class="fa fa-info fa-fw"></i>Details'),
-    state: 'applications.details'
+    state: 'applications.details',
+    show: function (application) {
+      return $http.head('api/applications/' + application.id + '/metrics').then(function () {
+        return true;
+      }).catch(function () {
+        return false;
+      });
+    }
   });
 });

--- a/spring-boot-admin-server-ui/modules/applications-environment/module.js
+++ b/spring-boot-admin-server-ui/modules/applications-environment/module.js
@@ -32,10 +32,17 @@ module.config(function ($stateProvider) {
   });
 });
 
-module.run(function (ApplicationViews, $sce) {
+module.run(function (ApplicationViews, $http, $sce) {
   ApplicationViews.register({
     order: 10,
     title: $sce.trustAsHtml('<i class="fa fa-server fa-fw"></i>Environment'),
-    state: 'applications.environment'
+    state: 'applications.environment',
+    show: function (application) {
+      return $http.head('api/applications/' + application.id + '/env').then(function () {
+        return true;
+      }).catch(function () {
+        return false;
+      });
+    }
   });
 });

--- a/spring-boot-admin-server-ui/modules/applications-jmx/module.js
+++ b/spring-boot-admin-server-ui/modules/applications-jmx/module.js
@@ -40,14 +40,19 @@ module.config(function ($stateProvider) {
   });
 });
 
-module.run(function (ApplicationViews, $sce, $http) {
+module.run(function (ApplicationViews, $sce, $http, jolokia, ApplicationJmx) {
   ApplicationViews.register({
     order: 40,
     title: $sce.trustAsHtml('<i class="fa fa-cogs fa-fw"></i>JMX'),
     state: 'applications.jmx',
     show: function (application) {
       return $http.head('api/applications/' + application.id + '/jolokia').then(function () {
-        return true;
+        return ApplicationJmx.list(application).then(function () {
+          return true;
+        }).catch(function () {
+          console.log(e);
+          return false;
+        });
       }).catch(function () {
         return false;
       });

--- a/spring-boot-admin-server-ui/modules/applications-jmx/module.js
+++ b/spring-boot-admin-server-ui/modules/applications-jmx/module.js
@@ -50,7 +50,6 @@ module.run(function (ApplicationViews, $sce, $http, jolokia, ApplicationJmx) {
         return ApplicationJmx.list(application).then(function () {
           return true;
         }).catch(function () {
-          console.log(e);
           return false;
         });
       }).catch(function () {

--- a/spring-boot-admin-server-ui/modules/applications-metrics/module.js
+++ b/spring-boot-admin-server-ui/modules/applications-metrics/module.js
@@ -33,10 +33,17 @@ module.config(function ($stateProvider) {
   });
 });
 
-module.run(function (ApplicationViews, $sce) {
+module.run(function (ApplicationViews, $http, $sce) {
   ApplicationViews.register({
     order: 5,
     title: $sce.trustAsHtml('<i class="fa fa-bar-chart fa-fw"></i>Metrics'),
-    state: 'applications.metrics'
+    state: 'applications.metrics',
+    show: function (application) {
+      return $http.head('api/applications/' + application.id + '/metrics').then(function () {
+        return true;
+      }).catch(function () {
+        return false;
+      });
+    }
   });
 });

--- a/spring-boot-admin-server-ui/modules/applications-threads/module.js
+++ b/spring-boot-admin-server-ui/modules/applications-threads/module.js
@@ -33,10 +33,17 @@ module.config(function ($stateProvider) {
   });
 });
 
-module.run(function (ApplicationViews, $sce) {
+module.run(function (ApplicationViews, $http, $sce) {
   ApplicationViews.register({
     order: 50,
     title: $sce.trustAsHtml('<i class="fa fa-list fa-fw"></i>Threads'),
-    state: 'applications.threads'
+    state: 'applications.threads',
+    show: function (application) {
+      return $http.head('api/applications/' + application.id + '/dump').then(function () {
+        return true;
+      }).catch(function () {
+        return false;
+      });
+    }
   });
 });


### PR DESCRIPTION
The property `spring.boot.admin.routes.endpoints` lists every application tab in the frontend. However, if some endpoints are removed, the tabs are still shown but throw an error, if they are accessed. This is the case for:

 * environment
 * metrics
 * threads
 * details (if metrics are not available)

The endpoint 'jmx' is hidden if jolokia is disabled completely.

In our project, we only allow access to the bean 'ch.qos.logback.classic.jmx.JMXConfigurator' to configure logging at runtime (the log-tab is shown correctly), but the rest of the JMX beans cannot be accessed. This can be tested using the following configuration:

```
<?xml version="1.0" encoding="utf-8"?>
<restrict>
    <commands>
        <command>search</command>
    </commands>

    <allow>
        <mbean>
            <name>ch.qos.logback.classic:Name=default,Type=ch.qos.logback.classic.jmx.JMXConfigurator</name>
            <operation>*</operation>
            <attribute>*</attribute>
        </mbean>
    </allow>
</restrict>
```

This causes the jmx-tab to be shown, but it only displays a warning. So I suggest to hide the jmx tab if the beans cannot be listed.

To summarize, this PR...
 
 * ... hides the tab "environment" if the env endpoint is disabled
 * ... hides the tabs "metrics" and "details" if the metrics endpoint is disabled
 * ... hides the "threads" tab if the threads endpoint is disabled
 * ... hides the jmx tab if jolokia is not availabe or listing of beans is disabled