### PR TITLE
Fix sba-time-ago test

### DIFF
--- a/spring-boot-admin-server-ui/src/main/frontend/components/sba-time-ago.spec.js
+++ b/spring-boot-admin-server-ui/src/main/frontend/components/sba-time-ago.spec.js
@@ -26,7 +26,7 @@ describe('time-ago', () => {
     it('should match the snapshot', () => {
       const wrapper = shallowMount(sbaTimeAgo, {
         propsData: {
-          date: moment(1318781000000)
+          date: moment(1318781000000).utc()
         }
       });
       expect(wrapper.vm.$el).toMatchSnapshot();
@@ -37,7 +37,7 @@ describe('time-ago', () => {
     it('should match the snapshot', () => {
       const wrapper = shallowMount(sbaTimeAgo, {
         propsData: {
-          date: moment(1310000000000)
+          date: moment(1310000000000).utc()
         }
       });
       expect(wrapper.vm.$el).toMatchSnapshot();


### PR DESCRIPTION
Using moment(Number) method creates a moment in the machines local time zone.

This causes the "given a long time passed time" test to fail when running in PST, as it would resolve to Jul 6 and not Jul 7 like the snapshot. 
