### PR TITLE
Build dynamically the list of clusters when no service discovery is used.

### DIFF
--- a/spring-boot-admin-samples/spring-boot-admin-sample/pom.xml
+++ b/spring-boot-admin-samples/spring-boot-admin-sample/pom.xml
@@ -30,6 +30,10 @@
             <artifactId>spring-boot-admin-starter-client</artifactId>
         </dependency>
         <dependency>
+            <groupId>de.codecentric</groupId>
+            <artifactId>spring-boot-admin-server-ui-turbine</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/spring-boot-admin-samples/spring-boot-admin-sample/src/main/java/de/codecentric/boot/admin/SpringBootAdminApplication.java
+++ b/spring-boot-admin-samples/spring-boot-admin-sample/src/main/java/de/codecentric/boot/admin/SpringBootAdminApplication.java
@@ -19,6 +19,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.cloud.netflix.turbine.EnableTurbine;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -36,6 +37,7 @@ import de.codecentric.boot.admin.notify.filter.FilteringNotifier;
 @Configuration
 @EnableAutoConfiguration
 @EnableAdminServer
+@EnableTurbine
 public class SpringBootAdminApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(SpringBootAdminApplication.class, args);

--- a/spring-boot-admin-samples/spring-boot-admin-sample/src/main/resources/application.yml
+++ b/spring-boot-admin-samples/spring-boot-admin-sample/src/main/resources/application.yml
@@ -49,4 +49,7 @@ security:
     name: user
     password: pass
 
-
+# tag::configuration-ui-turbine[]
+spring.boot.admin.turbine:
+  location: http://localhost:${server.port:8080}  #<1>
+# end::configuration-ui-turbine[]

--- a/spring-boot-admin-server-ui-turbine/pom.xml
+++ b/spring-boot-admin-server-ui-turbine/pom.xml
@@ -24,6 +24,14 @@
             <artifactId>spring-cloud-starter</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-netflix-turbine</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-configuration</groupId>
+            <artifactId>commons-configuration</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>
             <optional>true</optional>

