### PR TITLE
Server context path for Spring Flux

### DIFF
--- a/spring-boot-admin-client/src/main/java/de/codecentric/boot/admin/client/config/InstanceProperties.java
+++ b/spring-boot-admin-client/src/main/java/de/codecentric/boot/admin/client/config/InstanceProperties.java
@@ -16,10 +16,11 @@
 
 package de.codecentric.boot.admin.client.config;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 @lombok.Data
 @ConfigurationProperties(prefix = "spring.boot.admin.client.instance")
@@ -36,8 +37,12 @@ public class InstanceProperties {
     private String managementBaseUrl;
 
     /**
-     * Client-service-URL register with. Inferred at runtime, can be overridden in case the reachable
-     * URL is different (e.g. Docker).
+     * Client-service-URL register with.
+     * Inferred at runtime, can be overridden in case the reachable URL is different (e.g. Docker).
+     * <ul>
+     *     <li>If no value defined, the  `service-base-url`/`service-path` will be used</li>
+     *     <li>If `service-path` is undefined - the part /`service-path` will be missed</li>
+     * </ul>
      */
     private String serviceUrl;
 
@@ -45,6 +50,19 @@ public class InstanceProperties {
      * Base url for computing the service-url to register with. The path is inferred at runtime, and appended to the base url.
      */
     private String serviceBaseUrl;
+
+    /**
+     * Context path of your service.
+     * <p>Defaults:</p>
+     * <ul>
+     *     <li>For `non-reactive` applications the value will use
+     *         value of the standard spring property: `server.servlet.context-path`,
+     *         so, you don't need to define this parameter manually</li>
+     *     <li>For `reactive (web-flux)` applications you can define it if you are
+     *     using any custom context-path for your application/service.</li>
+     * </ul>
+     */
+    private String servicePath;
 
     /**
      * Client-health-URL to register with. Inferred at runtime, can be overridden in case the

--- a/spring-boot-admin-client/src/main/java/de/codecentric/boot/admin/client/registration/DefaultApplicationFactory.java
+++ b/spring-boot-admin-client/src/main/java/de/codecentric/boot/admin/client/registration/DefaultApplicationFactory.java
@@ -18,11 +18,6 @@ package de.codecentric.boot.admin.client.registration;
 
 import de.codecentric.boot.admin.client.config.InstanceProperties;
 import de.codecentric.boot.admin.client.registration.metadata.MetadataContributor;
-
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-import java.util.LinkedHashMap;
-import java.util.Map;
 import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
 import org.springframework.boot.actuate.autoconfigure.web.server.ManagementServerProperties;
 import org.springframework.boot.actuate.endpoint.web.PathMappedEndpoints;
@@ -32,6 +27,11 @@ import org.springframework.boot.web.server.Ssl;
 import org.springframework.context.event.EventListener;
 import org.springframework.util.StringUtils;
 import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  * Default implementation for creating the {@link Application} instance which gets registered at the
@@ -85,8 +85,17 @@ public class DefaultApplicationFactory implements ApplicationFactory {
         }
 
         return UriComponentsBuilder.fromUriString(getServiceBaseUrl())
-                                   .path(getServerContextPath())
+                                   .path("/")
+                                   .path(getServicePath())
                                    .toUriString();
+    }
+
+    protected String getServicePath() {
+        if (instance.getServicePath() != null) {
+            return instance.getServicePath();
+        }
+
+        return getServerContextPath();
     }
 
     protected String getServerContextPath() {

--- a/spring-boot-admin-client/src/main/java/de/codecentric/boot/admin/client/registration/DefaultApplicationFactory.java
+++ b/spring-boot-admin-client/src/main/java/de/codecentric/boot/admin/client/registration/DefaultApplicationFactory.java
@@ -84,7 +84,13 @@ public class DefaultApplicationFactory implements ApplicationFactory {
             return instance.getServiceUrl();
         }
 
-        return UriComponentsBuilder.fromUriString(getServiceBaseUrl()).path("/").toUriString();
+        return UriComponentsBuilder.fromUriString(getServiceBaseUrl())
+                                   .path(getServerContextPath())
+                                   .toUriString();
+    }
+
+    protected String getServerContextPath() {
+        return server.getServlet().getContextPath();
     }
 
     protected String getServiceBaseUrl() {

--- a/spring-boot-admin-client/src/main/java/de/codecentric/boot/admin/client/registration/ServletApplicationFactory.java
+++ b/spring-boot-admin-client/src/main/java/de/codecentric/boot/admin/client/registration/ServletApplicationFactory.java
@@ -50,18 +50,6 @@ public class ServletApplicationFactory extends DefaultApplicationFactory {
 
 
     @Override
-    protected String getServiceUrl() {
-        if (instance.getServiceUrl() != null) {
-            return instance.getServiceUrl();
-        }
-
-        return UriComponentsBuilder.fromUriString(getServiceBaseUrl())
-                                   .path("/")
-                                   .path(getServerContextPath())
-                                   .toUriString();
-    }
-
-    @Override
     protected String getManagementBaseUrl() {
         String baseUrl = instance.getManagementBaseUrl();
 
@@ -90,6 +78,7 @@ public class ServletApplicationFactory extends DefaultApplicationFactory {
         return management.getServlet().getContextPath();
     }
 
+    @Override
     protected String getServerContextPath() {
         return servletContext.getContextPath();
     }

--- a/spring-boot-admin-docs/src/main/asciidoc/client.adoc
+++ b/spring-boot-admin-docs/src/main/asciidoc/client.adoc
@@ -146,8 +146,23 @@ spring.boot.admin.client.password
 | Guessed based on hostname, `server.port`.
 
 | spring.boot.admin.client.instance.service-url
-| Service-url to register with. Can be overridden in case the reachable url is different (e.g. Docker).
-| Guessed based on service-base-url and `server.context-path`.
+| Client-service-URL register with. Inferred at runtime, can be overridden in case the reachable URL is different (e.g. Docker).
+| Defaults:
+
+* If no value defined, the  `service-base-url`/`service-path` will be used
+
+* If `service-path` is undefined - the part /`service-path` will be missed
+
+| spring.boot.admin.client.instance.service-path
+| Context path of your service
+| Defaults:
+
+* For `non-reactive` applications the value will use
+  value of the standard spring property: `server.servlet.context-path`,
+  so, in most cases, you don't need to define this parameter manually
+
+* For `reactive (web-flux)` applications you can define it if you are
+  using any custom context-path for your application/service.
 
 | spring.boot.admin.client.instance.name
 | Name to register with.


### PR DESCRIPTION
support of the `server.servlet.context-path` property for WebFlux

tested with standard spring-web applications
tested with WebFlux with the following setup of root context path:

```
application.yaml
server:
    port: 8080
    servlet.context-path: '/api'
```
```
// Spring Boot Application 

@SpringBootApplication
public class Application {

    public static void main(String[] args) {
        run(Application.class, args);
    }

    @Bean
    public UndertowReactiveWebServerFactory undertowReactiveWebServerFactory(
            @Value("${server.servlet.context-path}") String contextPath
    ) {
        return new UndertowReactiveWebServerFactory() {
            @Override
            public WebServer getWebServer(HttpHandler httpHandler) {
                Map<String, HttpHandler> handlerMap = new HashMap<>();
                handlerMap.put(contextPath, httpHandler);
                return super.getWebServer(new ContextPathCompositeHandler(handlerMap));
            }
        };
    }

}
```


