### PR TITLE
fix #445 : set header json for slack notification

### DIFF
--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/notify/SlackNotifier.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/notify/SlackNotifier.java
@@ -8,6 +8,9 @@ import java.util.Map;
 import org.springframework.expression.Expression;
 import org.springframework.expression.ParserContext;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.web.client.RestTemplate;
 
 import de.codecentric.boot.admin.event.ClientApplicationEvent;
@@ -62,7 +65,7 @@ public class SlackNotifier extends AbstractStatusChangeNotifier {
 		this.restTemplate = restTemplate;
 	}
 
-	protected Object createMessage(ClientApplicationEvent event) {
+	protected HttpEntity<Map<String, Object>> createMessage(ClientApplicationEvent event) {
 		Map<String, Object> messageJson = new HashMap<>();
 		messageJson.put("username", username);
 		if (icon != null) {
@@ -77,7 +80,10 @@ public class SlackNotifier extends AbstractStatusChangeNotifier {
 		attachments.put("color", getColor(event));
 		attachments.put("mrkdwn_in", Collections.singletonList("text"));
 		messageJson.put("attachments", Collections.singletonList(attachments));
-		return messageJson;
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_JSON);
+		return new HttpEntity<>(messageJson, headers);
 	}
 
 	protected String getText(ClientApplicationEvent event) {

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/notify/SlackNotifierTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/notify/SlackNotifierTest.java
@@ -14,6 +14,9 @@ import javax.annotation.Nullable;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.web.client.RestTemplate;
 
 import de.codecentric.boot.admin.event.ClientApplicationStatusChangedEvent;
@@ -121,7 +124,7 @@ public class SlackNotifierTest {
 				infoDown, infoUp);
 	}
 
-	private Object expectedMessage(String color, String user, @Nullable String icon,
+	private HttpEntity<Map<String, Object>> expectedMessage(String color, String user, @Nullable String icon,
 			@Nullable String channel, String message) {
 		Map<String, Object> messageJson = new HashMap<>();
 		messageJson.put("username", user);
@@ -139,7 +142,9 @@ public class SlackNotifierTest {
 
 		messageJson.put("attachments", Collections.singletonList(attachments));
 
-		return messageJson;
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_JSON);
+		return new HttpEntity<>(messageJson, headers);
 	}
 
 	private String standardMessage(String status, String appName, String id) {


### PR DESCRIPTION
Here a solution for issue #445.
RestTemplate has a xml converter before json converter, this is the reason for 400 bad request.

HipchatNotifier has probably the same issue before, and use a json header now. So I do the same thing for slack notifier