### PR TITLE
[MicrosoftTeamsNotifier] Fix order of to/from statuses in status changed notifications

### DIFF
--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/notify/MicrosoftTeamsNotifier.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/notify/MicrosoftTeamsNotifier.java
@@ -65,7 +65,7 @@ public class MicrosoftTeamsNotifier extends AbstractStatusChangeNotifier {
      * Message will be used as title of the Activity section of the Teams message when an app
      * registers
      */
-    private String registerActivitySubtitlePattern = "%s with id %s has registered from Spring Boot Admin";
+    private String registerActivitySubtitlePattern = "%s with id %s has registered with Spring Boot Admin";
 
     /**
      * Message will be used as title of the Activity section of the Teams message when an app

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/notify/MicrosoftTeamsNotifier.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/notify/MicrosoftTeamsNotifier.java
@@ -106,8 +106,8 @@ public class MicrosoftTeamsNotifier extends AbstractStatusChangeNotifier {
             message = getDeregisteredMessage(instance);
         } else if (event instanceof InstanceStatusChangedEvent) {
             InstanceStatusChangedEvent statusChangedEvent = (InstanceStatusChangedEvent) event;
-            message = getStatusChangedMessage(instance, statusChangedEvent.getStatusInfo().getStatus(),
-                getLastStatus(event.getInstance()));
+            message = getStatusChangedMessage(instance, getLastStatus(event.getInstance()),
+                statusChangedEvent.getStatusInfo().getStatus());
         } else {
             return Mono.empty();
         }

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/notify/MicrosoftTeamsNotifierTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/notify/MicrosoftTeamsNotifierTest.java
@@ -25,6 +25,7 @@ import de.codecentric.boot.admin.server.domain.values.InstanceId;
 import de.codecentric.boot.admin.server.domain.values.Registration;
 import de.codecentric.boot.admin.server.domain.values.StatusInfo;
 import de.codecentric.boot.admin.server.notify.MicrosoftTeamsNotifier.Message;
+import org.mockito.ArgumentCaptor;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
@@ -34,7 +35,6 @@ import org.junit.Test;
 import org.springframework.web.client.RestTemplate;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -76,8 +76,13 @@ public class MicrosoftTeamsNotifierTest {
 
         StepVerifier.create(notifier.doNotify(event, instance)).verifyComplete();
 
-        verify(mockRestTemplate).postForEntity(eq(URI.create("http://example.com")), any(Message.class),
+        ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
+        verify(mockRestTemplate).postForEntity(eq(URI.create("http://example.com")), messageCaptor.capture(),
             eq(Void.class));
+
+        assertMessage(messageCaptor.getValue(), notifier.getDeRegisteredTitle(), notifier.getMessageSummary(),
+            String.format(notifier.getDeregisterActivitySubtitlePattern(), instance.getRegistration().getName(),
+                instance.getId()));
     }
 
     @Test
@@ -86,8 +91,13 @@ public class MicrosoftTeamsNotifierTest {
 
         StepVerifier.create(notifier.doNotify(event, instance)).verifyComplete();
 
-        verify(mockRestTemplate).postForEntity(eq(URI.create("http://example.com")), any(Message.class),
+        ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
+        verify(mockRestTemplate).postForEntity(eq(URI.create("http://example.com")), messageCaptor.capture(),
             eq(Void.class));
+
+        assertMessage(messageCaptor.getValue(), notifier.getRegisteredTitle(), notifier.getMessageSummary(),
+            String.format(notifier.getRegisterActivitySubtitlePattern(), instance.getRegistration().getName(),
+                instance.getId()));
     }
 
     @Test
@@ -96,8 +106,13 @@ public class MicrosoftTeamsNotifierTest {
 
         StepVerifier.create(notifier.doNotify(event, instance)).verifyComplete();
 
-        verify(mockRestTemplate).postForEntity(eq(URI.create("http://example.com")), any(Message.class),
+        ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
+        verify(mockRestTemplate).postForEntity(eq(URI.create("http://example.com")), messageCaptor.capture(),
             eq(Void.class));
+
+        assertMessage(messageCaptor.getValue(), notifier.getStatusChangedTitle(), notifier.getMessageSummary(),
+            String.format(notifier.getStatusActivitySubtitlePattern(), instance.getRegistration().getName(),
+                instance.getId(), StatusInfo.ofUnknown().getStatus(), StatusInfo.ofUp().getStatus()));
     }
 
     @Test


### PR DESCRIPTION
The to/from statuses were previously inverted. For example for a status change from OFFLINE to UP the message read:

> \<instance> with id <instance_id> changed status from UP to OFFLINE

this pull request changes this to:

> \<instance> with id <instance_id> changed status from OFFLINE to UP 

Also includes a minor improvement to the registration message:

Before:
> \<instance> with id <instance_id> has registered **from** Spring Boot Admin

After:
> \<instance> with id <instance_id> has registered **with** Spring Boot Admin

