### PR TITLE
Update OpsGenie notifier to work with new api

### DIFF
--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/notify/OpsGenieNotifier.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/notify/OpsGenieNotifier.java
@@ -44,7 +44,7 @@ import org.springframework.web.client.RestTemplate;
  * @author Fernando Sure
  */
 public class OpsGenieNotifier extends AbstractStatusChangeNotifier {
-    private static final URI DEFAULT_URI = URI.create("https://api.opsgenie.com/v1/json/alert");
+    private static final URI DEFAULT_URI = URI.create("https://api.opsgenie.com/v2/alerts");
     private static final String DEFAULT_MESSAGE = "#{instance.registration.name}/#{instance.id} is #{instance.statusInfo.status}";
     private final SpelExpressionParser parser = new SpelExpressionParser();
     private RestTemplate restTemplate = new RestTemplate();
@@ -58,12 +58,6 @@ public class OpsGenieNotifier extends AbstractStatusChangeNotifier {
      * Integration ApiKey
      */
     private String apiKey;
-
-    /**
-     * Comma separated list of users, groups, schedules or escalation names
-     * to calculate which users will receive the notifications of the alert.
-     */
-    private String recipients;
 
     /**
      * Comma separated list of actions that can be executed.
@@ -95,8 +89,8 @@ public class OpsGenieNotifier extends AbstractStatusChangeNotifier {
      */
     private Expression description;
 
-    public OpsGenieNotifier(InstanceRepository repositpry) {
-        super(repositpry);
+    public OpsGenieNotifier(InstanceRepository repository) {
+        super(repository);
         this.description = parser.parseExpression(DEFAULT_MESSAGE, ParserContext.TEMPLATE_EXPRESSION);
     }
 
@@ -104,30 +98,26 @@ public class OpsGenieNotifier extends AbstractStatusChangeNotifier {
     @Override
     protected Mono<Void> doNotify(InstanceEvent event, Instance instance) {
         return Mono.fromRunnable(
-            () -> restTemplate.exchange(buildUrl(event), HttpMethod.POST, createRequest(event, instance), Void.class));
+            () -> restTemplate.exchange(buildUrl(event, instance), HttpMethod.POST, createRequest(event, instance), Void.class));
     }
 
-    protected String buildUrl(InstanceEvent event) {
+    protected String buildUrl(InstanceEvent event, Instance instance) {
         if ((event instanceof InstanceStatusChangedEvent) &&
             (StatusInfo.STATUS_UP.equals(((InstanceStatusChangedEvent) event).getStatusInfo().getStatus()))) {
-            return String.format("%s/close", url.toString());
+            return String.format("%s/%s/close",url.toString(), generateAlias(instance));
         }
         return url.toString();
     }
 
     protected HttpEntity createRequest(InstanceEvent event, Instance instance) {
         Map<String, Object> body = new HashMap<>();
-        body.put("apiKey", apiKey);
         body.put("message", getMessage(event, instance));
-        body.put("alias", instance.getRegistration().getName() + "/" + instance.getId());
+        body.put("alias", generateAlias(instance));
         body.put("description", getDescription(event, instance));
 
         if (event instanceof InstanceStatusChangedEvent &&
             !StatusInfo.STATUS_UP.equals(((InstanceStatusChangedEvent) event).getStatusInfo().getStatus())) {
 
-            if (recipients != null) {
-                body.put("recipients", recipients);
-            }
             if (actions != null) {
                 body.put("actions", actions);
             }
@@ -153,7 +143,12 @@ public class OpsGenieNotifier extends AbstractStatusChangeNotifier {
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set(HttpHeaders.AUTHORIZATION,"GenieKey " + apiKey);
         return new HttpEntity<>(body, headers);
+    }
+
+    private String generateAlias(Instance instance) {
+        return instance.getRegistration().getName() + "_" + instance.getId();
     }
 
     protected String getMessage(InstanceEvent event, Instance instance) {
@@ -190,14 +185,6 @@ public class OpsGenieNotifier extends AbstractStatusChangeNotifier {
 
     public void setRestTemplate(RestTemplate restTemplate) {
         this.restTemplate = restTemplate;
-    }
-
-    public String getRecipients() {
-        return recipients;
-    }
-
-    public void setRecipients(String recipients) {
-        this.recipients = recipients;
     }
 
     public String getActions() {

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/notify/OpsGenieNotifierTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/notify/OpsGenieNotifierTest.java
@@ -58,7 +58,6 @@ public class OpsGenieNotifierTest {
 
         notifier = new OpsGenieNotifier(repository);
         notifier.setApiKey("--service--");
-        notifier.setRecipients("--recipients--");
         notifier.setRestTemplate(restTemplate);
     }
 
@@ -74,7 +73,7 @@ public class OpsGenieNotifierTest {
             new InstanceStatusChangedEvent(INSTANCE.getId(), INSTANCE.getVersion() + 2, StatusInfo.ofUp())))
                     .verifyComplete();
 
-        verify(restTemplate).exchange(eq("https://api.opsgenie.com/v1/json/alert/close"), eq(HttpMethod.POST),
+        verify(restTemplate).exchange(eq("https://api.opsgenie.com/v2/alerts/App_-id-/close"), eq(HttpMethod.POST),
             eq(expectedRequest("DOWN", "UP")), eq(Void.class));
     }
 
@@ -90,7 +89,7 @@ public class OpsGenieNotifierTest {
             new InstanceStatusChangedEvent(INSTANCE.getId(), INSTANCE.getVersion() + 2, StatusInfo.ofDown())))
                     .verifyComplete();
 
-        verify(restTemplate).exchange(eq("https://api.opsgenie.com/v1/json/alert"), eq(HttpMethod.POST),
+        verify(restTemplate).exchange(eq("https://api.opsgenie.com/v2/alerts"), eq(HttpMethod.POST),
             eq(expectedRequest("UP", "DOWN")), eq(Void.class));
     }
 
@@ -105,14 +104,12 @@ public class OpsGenieNotifierTest {
 
     private HttpEntity expectedRequest(String expectedOldStatus, String expectedNewStatus) {
         Map<String, Object> expected = new HashMap<>();
-        expected.put("apiKey", "--service--");
         expected.put("message", getMessage(expectedNewStatus));
-        expected.put("alias", "App/-id-");
+        expected.put("alias", "App_-id-");
         expected.put("description", getDescription(expectedOldStatus, expectedNewStatus));
 
         if (!"UP".equals(expectedNewStatus)) {
 
-            expected.put("recipients", "--recipients--");
             Map<String, Object> details = new HashMap<>();
             details.put("type", "link");
             details.put("href", "http://health");
@@ -122,6 +119,7 @@ public class OpsGenieNotifierTest {
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set(HttpHeaders.AUTHORIZATION, "GenieKey --service--");
         return new HttpEntity<>(expected, headers);
     }
 }


### PR DESCRIPTION
Since the Opsgenie v1 api [will be deprecated in June 30](https://www.opsgenie.com/news/335) this class should be updated to work with the v2 alerts api. 

- Sending the api key in headers instead of the body is preferred way to use the api so i changed it that way.
- We are closing the alerts with aliases so i think using _ instead of / in the alias would be safer because alias is used as a path parameter on opsgenie side.
- Recipients field is not supported in the new api so i had to remove it. There is a new field named responders with a different syntax, it is harder to represent in a comma seperated value list so i can create a new pull request for responders and visibleTo field support.