### PR TITLE
added missing setter for metadata

### DIFF
--- a/spring-boot-admin-starter-client/src/main/java/de/codecentric/boot/admin/client/config/AdminClientProperties.java
+++ b/spring-boot-admin-starter-client/src/main/java/de/codecentric/boot/admin/client/config/AdminClientProperties.java
@@ -100,4 +100,8 @@ public class AdminClientProperties {
 	public Map<String, String> getMetadata() {
 		return metadata;
 	}
+
+	public void setMetadata(Map<String, String> metadata) {
+		this.metadata = metadata;
+	}
 }


### PR DESCRIPTION
This PR adds a setter so that the documented way of adding credentials for the communication with the clients works.

```
spring:
  boot:
    admin:
      client:
        metadata:
          user.name: "${security.user.name}"          #These two are needed so that the server
          user.password:  "${security.user.password}" #can access the proteceted client endpoints
```