### PR TITLE
Fixes Cloud Foundry registration with uppercase letters in route

### DIFF
--- a/spring-boot-admin-client/src/main/java/de/codecentric/boot/admin/client/registration/CloudFoundryApplicationFactory.java
+++ b/spring-boot-admin-client/src/main/java/de/codecentric/boot/admin/client/registration/CloudFoundryApplicationFactory.java
@@ -45,7 +45,7 @@ public class CloudFoundryApplicationFactory extends DefaultApplicationFactory {
             return null;
         }
 
-        String uri = cfApplicationProperties.getUris().get(0).toLowerCase();
+        String uri = cfApplicationProperties.getUris().get(0);
         return "http://" + uri;
     }
 }

--- a/spring-boot-admin-client/src/test/java/de/codecentric/boot/admin/client/registration/CloudFoundryApplicationFactoryTest.java
+++ b/spring-boot-admin-client/src/test/java/de/codecentric/boot/admin/client/registration/CloudFoundryApplicationFactoryTest.java
@@ -50,13 +50,13 @@ public class CloudFoundryApplicationFactoryTest {
     @Test
     public void should_use_application_uri() {
         when(pathMappedEndpoints.getPath("health")).thenReturn("/actuator/health");
-        cfApplicationProperties.setUris(singletonList("application"));
+        cfApplicationProperties.setUris(singletonList("application/Uppercase"));
 
         Application app = factory.createApplication();
 
-        assertThat(app.getManagementUrl()).isEqualTo("http://application/actuator");
-        assertThat(app.getHealthUrl()).isEqualTo("http://application/actuator/health");
-        assertThat(app.getServiceUrl()).isEqualTo("http://application/");
+        assertThat(app.getManagementUrl()).isEqualTo("http://application/Uppercase/actuator");
+        assertThat(app.getHealthUrl()).isEqualTo("http://application/Uppercase/actuator/health");
+        assertThat(app.getServiceUrl()).isEqualTo("http://application/Uppercase/");
     }
 
 }


### PR DESCRIPTION
Before this, the route was always lower-cased, but this makes the route registered with Spring Boot Admin not accessible. This changes to use the route as it is, and updates a test to include an uppercase letter in the route.