### PR TITLE
display application metadata in instance detail page

### DIFF
--- a/spring-boot-admin-server-ui/src/main/frontend/views/instances/details/details-metadata.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/instances/details/details-metadata.vue
@@ -35,17 +35,14 @@
 <script>
   export default {
     props: ['instance'],
-    data: () => ({
-      metadata: {}
-    }),
     computed: {
+      metadata() {
+        return this.instance.registration.metadata;
+      },
       isEmptyMetadata() {
         return Object.keys(this.metadata).length <= 0;
       }
     },
-    created() {
-      this.metadata = this.instance.registration.metadata;
-    }
   }
 </script>
 

--- a/spring-boot-admin-server-ui/src/main/frontend/views/instances/details/details-metadata.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/instances/details/details-metadata.vue
@@ -1,0 +1,61 @@
+<!--
+  - Copyright 2014-2018 the original author or authors.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+  -->
+
+<template>
+    <sba-panel title="Metadata">
+      <div slot="text">
+        <div class="content metadata" v-if="metadata">
+            <table class="table" v-if="!isEmptyMetadata">
+                <tr v-for="(value, key) in metadata" :key="key">
+                    <td class="metadata__key" v-text="key"></td>
+                    <td>
+                        <sba-formatted-obj :value="value"></sba-formatted-obj>
+                    </td>
+                </tr>
+            </table>
+            <p v-else class="is-muted">No metadata provided.</p>
+        </div>
+      </div>
+    </sba-panel>
+</template>
+
+<script>
+  export default {
+    props: ['instance'],
+    data: () => ({
+      metadata: {}
+    }),
+    computed: {
+      isEmptyMetadata() {
+        return Object.keys(this.metadata).length <= 0;
+      }
+    },
+    created() {
+      this.metadata = this.instance.registration.metadata;
+    }
+  }
+</script>
+
+<style lang="scss">
+    .metadata {
+        overflow: auto;
+
+        &__key {
+            vertical-align: top;
+        }
+    }
+
+</style>

--- a/spring-boot-admin-server-ui/src/main/frontend/views/instances/details/index.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/instances/details/index.vue
@@ -28,6 +28,7 @@
             <div class="columns is-desktop">
                 <div class="column is-half-desktop">
                     <details-info v-if="hasInfo" :instance="instance"></details-info>
+                    <details-metadata v-if="hasMetadata" :instance="instance"></details-metadata>
                 </div>
                 <div class="column is-half-desktop">
                     <details-health :instance="instance"></details-health>
@@ -71,6 +72,7 @@
   import detailsMemory from './details-memory';
   import detailsProcess from './details-process';
   import detailsThreads from './details-threads';
+  import detailsMetadata from './details-metadata';
 
   export default {
     components: {
@@ -81,7 +83,8 @@
       detailsDatasources,
       detailsMemory,
       detailsGc,
-      detailsCaches
+      detailsCaches,
+      detailsMetadata
     },
     props: ['instance'],
     data: () => ({
@@ -111,6 +114,9 @@
       hasThreads() {
         return this.metrics.indexOf('jvm.threads.live') >= 0;
       },
+      hasMetadata() {
+        return this.instance && this.instance.registration && this.instance.registration.metadata;
+      }
     },
     created() {
       this.fetchMetricIndex();


### PR DESCRIPTION
This PR adds the application metadata in the instance detail page. Solve the issue of #642 
I created this PR without the preferences from the maintainers so I would like your feedback.
Thank you in advance.

Desktop View
![2018-02-11 22 34 33](https://user-images.githubusercontent.com/24989207/36073927-b199d2ae-0f7b-11e8-96e7-eb4c75709306.png)

Smartphone View
![2018-02-11 22 31 11](https://user-images.githubusercontent.com/24989207/36073906-5748d6e2-0f7b-11e8-82ca-5fce507944a9.png)
