### PR TITLE
Preserve scheme from 'spring.boot.admin.ui.public-url' property

### DIFF
--- a/spring-boot-admin-server-ui/src/main/java/de/codecentric/boot/admin/server/ui/web/UiController.java
+++ b/spring-boot-admin-server-ui/src/main/java/de/codecentric/boot/admin/server/ui/web/UiController.java
@@ -57,6 +57,9 @@ public class UiController {
     @ModelAttribute(value = "baseUrl", binding = false)
     public String getBaseUrl(UriComponentsBuilder uriBuilder) {
         UriComponents publicComponents = UriComponentsBuilder.fromUriString(publicUrl).build();
+        if (publicComponents.getScheme() != null) {
+            uriBuilder.scheme(publicComponents.getScheme());
+        }
         if (publicComponents.getHost() != null) {
             uriBuilder.host(publicComponents.getHost());
         }

--- a/spring-boot-admin-server-ui/src/test/java/de/codecentric/boot/admin/server/ui/web/UiControllerTest.java
+++ b/spring-boot-admin-server-ui/src/test/java/de/codecentric/boot/admin/server/ui/web/UiControllerTest.java
@@ -60,6 +60,16 @@ public class UiControllerTest {
                .andExpect(model().attribute("baseUrl", "http://public/public/"));
     }
 
+    @Test
+    public void should_use_scheme_host_and_path_from_public_url() throws Exception {
+        MockMvc mockMvc = setupController("https://public/public");
+
+        mockMvc.perform(get("http://example/"))
+            .andExpect(status().isOk())
+            .andExpect(view().name("index"))
+            .andExpect(model().attribute("baseUrl", "https://public/public/"));
+    }
+
     private MockMvc setupController(String publicUrl) {
         return MockMvcBuilders.standaloneSetup(new UiController(publicUrl, "", "", Collections.emptyList()))
                               .setCustomHandlerMapping(() -> new AdminControllerHandlerMapping(""))


### PR DESCRIPTION
The scheme of the `spring.boot.admin.ui.public-url` property is ignored.

See https://github.com/codecentric/spring-boot-admin/issues/1007