### PR TITLE
Missing scheduler shutdown prevents graceful shutdown of the jvm

### DIFF
--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/notify/NotificationTrigger.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/notify/NotificationTrigger.java
@@ -44,8 +44,10 @@ public class NotificationTrigger extends AbstractEventHandler<InstanceEvent> {
     @Override
     public void stop() {
         super.stop();
-        scheduler.dispose();
-        scheduler = null;
+        if (scheduler != null) {
+            scheduler.dispose();
+            scheduler = null;
+        }
     }
 
     @Override

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/notify/NotificationTrigger.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/notify/NotificationTrigger.java
@@ -20,12 +20,14 @@ import de.codecentric.boot.admin.server.domain.events.InstanceEvent;
 import de.codecentric.boot.admin.server.services.AbstractEventHandler;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 
 import org.reactivestreams.Publisher;
 
 public class NotificationTrigger extends AbstractEventHandler<InstanceEvent> {
     private final Notifier notifier;
+    private Scheduler scheduler;
 
     public NotificationTrigger(Notifier notifier, Publisher<InstanceEvent> publisher) {
         super(publisher, InstanceEvent.class);
@@ -33,8 +35,22 @@ public class NotificationTrigger extends AbstractEventHandler<InstanceEvent> {
     }
 
     @Override
+    public void start() {
+        assert scheduler == null;
+        scheduler = Schedulers.newSingle("notifications");
+        super.start();
+    }
+
+    @Override
+    public void stop() {
+        super.stop();
+        scheduler.dispose();
+        scheduler = null;
+    }
+
+    @Override
     protected Publisher<Void> handle(Flux<InstanceEvent> publisher) {
-        return publisher.subscribeOn(Schedulers.newSingle("notifications")).flatMap(this::sendNotifications);
+        return publisher.subscribeOn(scheduler).flatMap(this::sendNotifications);
     }
 
     protected Mono<Void> sendNotifications(InstanceEvent event) {

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/notify/RemindingNotifier.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/notify/RemindingNotifier.java
@@ -90,8 +90,10 @@ public class RemindingNotifier extends AbstractEventNotifier {
             log.debug("stopped reminders");
             this.subscription.dispose();
         }
-        scheduler.dispose();
-        scheduler = null;
+        if (scheduler != null) {
+            scheduler.dispose();
+            scheduler = null;
+        }
     }
 
     protected Mono<Void> sendReminders() {

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/notify/RemindingNotifier.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/notify/RemindingNotifier.java
@@ -25,6 +25,7 @@ import de.codecentric.boot.admin.server.domain.values.InstanceId;
 import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 
 import java.time.Duration;
@@ -51,6 +52,7 @@ public class RemindingNotifier extends AbstractEventNotifier {
     private String[] reminderStatuses = {"DOWN", "OFFLINE"};
     @Nullable
     private Disposable subscription;
+    private Scheduler scheduler;
 
     public RemindingNotifier(Notifier delegate, InstanceRepository repository) {
         super(repository);
@@ -69,9 +71,10 @@ public class RemindingNotifier extends AbstractEventNotifier {
         }));
     }
 
-
     public void start() {
-        this.subscription = Flux.interval(this.checkReminderInverval, Schedulers.newSingle("reminders"))
+        assert scheduler == null;
+        scheduler = Schedulers.newSingle("reminders");
+        this.subscription = Flux.interval(this.checkReminderInverval, scheduler)
                                 .log(log.getName(), Level.FINEST)
                                 .doOnSubscribe(s -> log.debug("Started reminders"))
                                 .flatMap(i -> this.sendReminders())
@@ -87,6 +90,8 @@ public class RemindingNotifier extends AbstractEventNotifier {
             log.debug("stopped reminders");
             this.subscription.dispose();
         }
+        scheduler.dispose();
+        scheduler = null;
     }
 
     protected Mono<Void> sendReminders() {

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/EndpointDetectionTrigger.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/EndpointDetectionTrigger.java
@@ -45,8 +45,10 @@ public class EndpointDetectionTrigger extends AbstractEventHandler<InstanceEvent
     @Override
     public void stop() {
         super.stop();
-        scheduler.dispose();
-        scheduler = null;
+        if (scheduler != null) {
+            scheduler.dispose();
+            scheduler = null;
+        }
     }
 
     @Override

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/EndpointDetectionTrigger.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/EndpointDetectionTrigger.java
@@ -21,12 +21,14 @@ import de.codecentric.boot.admin.server.domain.events.InstanceRegistrationUpdate
 import de.codecentric.boot.admin.server.domain.events.InstanceStatusChangedEvent;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 
 import org.reactivestreams.Publisher;
 
 public class EndpointDetectionTrigger extends AbstractEventHandler<InstanceEvent> {
     private final EndpointDetector endpointDetector;
+    private Scheduler scheduler;
 
     public EndpointDetectionTrigger(EndpointDetector endpointDetector, Publisher<InstanceEvent> publisher) {
         super(publisher, InstanceEvent.class);
@@ -34,8 +36,22 @@ public class EndpointDetectionTrigger extends AbstractEventHandler<InstanceEvent
     }
 
     @Override
+    public void start() {
+        assert scheduler == null;
+        scheduler = Schedulers.newSingle("endpoint-detector");
+        super.start();
+    }
+
+    @Override
+    public void stop() {
+        super.stop();
+        scheduler.dispose();
+        scheduler = null;
+    }
+
+    @Override
     protected Publisher<Void> handle(Flux<InstanceEvent> publisher) {
-        return publisher.subscribeOn(Schedulers.newSingle("endpoint-detector"))
+        return publisher.subscribeOn(scheduler)
                         .filter(event -> event instanceof InstanceStatusChangedEvent ||
                                          event instanceof InstanceRegistrationUpdatedEvent)
                         .flatMap(this::detectEndpoints);

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/InfoUpdateTrigger.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/InfoUpdateTrigger.java
@@ -22,12 +22,14 @@ import de.codecentric.boot.admin.server.domain.events.InstanceRegistrationUpdate
 import de.codecentric.boot.admin.server.domain.events.InstanceStatusChangedEvent;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 
 import org.reactivestreams.Publisher;
 
 public class InfoUpdateTrigger extends AbstractEventHandler<InstanceEvent> {
     private final InfoUpdater infoUpdater;
+    private Scheduler scheduler;
 
     public InfoUpdateTrigger(InfoUpdater infoUpdater, Publisher<InstanceEvent> publisher) {
         super(publisher, InstanceEvent.class);
@@ -35,8 +37,22 @@ public class InfoUpdateTrigger extends AbstractEventHandler<InstanceEvent> {
     }
 
     @Override
+    public void start() {
+        assert scheduler == null;
+        scheduler = Schedulers.newSingle("info-updater");
+        super.start();
+    }
+
+    @Override
+    public void stop() {
+        super.stop();
+        scheduler.dispose();
+        scheduler = null;
+    }
+
+    @Override
     protected Publisher<Void> handle(Flux<InstanceEvent> publisher) {
-        return publisher.subscribeOn(Schedulers.newSingle("info-updater"))
+        return publisher.subscribeOn(scheduler)
                         .filter(event -> event instanceof InstanceEndpointsDetectedEvent ||
                                          event instanceof InstanceStatusChangedEvent ||
                                          event instanceof InstanceRegistrationUpdatedEvent)

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/InfoUpdateTrigger.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/InfoUpdateTrigger.java
@@ -46,8 +46,10 @@ public class InfoUpdateTrigger extends AbstractEventHandler<InstanceEvent> {
     @Override
     public void stop() {
         super.stop();
-        scheduler.dispose();
-        scheduler = null;
+        if (scheduler != null) {
+            scheduler.dispose();
+            scheduler = null;
+        }
     }
 
     @Override

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/StatusUpdateTrigger.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/StatusUpdateTrigger.java
@@ -84,10 +84,14 @@ public class StatusUpdateTrigger extends AbstractEventHandler<InstanceEvent> {
         if (intervalSubscription != null) {
             intervalSubscription.dispose();
         }
-        statusUpdaterScheduler.dispose();
-        statusUpdaterScheduler = null;
-        statusMonitorScheduler.dispose();
-        statusMonitorScheduler = null;
+        if (statusUpdaterScheduler != null) {
+            statusUpdaterScheduler.dispose();
+            statusUpdaterScheduler = null;
+        }
+        if (statusMonitorScheduler != null) {
+            statusMonitorScheduler.dispose();
+            statusMonitorScheduler = null;
+        }
     }
 
     protected Mono<Void> updateStatusForAllInstances() {

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/StatusUpdateTrigger.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/StatusUpdateTrigger.java
@@ -23,6 +23,7 @@ import de.codecentric.boot.admin.server.domain.values.InstanceId;
 import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 
 import java.time.Duration;
@@ -43,7 +44,8 @@ public class StatusUpdateTrigger extends AbstractEventHandler<InstanceEvent> {
     private Duration statusLifetime = Duration.ofSeconds(10);
     @Nullable
     private Disposable intervalSubscription;
-
+    private Scheduler statusMonitorScheduler;
+    private Scheduler statusUpdaterScheduler;
 
     public StatusUpdateTrigger(StatusUpdater statusUpdater, Publisher<InstanceEvent> publisher) {
         super(publisher, InstanceEvent.class);
@@ -52,11 +54,15 @@ public class StatusUpdateTrigger extends AbstractEventHandler<InstanceEvent> {
 
     @Override
     public void start() {
+        assert statusMonitorScheduler == null;
+        statusMonitorScheduler = Schedulers.newSingle("status-monitor");
+        assert statusUpdaterScheduler == null;
+        statusUpdaterScheduler = Schedulers.newSingle("status-updater");
         super.start();
         intervalSubscription = Flux.interval(updateInterval)
                                    .doOnSubscribe(s -> log.debug("Scheduled status update every {}", updateInterval))
                                    .log(log.getName(), Level.FINEST)
-                                   .subscribeOn(Schedulers.newSingle("status-monitor"))
+                                   .subscribeOn(statusMonitorScheduler)
                                    .concatMap(i -> this.updateStatusForAllInstances())
                                    .onErrorContinue((ex, value) -> log.warn("Unexpected error while updating statuses",
                                        ex
@@ -66,7 +72,7 @@ public class StatusUpdateTrigger extends AbstractEventHandler<InstanceEvent> {
 
     @Override
     protected Publisher<Void> handle(Flux<InstanceEvent> publisher) {
-        return publisher.subscribeOn(Schedulers.newSingle("status-updater"))
+        return publisher.subscribeOn(statusUpdaterScheduler)
                         .filter(event -> event instanceof InstanceRegisteredEvent ||
                                          event instanceof InstanceRegistrationUpdatedEvent)
                         .flatMap(event -> updateStatus(event.getInstance()));
@@ -78,6 +84,10 @@ public class StatusUpdateTrigger extends AbstractEventHandler<InstanceEvent> {
         if (intervalSubscription != null) {
             intervalSubscription.dispose();
         }
+        statusUpdaterScheduler.dispose();
+        statusUpdaterScheduler = null;
+        statusMonitorScheduler.dispose();
+        statusMonitorScheduler = null;
     }
 
     protected Mono<Void> updateStatusForAllInstances() {


### PR DESCRIPTION
Left open (non-daemon) threads cause the Spring Boot Admin management server not to properly exit the JVM when using the Shutdown Actuator endpoints, for example. The threads are created because reactive schedulers are not being disposed off when beans are destructed. This PR fixes the issue.