### PR TITLE
Issue #885: Support for custom management address

### DIFF
--- a/spring-boot-admin-docs/src/main/asciidoc/server-discovery.adoc
+++ b/spring-boot-admin-docs/src/main/asciidoc/server-discovery.adoc
@@ -56,8 +56,9 @@ user.password
 | Credentials being used to access the endpoints.
 |
 
-| management.port
-| The port is substituted in the service URL and will be used for accessing the actuator endpoints.
+| management.port +
+management.address
+| The address and port are substituted in the service URL and will be used for accessing the actuator endpoints.
 |
 
 | management.context-path

--- a/spring-boot-admin-server-cloud/src/main/java/de/codecentric/boot/admin/server/cloud/discovery/DefaultServiceInstanceConverter.java
+++ b/spring-boot-admin-server-cloud/src/main/java/de/codecentric/boot/admin/server/cloud/discovery/DefaultServiceInstanceConverter.java
@@ -41,6 +41,7 @@ public class DefaultServiceInstanceConverter implements ServiceInstanceConverter
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultServiceInstanceConverter.class);
     private static final String KEY_MANAGEMENT_PORT = "management.port";
     private static final String KEY_MANAGEMENT_PATH = "management.context-path";
+    private static final String KEY_MANAGEMENT_ADDRESS = "management.address";
     private static final String KEY_HEALTH_PATH = "health.path";
 
     /**
@@ -99,12 +100,18 @@ public class DefaultServiceInstanceConverter implements ServiceInstanceConverter
             managamentPort = String.valueOf(serviceUrl.getPort());
         }
 
-        return UriComponentsBuilder.fromUri(serviceUrl)
-                                   .port(managamentPort)
-                                   .path("/")
-                                   .path(managamentPath)
-                                   .build()
-                                   .toUri();
+        final URI uri = UriComponentsBuilder.fromUri(serviceUrl)
+            .port(managamentPort)
+            .path("/")
+            .path(managamentPath)
+            .build()
+            .toUri();
+
+        String managementServerAddress = instance.getMetadata().get(KEY_MANAGEMENT_ADDRESS);
+        if (!isEmpty(managementServerAddress)) {
+            return UriComponentsBuilder.fromUri(uri).host(managementServerAddress).build().toUri();
+        }
+        return uri;
     }
 
     protected URI getServiceUrl(ServiceInstance instance) {

--- a/spring-boot-admin-server-cloud/src/main/java/de/codecentric/boot/admin/server/cloud/discovery/DefaultServiceInstanceConverter.java
+++ b/spring-boot-admin-server-cloud/src/main/java/de/codecentric/boot/admin/server/cloud/discovery/DefaultServiceInstanceConverter.java
@@ -32,7 +32,7 @@ import static org.springframework.util.StringUtils.isEmpty;
  * Converts any {@link ServiceInstance}s to {@link Instance}s. To customize the health- or
  * management-url for all instances you can set healthEndpointPath or managementContextPath
  * respectively. If you want to influence the url per service you can add
- * <code>management.context-path</code> or <code>management.port</code> or <code>health.path</code>
+ * <code>management.context-path</code>, <code>management.port</code>, <code>management.address</code> or <code>health.path</code>
  * to the instances metadata.
  *
  * @author Johannes Edmeier
@@ -109,7 +109,11 @@ public class DefaultServiceInstanceConverter implements ServiceInstanceConverter
 
         String managementServerAddress = instance.getMetadata().get(KEY_MANAGEMENT_ADDRESS);
         if (!isEmpty(managementServerAddress)) {
-            return UriComponentsBuilder.fromUri(uri).host(managementServerAddress).build().toUri();
+            return UriComponentsBuilder
+                .fromUri(uri)
+                .host(managementServerAddress)
+                .build()
+                .toUri();
         }
         return uri;
     }

--- a/spring-boot-admin-server-cloud/src/test/java/de/codecentric/boot/admin/server/cloud/discovery/DefaultServiceInstanceConverterTest.java
+++ b/spring-boot-admin-server-cloud/src/test/java/de/codecentric/boot/admin/server/cloud/discovery/DefaultServiceInstanceConverterTest.java
@@ -61,14 +61,15 @@ public class DefaultServiceInstanceConverterTest {
         metadata.put("health.path", "ping");
         metadata.put("management.context-path", "mgmt");
         metadata.put("management.port", "1234");
+        metadata.put("management.address", "127.0.0.1");
         service.getMetadata().putAll(metadata);
 
         Registration registration = new DefaultServiceInstanceConverter().convert(service);
 
         assertThat(registration.getName()).isEqualTo("test");
         assertThat(registration.getServiceUrl()).isEqualTo("http://localhost:80/");
-        assertThat(registration.getManagementUrl()).isEqualTo("http://localhost:1234/mgmt");
-        assertThat(registration.getHealthUrl()).isEqualTo("http://localhost:1234/mgmt/ping");
+        assertThat(registration.getManagementUrl()).isEqualTo("http://127.0.0.1:1234/mgmt");
+        assertThat(registration.getHealthUrl()).isEqualTo("http://127.0.0.1:1234/mgmt/ping");
         assertThat(registration.getMetadata()).isEqualTo(metadata);
     }
 


### PR DESCRIPTION
Hello,

We are using spring boot admin to monitor multiple spring boot 2 containers over an eureka registry. In our environment, it is mandatory to configure each container's management address different from the service address, so that the management port is bound to a different network address than the service port.

Therefore, each container has the configuration property "management.server.address" set to a different value than "server.address", as well as different values for "management.server.port" and "server.port".

For port configurations, spring boot admin offers the possibility to set the property "management.port" in Eureka's Metadata map, which works great. But for the management address, there is no such solution, so all monitoring (except for health) does not work.

Would it be possible to change DefaultServiceInstanceConverter.getManagementUrl() to also read an additional property from the metadata map?