### PR TITLE
Fixed typos in documentation

### DIFF
--- a/spring-boot-admin-docs/src/main/asciidoc/changes-2.x.adoc
+++ b/spring-boot-admin-docs/src/main/asciidoc/changes-2.x.adoc
@@ -22,7 +22,7 @@ As some of the actuator endpoints changed with the Spring Boot 2 release not all
 === UI
 * Rewritten ui using vue.js
 * Integrated ui-login module into the main ui module
-* Removed ui-activiti module, as it was only used rarely
+* Removed ui-activity module, as it was only used rarely
 * Removed Hystrix-Dashboard integration (subject to change)
 * Added support for the session endpoint
 * Added display of the (sanitized) metadata
@@ -31,7 +31,7 @@ As some of the actuator endpoints changed with the Spring Boot 2 release not all
 
 === Backend
 * Moved all classes to the `spring.boot.admin.server` package
-* Spring cloud related extenstions moved to `spring-boot-admin-server-cloud`.
+* Spring cloud related extensions moved to `spring-boot-admin-server-cloud`.
 * Redesigned backend using event sourcing principles
 * Added concept of applications (consisting of 1 to n instances)
 * Moved endpoint detection to the backend by querying the `/actuator`-index or by probing via OPTIONS request

--- a/spring-boot-admin-docs/src/main/asciidoc/client.adoc
+++ b/spring-boot-admin-docs/src/main/asciidoc/client.adoc
@@ -82,7 +82,7 @@ info.tags.environment=test
 
 The Spring Boot Admin Client registers the application at the admin server. This is done by periodically doing a HTTP post request to the SBA Server providing information about the application. It also adds Jolokia to your application, so that JMX-beans are accessible via HTTP.
 
-TIP: There are plenty of properties to influence the way how the SBA Client registers your application. In case that doesn't fit your needs, you can provide your own `AppliationFactory` implementation.
+TIP: There are plenty of properties to influence the way how the SBA Client registers your application. In case that doesn't fit your needs, you can provide your own `ApplicationFactory` implementation.
 
 .Spring Boot Admin Client configuration options
 |===

--- a/spring-boot-admin-docs/src/main/asciidoc/customizing.adoc
+++ b/spring-boot-admin-docs/src/main/asciidoc/customizing.adoc
@@ -48,7 +48,7 @@ include::{samples-dir}/spring-boot-admin-sample-servlet/src/main/resources/appli
 
 It is possible to add custom views to the ui. The views must be implemented as https://vuejs.org/[Vue.js] components.
 
-The Javascript-Bundle and Css-Stylesheet must be placed on the classpath at `/META-INF/spring-boot-admin-server-ui/extensions/{name}/` so the server can pick them up.
+The JavaScript-Bundle and CSS-Stylesheet must be placed on the classpath at `/META-INF/spring-boot-admin-server-ui/extensions/{name}/` so the server can pick them up.
 The {github-src}/spring-boot-admin-samples/spring-boot-admin-sample-custom-ui/[spring-boot-admin-sample-custom-ui] module contains a sample which has the necessary maven setup to build such a module.
 
 The custom extension registers itself by calling `SBA.use()` and need to expose a `install()` function, which is called by the ui when setting up the routes.

--- a/spring-boot-admin-docs/src/main/asciidoc/customizing.adoc
+++ b/spring-boot-admin-docs/src/main/asciidoc/customizing.adoc
@@ -48,11 +48,11 @@ include::{samples-dir}/spring-boot-admin-sample-servlet/src/main/resources/appli
 
 It is possible to add custom views to the ui. The views must be implemented as https://vuejs.org/[Vue.js] components.
 
-The Javascript-Bundle and Css-Stlysheet must be placed on the classpath at `/META-INF/spring-boot-admin-server-ui/extensions/{name}/` so the server can pick them up.
+The Javascript-Bundle and Css-Stylesheet must be placed on the classpath at `/META-INF/spring-boot-admin-server-ui/extensions/{name}/` so the server can pick them up.
 The {github-src}/spring-boot-admin-samples/spring-boot-admin-sample-custom-ui/[spring-boot-admin-sample-custom-ui] module contains a sample which has the necessary maven setup to build such a module.
 
 The custom extension registers itself by calling `SBA.use()` and need to expose a `install()` function, which is called by the ui when setting up the routes.
-The `install()` function receives the folliwing parameters in order to register views and/or callbacks:
+The `install()` function receives the following parameters in order to register views and/or callbacks:
 
 * Object referencing the {github-src}/spring-boot-admin-server-ui/src/main/frontend/viewRegistry.js[viewRegistry]
 

--- a/spring-boot-admin-docs/src/main/asciidoc/security.adoc
+++ b/spring-boot-admin-docs/src/main/asciidoc/security.adoc
@@ -16,7 +16,7 @@ include::{samples-dir}/spring-boot-admin-sample-servlet/src/main/java/de/codecen
 <3> Configures login and logout.
 <4> Enables HTTP-Basic support. This is needed for the Spring Boot Admin Client to register.
 <5> Enables CSRF-Protection using Cookies
