### PR TITLE
Update security documentation

### DIFF
--- a/spring-boot-admin-docs/src/main/asciidoc/security.adoc
+++ b/spring-boot-admin-docs/src/main/asciidoc/security.adoc
@@ -28,10 +28,8 @@ Submitting the credentials using SBA Client:
 ----
 spring.boot.admin:
   url: http://localhost:8080
-  client:
-    metadata:
-      user.name: ${security.user.name}
-      user.password: ${security.user.password}
+  username: ${security.user.name}
+  password: ${security.user.password}
 ----
 
 Submitting the credentials using Eureka:


### PR DESCRIPTION
Security documentation contains wrong application properties in SBA client example.
spring.boot.admin.client.metadata.user.name and spring.boot.client.metadata.user.password are not working.
spring.boot.admin.username and spring.boot.admin.password work well.