### PR TITLE
The event handler should continue when it encounters an error.

### DIFF
--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/AbstractEventHandler.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/AbstractEventHandler.java
@@ -49,6 +49,7 @@ public abstract class AbstractEventHandler<T extends InstanceEvent> {
                            .retryWhen(Retry.any()
                                            .retryMax(Long.MAX_VALUE)
                                            .doOnRetry(ctx -> log.warn("Unexpected error", ctx.exception())))
+                           .onErrorContinue((ex, value) -> log.warn("Unexpected error while handling {}", value, ex))
                            .subscribe();
     }
 

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/EndpointDetector.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/EndpointDetector.java
@@ -45,8 +45,7 @@ public class EndpointDetector {
 
     private Mono<Instance> doDetectEndpoints(Instance instance) {
         if (!StringUtils.hasText(instance.getRegistration().getManagementUrl()) ||
-            instance.getStatusInfo().isOffline() ||
-            instance.getStatusInfo().isUnknown()) {
+            !instance.getStatusInfo().isUp()) {
             return Mono.empty();
         }
         log.debug("Detect endpoints for {}", instance);


### PR DESCRIPTION
This is a fix for #1128.

It also tries to reduce the amount of errors by only detecting endpoints of instances in UP state.