--- a/spring-boot-admin-server-ui-turbine/src/main/java/spring/boot/admin/turbine/config/TurbineProperties.java
+++ b/spring-boot-admin-server-ui-turbine/src/main/java/spring/boot/admin/turbine/config/TurbineProperties.java
@@ -30,23 +30,9 @@ public class TurbineProperties {
 	private String location = "turbine";
 
 	/**
-	 * List of available Turbine clusters.
-	 */
-	private String[] clusters = { "default" };
-
-	/**
 	 * Enable the Spring Boot Admin backend configuration for Turbine.
 	 */
 	private boolean enabled = true;
-
-
-	public String[] getClusters() {
-		return clusters;
-	}
-
-	public void setClusters(String[] clusters) {
-		this.clusters = Arrays.copyOf(clusters, clusters.length);
-	}
 
 	public boolean isEnabled() {
 		return enabled;

--- a/spring-boot-admin-server-ui-turbine/src/main/java/spring/boot/admin/turbine/discovery/ApplicationDiscoveryClient.java
+++ b/spring-boot-admin-server-ui-turbine/src/main/java/spring/boot/admin/turbine/discovery/ApplicationDiscoveryClient.java
@@ -1,0 +1,105 @@
+package spring.boot.admin.turbine.discovery;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.cloud.client.discovery.simple.SimpleDiscoveryProperties.SimpleServiceInstance;
+import org.springframework.cloud.netflix.turbine.SpringAggregatorFactory;
+import org.springframework.context.event.EventListener;
+import org.springframework.util.StringUtils;
+
+import com.netflix.config.ConfigurationManager;
+import com.netflix.turbine.discovery.InstanceDiscovery;
+import com.netflix.turbine.plugins.PluginsFactory;
+
+import de.codecentric.boot.admin.discovery.ApplicationDiscoveryListener;
+import de.codecentric.boot.admin.event.ClientApplicationRegisteredEvent;
+import de.codecentric.boot.admin.model.Application;
+
+/**
+ * Create a discovery client which will discover the applications registered within Spring Boot Admin
+ *
+ * @author Jérôme Mirc
+ */
+public class ApplicationDiscoveryClient implements DiscoveryClient {
+    private static final Logger LOGGER = LoggerFactory
+            .getLogger(ApplicationDiscoveryListener.class);
+
+
+    private Map<String, List<ServiceInstance>> instances = new HashMap<>();
+
+    @EventListener
+    public void registerApplication(ClientApplicationRegisteredEvent clientApplicationRegisteredEvent) {
+        Application application = clientApplicationRegisteredEvent.getApplication();
+        String serviceId = application.getName();
+
+        if (!instances.containsKey(serviceId)) {
+            instances.put(serviceId, new ArrayList<ServiceInstance>());
+        }
+
+        ServiceInstance serviceInstance = marshall(application);
+
+        if (serviceInstance != null) {
+            instances.get(serviceId).add(serviceInstance);
+        }
+
+        // Register each registered applications as a turbine's cluster
+        registerTurbineClusters();
+    }
+
+    @Override
+    public String description() {
+        return "Spring Boot Monitoring Instances Discovery";
+    }
+
+    @Override
+    public ServiceInstance getLocalServiceInstance() {
+        return null;
+    }
+
+    @Override
+    public List<ServiceInstance> getInstances(String serviceId) {
+        return instances.get(serviceId);
+
+    }
+
+    @Override
+    public List<String> getServices() {
+        return new ArrayList<>(instances.keySet());
+    }
+
+    /**
+     * Private helper that marshals the information from each instance into something that
+     * Turbine can understand.
+     *
+     * @return Instance
+     */
+    private ServiceInstance marshall(Application application) {
+        try {
+            URL serviceURL = new URL(application.getServiceUrl());
+            return new SimpleServiceInstance(serviceURL.toURI().toString());
+        } catch (Exception e) {
+            LOGGER.error("Failed to parse the URL {}", application.getServiceUrl(), e);
+        }
+
+        return null;
+    }
+
+    /**
+     *  Turbine clusters are registered dynamically
+     */
+    private void registerTurbineClusters() {
+        ConfigurationManager
+                .getConfigInstance()
+                .setProperty(InstanceDiscovery.TURBINE_AGGREGATOR_CLUSTER_CONFIG, StringUtils.collectionToCommaDelimitedString(getServices()));
+
+        PluginsFactory.getClusterMonitorFactory().initClusterMonitors();
+    }
+}

--- a/spring-boot-admin-server-ui-turbine/src/main/java/spring/boot/admin/turbine/discovery/ApplicationDiscoveryClient.java
+++ b/spring-boot-admin-server-ui-turbine/src/main/java/spring/boot/admin/turbine/discovery/ApplicationDiscoveryClient.java
@@ -11,7 +11,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.cloud.client.discovery.simple.SimpleDiscoveryProperties.SimpleServiceInstance;
-import org.springframework.cloud.netflix.turbine.SpringAggregatorFactory;
 import org.springframework.context.event.EventListener;
 import org.springframework.util.StringUtils;
 

--- a/spring-boot-admin-server-ui-turbine/src/main/java/spring/boot/admin/turbine/discovery/ApplicationInstanceDiscovery.java
+++ b/spring-boot-admin-server-ui-turbine/src/main/java/spring/boot/admin/turbine/discovery/ApplicationInstanceDiscovery.java
@@ -1,0 +1,68 @@
+package spring.boot.admin.turbine.discovery;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.cloud.netflix.turbine.CommonsInstanceDiscovery;
+import org.springframework.cloud.netflix.turbine.TurbineProperties;
+import org.springframework.util.StringUtils;
+
+import com.netflix.turbine.discovery.Instance;
+
+/**
+ *  A custom implementation to support Spring Boot Admin {@link de.codecentric.boot.admin.model.Application}.
+ *
+ * @author Jérôme Mirc
+ */
+public class ApplicationInstanceDiscovery extends CommonsInstanceDiscovery {
+
+    private final DiscoveryClient discoveryClient;
+
+    public ApplicationInstanceDiscovery(DiscoveryClient discoveryClient) {
+        super(new TurbineProperties(), discoveryClient);
+        this.discoveryClient = discoveryClient;
+    }
+
+    @Override
+    public TurbineProperties getTurbineProperties() {
+        TurbineProperties turbineProperties = new TurbineProperties();
+        List<String> services = discoveryClient.getServices();
+        String appConfigList = StringUtils.collectionToCommaDelimitedString(services);
+        turbineProperties.setAppConfig(appConfigList);
+        return turbineProperties;
+    }
+
+    @Override
+    protected List<Instance> getInstancesForApp(String serviceId) throws Exception {
+        List<ServiceInstance> instances = discoveryClient.getInstances(serviceId);
+
+        if (instances == null) {
+            return Collections.emptyList();
+        }
+
+        List<Instance> results = new ArrayList<>();
+
+        for (ServiceInstance instance : instances) {
+            results.add(convert(serviceId, instance));
+        }
+
+        return results;
+    }
+
+    private Instance convert(String serviceId, ServiceInstance serviceInstance) {
+        Instance instance = getInstance(serviceInstance.getHost(), String.valueOf(serviceInstance.getPort()), serviceId, true);
+
+        instance.getAttributes().put("fusedHostPort", String.format("%s:%d", serviceInstance.getHost(), serviceInstance.getPort()));
+
+        if (serviceInstance.isSecure()) {
+            instance.getAttributes().put("securePort", String.valueOf(serviceInstance.getPort()));
+        } else {
+            instance.getAttributes().put("port", String.valueOf(serviceInstance.getPort()));
+        }
+
+        return instance;
+    }
+}

--- a/spring-boot-admin-server-ui-turbine/src/main/java/spring/boot/admin/turbine/web/TurbineController.java
+++ b/spring-boot-admin-server-ui-turbine/src/main/java/spring/boot/admin/turbine/web/TurbineController.java
@@ -17,8 +17,10 @@ package spring.boot.admin.turbine.web;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
+import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -29,20 +31,30 @@ import de.codecentric.boot.admin.web.AdminController;
  * Provides informations for the turbine view. Only available clusters until now.
  * 
  * @author Johannes Edmeier
+ * @author Jérôme Mirc
  */
 @AdminController
 @ResponseBody
 @RequestMapping("/api/turbine")
 public class TurbineController {
-	private final String[] clusters;
+	private final DiscoveryClient discoveryClient;
 
-	public TurbineController(String[] clusters) {
-		this.clusters = Arrays.copyOf(clusters, clusters.length);
+	public TurbineController(DiscoveryClient discoveryClient) {
+		this.discoveryClient = discoveryClient;
 	}
 
 	@RequestMapping(value = "/clusters", method = RequestMethod.GET)
 	public Map<String, ?> getClusters() {
-		return Collections.singletonMap("clusters", clusters);
+		String[] clusterNames = new String[]{"default"};
+
+		List<String> services = discoveryClient.getServices();
+
+		if (services != null) {
+			clusterNames = services.toArray(new String[0]);
+		}
+
+		Arrays.sort(clusterNames);
+		return Collections.singletonMap("clusters", clusterNames);
 	}
 
 }

--- a/spring-boot-admin-server-ui-turbine/src/test/java/spring/boot/admin/turbine/discovery/ApplicationDiscoveryClientTest.java
+++ b/spring-boot-admin-server-ui-turbine/src/test/java/spring/boot/admin/turbine/discovery/ApplicationDiscoveryClientTest.java
@@ -1,0 +1,54 @@
+package spring.boot.admin.turbine.discovery;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+import java.util.List;
+
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.cloud.client.ServiceInstance;
+
+import com.netflix.turbine.plugins.DefaultAggregatorFactory;
+import com.netflix.turbine.plugins.PluginsFactory;
+
+import de.codecentric.boot.admin.event.ClientApplicationRegisteredEvent;
+import de.codecentric.boot.admin.model.Application;
+
+public class ApplicationDiscoveryClientTest {
+
+    @Before
+    public void init() {
+        PluginsFactory.setClusterMonitorFactory(new DefaultAggregatorFactory());
+    }
+
+    @Test
+    public void registerNoApplication() {
+        ApplicationDiscoveryClient applicationDiscoveryClient = new ApplicationDiscoveryClient();
+        assertThat(applicationDiscoveryClient.getServices(), Matchers.<String>empty());
+    }
+
+    @Test
+    public void registerOneApplication() {
+        ApplicationDiscoveryClient discoveryClient = new ApplicationDiscoveryClient();
+
+        String serviceId = "test";
+        discoveryClient.registerApplication(new ClientApplicationRegisteredEvent(Application
+                                                                                         .create(serviceId)
+                                                                                         .withServiceUrl("http://localhost:8080")
+                                                                                         .withHealthUrl("http://localhost:8080/health")
+                                                                                         .build()));
+
+        assertThat(discoveryClient.getServices(), hasSize(1));
+        List<ServiceInstance> instances = discoveryClient.getInstances(serviceId);
+        assertThat(instances, notNullValue());
+        assertThat(instances, hasSize(1));
+
+        ServiceInstance serviceInstance = instances.get(0);
+        assertThat(serviceInstance.getHost(), is("localhost"));
+        assertThat(serviceInstance.getPort(), is(8080));
+    }
+}

--- a/spring-boot-admin-server-ui-turbine/src/test/java/spring/boot/admin/turbine/discovery/ApplicationInstanceDiscoveryTest.java
+++ b/spring-boot-admin-server-ui-turbine/src/test/java/spring/boot/admin/turbine/discovery/ApplicationInstanceDiscoveryTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
-import java.util.Collection;
 import java.util.List;
 
 import org.junit.Before;

--- a/spring-boot-admin-server-ui-turbine/src/test/java/spring/boot/admin/turbine/discovery/ApplicationInstanceDiscoveryTest.java
+++ b/spring-boot-admin-server-ui-turbine/src/test/java/spring/boot/admin/turbine/discovery/ApplicationInstanceDiscoveryTest.java
@@ -1,0 +1,66 @@
+package spring.boot.admin.turbine.discovery;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.netflix.turbine.discovery.Instance;
+import com.netflix.turbine.plugins.DefaultAggregatorFactory;
+import com.netflix.turbine.plugins.PluginsFactory;
+
+import de.codecentric.boot.admin.event.ClientApplicationRegisteredEvent;
+import de.codecentric.boot.admin.model.Application;
+
+public class ApplicationInstanceDiscoveryTest {
+
+    @Before
+    public void init() {
+        PluginsFactory.setClusterMonitorFactory(new DefaultAggregatorFactory());
+    }
+
+    @Test
+    public void registerNoApplication() throws Exception {
+        ApplicationDiscoveryClient discoveryClient = new ApplicationDiscoveryClient();
+
+        ApplicationInstanceDiscovery applicationInstanceDiscovery = new ApplicationInstanceDiscovery(discoveryClient);
+
+        assertThat(applicationInstanceDiscovery.getInstanceList(), hasSize(0));
+    }
+
+    @Test
+    public void registerOneApplication() throws Exception {
+        ApplicationDiscoveryClient discoveryClient = new ApplicationDiscoveryClient();
+
+        String serviceId = "test";
+        discoveryClient.registerApplication(new ClientApplicationRegisteredEvent(Application
+                                                                                         .create(serviceId)
+                                                                                         .withServiceUrl("http://localhost:8080")
+                                                                                         .withHealthUrl("http://localhost:8080/health")
+                                                                                         .build()));
+
+        ApplicationInstanceDiscovery applicationInstanceDiscovery = new ApplicationInstanceDiscovery(discoveryClient);
+        assertThat(applicationInstanceDiscovery.getInstanceList(), hasSize(1));
+
+        discoveryClient.registerApplication(new ClientApplicationRegisteredEvent(Application
+                                                    .create(serviceId)
+                                                    .withServiceUrl("http://localhost:8081")
+                                                    .withHealthUrl("http://localhost:8081/health")
+                                                    .build()));
+
+        assertThat(applicationInstanceDiscovery.getInstanceList(), hasSize(2));
+        assertThat(applicationInstanceDiscovery.getInstancesForApp(serviceId), hasSize(2));
+
+        List<Instance> instances = applicationInstanceDiscovery.getInstancesForApp(serviceId);
+        assertThat(instances.get(0).getCluster(), is(serviceId));
+        assertThat(instances.get(0).getHostname(), is("localhost:8080"));
+        assertThat(instances.get(1).getCluster(), is(serviceId));
+        assertThat(instances.get(1).getHostname(), is("localhost:8081"));
+
+    }
+}

--- a/spring-boot-admin-server-ui-turbine/src/test/java/spring/boot/admin/turbine/web/TurbineControllerTest.java
+++ b/spring-boot-admin-server-ui-turbine/src/test/java/spring/boot/admin/turbine/web/TurbineControllerTest.java
@@ -8,8 +8,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.util.Arrays;
-
 import org.junit.Test;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.test.web.servlet.MockMvc;
@@ -25,7 +23,7 @@ public class TurbineControllerTest {
 
 	@Test
 	public void test_clusters() throws Exception {
-		when(discoveryClient.getServices()).thenReturn(Arrays.asList("c1", "c2"));
+		when(discoveryClient.getServices()).thenReturn(asList("c1", "c2"));
 		mvc.perform(get("/api/turbine/clusters")).andExpect(status().isOk())
 				.andExpect(jsonPath("$.clusters").value(is(asList("c1", "c2"))));
 	}

--- a/spring-boot-admin-server-ui-turbine/src/test/java/spring/boot/admin/turbine/web/TurbineControllerTest.java
+++ b/spring-boot-admin-server-ui-turbine/src/test/java/spring/boot/admin/turbine/web/TurbineControllerTest.java
@@ -2,22 +2,30 @@ package spring.boot.admin.turbine.web;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.util.Arrays;
+
 import org.junit.Test;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 public class TurbineControllerTest {
 
+	private DiscoveryClient discoveryClient = mock(DiscoveryClient.class);
+
 	private MockMvc mvc = MockMvcBuilders
-			.standaloneSetup(new TurbineController(new String[] { "c1", "c2" }))
+			.standaloneSetup(new TurbineController(discoveryClient))
 			.build();
 
 	@Test
 	public void test_clusters() throws Exception {
+		when(discoveryClient.getServices()).thenReturn(Arrays.asList("c1", "c2"));
 		mvc.perform(get("/api/turbine/clusters")).andExpect(status().isOk())
 				.andExpect(jsonPath("$.clusters").value(is(asList("c1", "c2"))));
 	}


### PR DESCRIPTION
Actually when no service discovery is used, the list of clusters is retrieved from the properties.

This PR will remove the need to hard code the list of clusters in TurbineProperties and will build the list dynamically.

We are using this code for one year and I took times to send a PR.