### PR TITLE
Use application/javascript

### DIFF
--- a/spring-boot-admin-server-ui/src/main/java/de/codecentric/boot/admin/server/ui/web/UiController.java
+++ b/spring-boot-admin-server-ui/src/main/java/de/codecentric/boot/admin/server/ui/web/UiController.java
@@ -100,7 +100,7 @@ public class UiController {
         return "index";
     }
 
-    @GetMapping(path = "/sba-settings.js", produces = "text/javascript")
+    @GetMapping(path = "/sba-settings.js", produces = "application/javascript")
     public String sbaSettings() {
         return "sba-settings.js";
     }


### PR DESCRIPTION
This PR changes to use `application/javascript` as [`text/javascript` seems obsolete](https://tools.ietf.org/html/rfc4329#section-7.1).