### PR TITLE
Add spring-boot-autoconfigure-processor

### DIFF
--- a/spring-boot-admin-client/pom.xml
+++ b/spring-boot-admin-client/pom.xml
@@ -47,6 +47,11 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>
             <optional>true</optional>
         </dependency>

--- a/spring-boot-admin-server-cloud/pom.xml
+++ b/spring-boot-admin-server-cloud/pom.xml
@@ -50,6 +50,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Optional Configuration Processor for metadata -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/spring-boot-admin-server-ui/pom.xml
+++ b/spring-boot-admin-server-ui/pom.xml
@@ -44,6 +44,11 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>
             <optional>true</optional>
         </dependency>

--- a/spring-boot-admin-server/pom.xml
+++ b/spring-boot-admin-server/pom.xml
@@ -70,6 +70,11 @@
             <artifactId>hazelcast</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Optional Configuration Processor for metadata -->
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
This PR adds `spring-boot-autoconfigure-processor` to improve startup time with auto-configurations.

I confirmed 4 `spring-autoconfigure-metadata.properties` files have been created as follows:

```
$ find . -name spring-autoconfigure-metadata.properties
./spring-boot-admin-client/target/classes/META-INF/spring-autoconfigure-metadata.properties
./spring-boot-admin-server-cloud/target/classes/META-INF/spring-autoconfigure-metadata.properties
./spring-boot-admin-server/target/classes/META-INF/spring-autoconfigure-metadata.properties
./spring-boot-admin-server-ui/target/classes/META-INF/spring-autoconfigure-metadata.properties
$ 
```

Closes gh-815