### PR TITLE
Pretty print jolokia json responses

### DIFF
--- a/spring-boot-admin-server-ui/src/main/frontend/views/instances/jolokia/m-bean-operation-invocation.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/instances/jolokia/m-bean-operation-invocation.vue
@@ -60,7 +60,7 @@
                 <strong>Execution successful.</strong>
               </div>
             </div>
-            <pre v-text="result" />
+            <pre v-text="prettyPrintedResult" />
           </section>
           <footer class="modal-card-foot">
             <div class="field is-grouped is-grouped-right">
@@ -136,7 +136,25 @@
       args: null,
       result: null
     }),
-    computed: {},
+    computed: {
+      prettyPrintedResult() {
+        var json;
+        var prettyResult;
+          try {
+              json = JSON.parse(this.result);
+          } catch (e) {
+              // do nothing
+          }
+
+          if(json){
+            prettyResult = JSON.stringify(json, undefined, 2);
+          }else{
+            prettyResult = this.result;
+          }
+
+          return prettyResult;
+      }
+    },
     methods: {
       abort() {
         this.onClose();
@@ -156,7 +174,7 @@
         try {
           const result = await this.onExecute(this.args);
           if (result.data.status < 400) {
-            this.result = JSON.stringify(result.data.value, null, 4);
+            this.result = result.data.value;
             this.state = 'completed';
           } else {
             const error = new Error(`Execution failed: ${result.data.error}`);


### PR DESCRIPTION
Hi, 

If the JMX (Jolokia) response text is a JSON value (e.g. for an object representation), it printed currently in a single line. 
<img width="689" alt="screenshot 2018-11-08 at 16 31 23" src="https://user-images.githubusercontent.com/1064818/48211404-b4488680-e379-11e8-8a7c-a24d23a1153b.png">


With this patch the response will be checked whether it is a plain text or a JSON value. In latter case it will be unescaped/parsed and pretty printed in multiple lines to increase readibility. 

![screenshot 2018-11-08 at 17 05 58](https://user-images.githubusercontent.com/1064818/48211423-bad6fe00-e379-11e8-909e-a5d02986e3fe.png)

I hope my pull request will be accepted. 

Kind Regards,
Selim 