### PR TITLE
Fix actuator path filter in http traces view

### DIFF
--- a/spring-boot-admin-server-ui/src/main/frontend/views/instances/httptrace/index.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/instances/httptrace/index.vue
@@ -164,7 +164,11 @@
         if (this.instance.registration.managementUrl.indexOf(this.instance.registration.serviceUrl) >= 0) {
           const appendix = this.instance.registration.managementUrl.substring(this.instance.registration.serviceUrl.length);
           if (appendix.length > 0) {
-            return `/${appendix}`;
+          	if (appendix.indexOf('/') == 0) {
+              return appendix;
+          	} else {
+              return `/${appendix}`;
+          	}
           }
         }
         return null;

--- a/spring-boot-admin-server-ui/src/main/frontend/views/instances/httptrace/index.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/instances/httptrace/index.vue
@@ -164,11 +164,11 @@
         if (this.instance.registration.managementUrl.indexOf(this.instance.registration.serviceUrl) >= 0) {
           const appendix = this.instance.registration.managementUrl.substring(this.instance.registration.serviceUrl.length);
           if (appendix.length > 0) {
-          	if (appendix.indexOf('/') == 0) {
+            if (appendix.indexOf('/') == 0) {
               return appendix;
-          	} else {
+            } else {
               return `/${appendix}`;
-          	}
+            }
           }
         }
         return null;

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/services/StatusUpdaterTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/services/StatusUpdaterTest.java
@@ -25,6 +25,7 @@ import de.codecentric.boot.admin.server.domain.values.Registration;
 import de.codecentric.boot.admin.server.eventstore.ConcurrentMapEventStore;
 import de.codecentric.boot.admin.server.eventstore.InMemoryEventStore;
 import de.codecentric.boot.admin.server.web.client.InstanceWebClient;
+import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.time.Duration;
@@ -35,7 +36,9 @@ import org.junit.Test;
 import org.springframework.boot.actuate.endpoint.http.ActuatorMediaType;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.core.Options;
+import com.github.tomakehurst.wiremock.http.Fault;
 import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
@@ -66,7 +69,7 @@ public class StatusUpdaterTest {
         StepVerifier.create(repository.save(instance)).expectNextCount(1).verifyComplete();
 
         updater = new StatusUpdater(repository,
-            new InstanceWebClient(instance -> HttpHeaders.EMPTY, Duration.ofSeconds(5), Duration.ofSeconds(20)));
+            new InstanceWebClient(instance -> HttpHeaders.EMPTY, Duration.ofSeconds(5), Duration.ofSeconds(10)));
     }
 
     @Test
@@ -92,6 +95,15 @@ public class StatusUpdaterTest {
 
         StepVerifier.create(repository.find(instance.getId()))
                     .assertNext(app -> assertThat(app.getStatusInfo().getStatus()).isEqualTo("UP"))
+                    .verifyComplete();
+
+        StepVerifier.create(repository.computeIfPresent(instance.getId(), (key, instance) -> Mono.just(instance.deregister())))
+                    .then(() -> StepVerifier.create(updater.updateStatus(instance.getId())).verifyComplete())
+                    .thenCancel()
+                    .verify();
+
+        StepVerifier.create(repository.find(instance.getId()))
+                    .assertNext(app -> assertThat(app.getStatusInfo().getStatus()).isEqualTo("UNKNOWN"))
                     .verifyComplete();
     }
 
@@ -168,21 +180,20 @@ public class StatusUpdaterTest {
 
     @Test
     public void test_update_offline() {
-        Instance offlineInstance = Instance.create(InstanceId.of("offline"))
-                                           .register(Registration.create("foo", "http://0.0.0.0/health").build());
-
-        StepVerifier.create(repository.save(offlineInstance)).expectNextCount(1).verifyComplete();
+        wireMock.stubFor(get("/health").willReturn(WireMock.aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER)));
 
         StepVerifier.create(eventStore)
                     .expectSubscription()
-                    .then(() -> StepVerifier.create(updater.updateStatus(offlineInstance.getId())).verifyComplete())
+                    .then(() -> StepVerifier.create(updater.updateStatus(instance.getId())).verifyComplete())
                     .assertNext(event -> assertThat(event).isInstanceOf(InstanceStatusChangedEvent.class))
                     .thenCancel()
                     .verify();
 
-        StepVerifier.create(repository.find(offlineInstance.getId())).assertNext(app -> {
+        StepVerifier.create(repository.find(instance.getId())).assertNext(app -> {
             assertThat(app.getStatusInfo().getStatus()).isEqualTo("OFFLINE");
             assertThat(app.getStatusInfo().getDetails()).containsKeys("message", "exception");
         }).verifyComplete();
+
+        StepVerifier.create(updater.updateStatus(instance.getId())).verifyComplete();
     }
 }


### PR DESCRIPTION
The filter for actuator path doesn't work if server.servlet.contextPath is set.
