### PR TITLE
Polish AdminServerUiAutoConfiguration.uiExtensions()

### DIFF
--- a/spring-boot-admin-server-ui/src/main/java/de/codecentric/boot/admin/server/ui/config/AdminServerUiAutoConfiguration.java
+++ b/spring-boot-admin-server-ui/src/main/java/de/codecentric/boot/admin/server/ui/config/AdminServerUiAutoConfiguration.java
@@ -74,7 +74,7 @@ public class AdminServerUiAutoConfiguration {
     private List<UiExtension> uiExtensions() throws IOException {
         UiExtensionsScanner scanner = new UiExtensionsScanner(this.applicationContext);
         List<UiExtension> uiExtensions = scanner.scan(this.uiProperties.getExtensionResourceLocations());
-        uiExtensions.forEach(e -> log.info("Loaded Spring Boot Admin UI Extension: {}", e));
+        uiExtensions.forEach(e -> log.info("Loaded Spring Boot Admin UI Extension:", e));
         return uiExtensions;
     }
 


### PR DESCRIPTION
The "{}" won't be used as a formatting anchor with a `Throwable` object, so this PR simply removes it.