### PR TITLE
Updated Spring Boot from 2.1.0.M3 to 2.1.0.M4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <url>https://github.com/codecentric/spring-boot-admin/</url>
     <properties>
         <revision>2.1.0-SNAPSHOT</revision>
-        <spring-boot.version>2.1.0.M3</spring-boot.version>
+        <spring-boot.version>2.1.0.M4</spring-boot.version>
         <spring-cloud.version>Finchley.SR1</spring-cloud.version>
         <hazelcast-tests.version>3.9.4</hazelcast-tests.version>
         <java.version>1.8</java.version>

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/client/InstanceWebClient.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/client/InstanceWebClient.java
@@ -78,7 +78,7 @@ public class InstanceWebClient {
                                                     Duration readTimeout,
                                                     WebClientCustomizer customizer) {
         //@formatter:off
-        HttpClient httpClient = HttpClient.create().compress().tcpConfiguration(
+        HttpClient httpClient = HttpClient.create().compress(true).tcpConfiguration(
             tcp -> tcp.bootstrap(
                 bootstrap -> bootstrap.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, (int) connectTimeout.toMillis())
             ).observe(


### PR DESCRIPTION
With Spring Boot 2.1.0.M4 reactor-netty dependency was lifted to 0.8.0.RELEASE.
In this Version reactor.netty.http.client.HttpClient#compress() has a mandatory boolean parameter causing a compilation error in
de.codecentric.boot.admin.server.web.client.InstranceWebClient.
This parameter was set to true.