### PR TITLE
Fix cache stats display when hit/miss ration is missing

### DIFF
--- a/spring-boot-admin-server-ui/modules/applications-details/components/cacheStats.tpl.html
+++ b/spring-boot-admin-server-ui/modules/applications-details/components/cacheStats.tpl.html
@@ -1,6 +1,6 @@
 <table class="table">
 	<tr ng-repeat-start="cache in $ctrl.caches track by cache.name">
-		<td rowspan="2" ng-bind="cache.name"></td>
+		<td rowspan="{{cache.hitRatio || cache.missRatio ? 2 : 1}}" ng-bind="cache.name"></td>
 		<td>size</td>
 		<td ng-bind="cache.size">
 	</tr>


### PR DESCRIPTION
Fixing a display error with cache rowspan when hitRatio is not present