-<6> Disables CSRF-Protection the endpoint the Spring Boot Admin Client uses to register.
+<6> Disables CSRF-Protection for the endpoint the Spring Boot Admin Client uses to register.
 <7> Disables CSRF-Protection for the actuator endpoints.
 
 In case you use the Spring Boot Admin Client, it needs the credentials for accessing the server:

--- a/spring-boot-admin-docs/src/main/asciidoc/security.adoc
+++ b/spring-boot-admin-docs/src/main/asciidoc/security.adoc
@@ -16,8 +16,8 @@ include::{samples-dir}/spring-boot-admin-sample-servlet/src/main/java/de/codecen
 <3> Configures login and logout.
 <4> Enables HTTP-Basic support. This is needed for the Spring Boot Admin Client to register.
 <5> Enables CSRF-Protection using Cookies
-<6> Disables CRSF-Protection the endpoint the Spring Boot Admin Client uses to register.
-<7> Disables CRSF-Protection for the actuator endpoints.
+<6> Disables CSRF-Protection the endpoint the Spring Boot Admin Client uses to register.
+<7> Disables CSRF-Protection for the actuator endpoints.
 
 In case you use the Spring Boot Admin Client, it needs the credentials for accessing the server:
 [source,yaml]

--- a/spring-boot-admin-docs/src/main/asciidoc/server-discovery.adoc
+++ b/spring-boot-admin-docs/src/main/asciidoc/server-discovery.adoc
@@ -66,7 +66,7 @@ user.password
 
 | management.context-path
 | The path is appended to the service URL and will be used for accessing the actuator endpoints.
-| `${spring.boot.admin.discovery.converter.mangement-context-path}`
+| `${spring.boot.admin.discovery.converter.management-context-path}`
 
 | health.path
 | The path is appended to the service URL and will be used for the health-checking. Ignored by the `EurekaServiceInstanceConverter`.

--- a/spring-boot-admin-docs/src/main/asciidoc/server-notifications.adoc
+++ b/spring-boot-admin-docs/src/main/asciidoc/server-notifications.adoc
@@ -37,7 +37,7 @@ The `FilteringNotifier` allows you to filter certain notification based on rules
 
 If you add a `FilteringNotifier` to your `ApplicationContext` a RESTful interface on `notifications/filter` gets available.
 
-This notifier is useful if you don't want recieve notifications when deploying your applications. Before stopping the application you can add an (expiring) filter either via a `POST` request.
+This notifier is useful if you don't want receive notifications when deploying your applications. Before stopping the application you can add an (expiring) filter either via a `POST` request.
 
 .How to configure filtering
 [source,java,indent=0]
@@ -96,7 +96,7 @@ spring.boot.admin.notify.mail.to=admin@example.com
 | `"UNKNOWN:UP"`
 
 | spring.boot.admin.notify.mail.template
-| Resource path to the Thymelef template used for rendering.
+| Resource path to the Thymeleaf template used for rendering.
 | `"classpath:/META-INF/spring-boot-admin-server/mail/status-changed.html"`
 
 | spring.boot.admin.notify.mail.to
@@ -358,7 +358,7 @@ To enable https://telegram.org/[Telegram] notifications you need to create and a
 | `true`
 
 | spring.boot.admin.notify.telegram.auth-token
-| The token identifiying und authorizing your Telegram bot (e.g. `123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11`).
+| The token identifying und authorizing your Telegram bot (e.g. `123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11`).
 |
 
 | spring.boot.admin.notify.telegram.chat-id

--- a/spring-boot-admin-docs/src/main/asciidoc/server.adoc
+++ b/spring-boot-admin-docs/src/main/asciidoc/server.adoc
@@ -31,7 +31,7 @@ In addition when the reverse proxy terminates the https connection, it may be ne
 | 1m
 
 | spring.boot.admin.monitor.default-timeout
-| Default timeout when making requests. Individual values for specific endpoints can be overriden using `spring.boot.admin.monitor.timeout.*`.
+| Default timeout when making requests. Individual values for specific endpoints can be overridden using `spring.boot.admin.monitor.timeout.*`.
 | 10,000
 
 | spring.boot.admin.monitor.timeout.*
@@ -39,11 +39,11 @@ In addition when the reverse proxy terminates the https connection, it may be ne
 |
 
 | spring.boot.admin.monitor.default-retries
-| Default number of retries for failed requests. Modyfing requests (`PUT`, `POST`, `PATCH`, `DELETE`) are never retried. Individual values for specific endpoints can be overriden using `spring.boot.admin.monitor.retries.*`.
+| Default number of retries for failed requests. Modifying requests (`PUT`, `POST`, `PATCH`, `DELETE`) are never retried. Individual values for specific endpoints can be overridden using `spring.boot.admin.monitor.retries.*`.
 | 0
 
 | spring.boot.admin.monitor.retries.*
-| Key-Value-Pairs with the number of retries per endpointId. Defaults to default-retries. Modyfing requests (`PUT`, `POST`, `PATCH`, `DELETE`) are never retried.
+| Key-Value-Pairs with the number of retries per endpointId. Defaults to default-retries. Modifying requests (`PUT`, `POST`, `PATCH`, `DELETE`) are never retried.
 |
 
 | spring.boot.admin.metadata-keys-to-sanitize


### PR DESCRIPTION
I noticed two typos in one of the recent commits and decided to open a pull request to correct it.