### PR TITLE
Replace AngularJS with Vue.js

### DIFF
--- a/spring-boot-admin-docs/src/main/asciidoc/index.adoc
+++ b/spring-boot-admin-docs/src/main/asciidoc/index.adoc
@@ -17,7 +17,7 @@ Johannes Edmeier <https://twitter.com/joshiste[@joshiste]>
 
 codecentric's Spring Boot Admin is a community project to manage and monitor your http://projects.spring.io/spring-boot/[Spring Boot] ^(R)^ applications.
 The applications register with our Spring Boot Admin Client (via HTTP) or are discovered using Spring Cloud ^(R)^ (e.g. Eureka, Consul).
-The UI is just an AngularJs application on top of the Spring Boot Actuator endpoints.
+The UI is just a Vue.js application on top of the Spring Boot Actuator endpoints.
 
 include::getting-started.adoc[]
 


### PR DESCRIPTION
_What is Spring Boot Admin?_ still states the UI is written in AngularJS whereas it's Vue.js.