### PR TITLE
Upgrade to spring boot 2.1 RC1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <url>https://github.com/codecentric/spring-boot-admin/</url>
     <properties>
         <revision>2.1.0-SNAPSHOT</revision>
-        <spring-boot.version>2.1.0.M4</spring-boot.version>
+        <spring-boot.version>2.1.0.RC1</spring-boot.version>
         <spring-cloud.version>Finchley.SR1</spring-cloud.version>
         <hazelcast-tests.version>3.9.4</hazelcast-tests.version>
         <java.version>1.8</java.version>

--- a/spring-boot-admin-client/src/main/java/de/codecentric/boot/admin/client/registration/DefaultApplicationFactory.java
+++ b/spring-boot-admin-client/src/main/java/de/codecentric/boot/admin/client/registration/DefaultApplicationFactory.java
@@ -25,6 +25,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
 import org.springframework.boot.actuate.autoconfigure.web.server.ManagementServerProperties;
+import org.springframework.boot.actuate.endpoint.EndpointId;
 import org.springframework.boot.actuate.endpoint.web.PathMappedEndpoints;
 import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.boot.web.context.WebServerInitializedEvent;
@@ -193,11 +194,11 @@ public class DefaultApplicationFactory implements ApplicationFactory {
     }
 
     protected String getHealthEndpointPath() {
-        String health = pathMappedEndpoints.getPath("health");
+        String health = pathMappedEndpoints.getPath(EndpointId.of("health"));
         if (StringUtils.hasText(health)) {
             return health;
         }
-        String status = pathMappedEndpoints.getPath("status");
+        String status = pathMappedEndpoints.getPath(EndpointId.of("status"));
         if (StringUtils.hasText(status)) {
             return status;
         }

--- a/spring-boot-admin-client/src/test/java/de/codecentric/boot/admin/client/registration/CloudFoundryApplicationFactoryTest.java
+++ b/spring-boot-admin-client/src/test/java/de/codecentric/boot/admin/client/registration/CloudFoundryApplicationFactoryTest.java
@@ -23,6 +23,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
 import org.springframework.boot.actuate.autoconfigure.web.server.ManagementServerProperties;
+import org.springframework.boot.actuate.endpoint.EndpointId;
 import org.springframework.boot.actuate.endpoint.web.PathMappedEndpoints;
 import org.springframework.boot.autoconfigure.web.ServerProperties;
 
@@ -49,7 +50,7 @@ public class CloudFoundryApplicationFactoryTest {
 
     @Test
     public void should_use_application_uri() {
-        when(pathMappedEndpoints.getPath("health")).thenReturn("/actuator/health");
+        when(pathMappedEndpoints.getPath(EndpointId.of("health"))).thenReturn("/actuator/health");
         cfApplicationProperties.setUris(singletonList("application/Uppercase"));
 
         Application app = factory.createApplication();

--- a/spring-boot-admin-client/src/test/java/de/codecentric/boot/admin/client/registration/DefaultApplicationFactoryTest.java
+++ b/spring-boot-admin-client/src/test/java/de/codecentric/boot/admin/client/registration/DefaultApplicationFactoryTest.java
@@ -24,6 +24,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
 import org.springframework.boot.actuate.autoconfigure.web.server.ManagementServerProperties;
+import org.springframework.boot.actuate.endpoint.EndpointId;
 import org.springframework.boot.actuate.endpoint.web.PathMappedEndpoints;
 import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.boot.web.context.WebServerApplicationContext;
@@ -56,7 +57,7 @@ public class DefaultApplicationFactoryTest {
     @Test
     public void test_mgmtPortPath() {
         webEndpoint.setBasePath("/admin");
-        when(pathMappedEndpoints.getPath("health")).thenReturn("/admin/alive");
+        when(pathMappedEndpoints.getPath(EndpointId.of("health"))).thenReturn("/admin/alive");
         publishApplicationReadyEvent(factory, 8080, 8081);
 
         Application app = factory.createApplication();
@@ -68,7 +69,7 @@ public class DefaultApplicationFactoryTest {
     @Test
     public void test_default() {
         instanceProperties.setMetadata(singletonMap("instance", "test"));
-        when(pathMappedEndpoints.getPath("health")).thenReturn("/actuator/health");
+        when(pathMappedEndpoints.getPath(EndpointId.of("health"))).thenReturn("/actuator/health");
         publishApplicationReadyEvent(factory, 8080, null);
 
         Application app = factory.createApplication();
@@ -83,7 +84,7 @@ public class DefaultApplicationFactoryTest {
     public void test_ssl() {
         server.setSsl(new Ssl());
         server.getSsl().setEnabled(true);
-        when(pathMappedEndpoints.getPath("health")).thenReturn("/actuator/health");
+        when(pathMappedEndpoints.getPath(EndpointId.of("health"))).thenReturn("/actuator/health");
         publishApplicationReadyEvent(factory, 8080, null);
 
         Application app = factory.createApplication();
@@ -96,7 +97,7 @@ public class DefaultApplicationFactoryTest {
     public void test_ssl_management() {
         management.setSsl(new Ssl());
         management.getSsl().setEnabled(true);
-        when(pathMappedEndpoints.getPath("health")).thenReturn("/actuator/alive");
+        when(pathMappedEndpoints.getPath(EndpointId.of("health"))).thenReturn("/actuator/alive");
         publishApplicationReadyEvent(factory, 8080, 9090);
 
         Application app = factory.createApplication();
@@ -108,7 +109,7 @@ public class DefaultApplicationFactoryTest {
     @Test
     public void test_preferIpAddress_serveraddress_missing() {
         instanceProperties.setPreferIp(true);
-        when(pathMappedEndpoints.getPath("health")).thenReturn("/application/alive");
+        when(pathMappedEndpoints.getPath(EndpointId.of("health"))).thenReturn("/application/alive");
         publishApplicationReadyEvent(factory, 8080, null);
 
         Application app = factory.createApplication();
@@ -118,7 +119,7 @@ public class DefaultApplicationFactoryTest {
     @Test
     public void test_preferIpAddress_managementaddress_missing() {
         instanceProperties.setPreferIp(true);
-        when(pathMappedEndpoints.getPath("health")).thenReturn("/application/alive");
+        when(pathMappedEndpoints.getPath(EndpointId.of("health"))).thenReturn("/application/alive");
         publishApplicationReadyEvent(factory, 8080, 8081);
 
         Application app = factory.createApplication();
@@ -130,7 +131,7 @@ public class DefaultApplicationFactoryTest {
         instanceProperties.setPreferIp(true);
         server.setAddress(InetAddress.getByName("127.0.0.1"));
         management.setAddress(InetAddress.getByName("127.0.0.2"));
-        when(pathMappedEndpoints.getPath("health")).thenReturn("/actuator/health");
+        when(pathMappedEndpoints.getPath(EndpointId.of("health"))).thenReturn("/actuator/health");
         publishApplicationReadyEvent(factory, 8080, 8081);
 
         Application app = factory.createApplication();
@@ -156,7 +157,7 @@ public class DefaultApplicationFactoryTest {
         instanceProperties.setManagementBaseUrl("http://management:8090");
         instanceProperties.setServiceBaseUrl("http://service:80");
         webEndpoint.setBasePath("/admin");
-        when(pathMappedEndpoints.getPath("health")).thenReturn("/admin/health");
+        when(pathMappedEndpoints.getPath(EndpointId.of("health"))).thenReturn("/admin/health");
 
         Application app = factory.createApplication();
         assertThat(app.getServiceUrl()).isEqualTo("http://service:80/");
@@ -168,7 +169,7 @@ public class DefaultApplicationFactoryTest {
     public void test_service_baseUrl() {
         instanceProperties.setServiceBaseUrl("http://service:80");
         webEndpoint.setBasePath("/admin");
-        when(pathMappedEndpoints.getPath("health")).thenReturn("/admin/health");
+        when(pathMappedEndpoints.getPath(EndpointId.of("health"))).thenReturn("/admin/health");
 
         Application app = factory.createApplication();
         assertThat(app.getServiceUrl()).isEqualTo("http://service:80/");

--- a/spring-boot-admin-client/src/test/java/de/codecentric/boot/admin/client/registration/ServletApplicationFactoryTest.java
+++ b/spring-boot-admin-client/src/test/java/de/codecentric/boot/admin/client/registration/ServletApplicationFactoryTest.java
@@ -25,6 +25,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
 import org.springframework.boot.actuate.autoconfigure.web.server.ManagementServerProperties;
+import org.springframework.boot.actuate.endpoint.EndpointId;
 import org.springframework.boot.actuate.endpoint.web.PathMappedEndpoints;
 import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.boot.autoconfigure.web.servlet.DispatcherServletPath;
@@ -59,7 +60,7 @@ public class ServletApplicationFactoryTest {
     public void test_contextPath_mgmtPath() {
         servletContext.setContextPath("app");
         webEndpoint.setBasePath("/admin");
-        when(pathMappedEndpoints.getPath("health")).thenReturn("/admin/health");
+        when(pathMappedEndpoints.getPath(EndpointId.of("health"))).thenReturn("/admin/health");
         publishApplicationReadyEvent(factory, 8080, null);
 
         Application app = factory.createApplication();
@@ -72,7 +73,7 @@ public class ServletApplicationFactoryTest {
     public void test_contextPath_mgmtPortPath() {
         servletContext.setContextPath("app");
         webEndpoint.setBasePath("/admin");
-        when(pathMappedEndpoints.getPath("health")).thenReturn("/admin/health");
+        when(pathMappedEndpoints.getPath(EndpointId.of("health"))).thenReturn("/admin/health");
         publishApplicationReadyEvent(factory, 8080, 8081);
 
         Application app = factory.createApplication();
@@ -84,7 +85,7 @@ public class ServletApplicationFactoryTest {
     @Test
     public void test_contextPath() {
         servletContext.setContextPath("app");
-        when(pathMappedEndpoints.getPath("health")).thenReturn("/actuator/health");
+        when(pathMappedEndpoints.getPath(EndpointId.of("health"))).thenReturn("/actuator/health");
         publishApplicationReadyEvent(factory, 80, null);
 
         Application app = factory.createApplication();
@@ -97,7 +98,7 @@ public class ServletApplicationFactoryTest {
     public void test_servletPath() {
         when(dispatcherServletPath.getPrefix()).thenReturn("app");
         servletContext.setContextPath("srv");
-        when(pathMappedEndpoints.getPath("health")).thenReturn("/actuator/health");
+        when(pathMappedEndpoints.getPath(EndpointId.of("health"))).thenReturn("/actuator/health");
         publishApplicationReadyEvent(factory, 80, null);
 
         Application app = factory.createApplication();


### PR DESCRIPTION
## Problem

Spring Boot Admin seems incompatible with Spring Boot 2.1 RC1, due to a few API changes in `PathMappedEndpoints`.

## What

This pull request takes a pass at providing support for Spring Boot 2.1 RC1. 

## How

It updates the version number and also fixes a few API changes that deal with retrieving paths for endpoint ids.