### PR TITLE
Add an application registry service

### DIFF
--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerAutoConfiguration.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerAutoConfiguration.java
@@ -20,7 +20,9 @@ import de.codecentric.boot.admin.server.domain.entities.InstanceRepository;
 import de.codecentric.boot.admin.server.domain.entities.SnapshottingInstanceRepository;
 import de.codecentric.boot.admin.server.domain.events.InstanceEvent;
 import de.codecentric.boot.admin.server.eventstore.InMemoryEventStore;
+import de.codecentric.boot.admin.server.eventstore.InstanceEventPublisher;
 import de.codecentric.boot.admin.server.eventstore.InstanceEventStore;
+import de.codecentric.boot.admin.server.services.ApplicationRegistry;
 import de.codecentric.boot.admin.server.services.EndpointDetectionTrigger;
 import de.codecentric.boot.admin.server.services.EndpointDetector;
 import de.codecentric.boot.admin.server.services.HashingInstanceUrlIdGenerator;
@@ -62,6 +64,13 @@ public class AdminServerAutoConfiguration {
     public InstanceRegistry instanceRegistry(InstanceRepository instanceRepository,
                                              InstanceIdGenerator instanceIdGenerator) {
         return new InstanceRegistry(instanceRepository, instanceIdGenerator);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ApplicationRegistry applicationRegistry(InstanceRegistry instanceRegistry,
+                                                   InstanceEventPublisher instanceEventPublisher) {
+        return new ApplicationRegistry(instanceRegistry, instanceEventPublisher);
     }
 
     @Bean

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerWebConfiguration.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerWebConfiguration.java
@@ -17,8 +17,8 @@
 package de.codecentric.boot.admin.server.config;
 
 import de.codecentric.boot.admin.server.domain.values.Registration;
-import de.codecentric.boot.admin.server.eventstore.InstanceEventPublisher;
 import de.codecentric.boot.admin.server.eventstore.InstanceEventStore;
+import de.codecentric.boot.admin.server.services.ApplicationRegistry;
 import de.codecentric.boot.admin.server.services.InstanceRegistry;
 import de.codecentric.boot.admin.server.utils.jackson.RegistrationBeanSerializerModifier;
 import de.codecentric.boot.admin.server.utils.jackson.RegistrationDeserializer;
@@ -62,9 +62,8 @@ public class AdminServerWebConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public ApplicationsController applicationsController(InstanceRegistry instanceRegistry,
-                                                         InstanceEventPublisher eventPublisher) {
-        return new ApplicationsController(instanceRegistry, eventPublisher);
+    public ApplicationsController applicationsController(ApplicationRegistry applicationRegistry) {
+        return new ApplicationsController(applicationRegistry);
     }
 
     @Configuration

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/domain/entities/Application.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/domain/entities/Application.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2014-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.codecentric.boot.admin.server.domain.entities;
+
+import de.codecentric.boot.admin.server.domain.values.BuildVersion;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nullable;
+
+import static de.codecentric.boot.admin.server.domain.values.StatusInfo.STATUS_UNKNOWN;
+
+@lombok.Data
+public class Application {
+
+    private final String name;
+    @Nullable
+    private BuildVersion buildVersion;
+    private String status = STATUS_UNKNOWN;
+    private Instant statusTimestamp = Instant.now();
+    private List<Instance> instances = new ArrayList<>();
+
+}

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/ApplicationRegistry.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/ApplicationRegistry.java
@@ -56,7 +56,7 @@ public class ApplicationRegistry {
     }
 
     /**
-     * Get a list of all registered instances.
+     * Get a list of all registered applications.
      *
      * @return List of all the applications.
      */
@@ -67,6 +67,9 @@ public class ApplicationRegistry {
             .flatMap(grouped -> toApplication(grouped.key(), grouped), Integer.MAX_VALUE);
     }
 
+    /**
+     * Get a specific application instance.
+     */
     public Mono<Application> getApplication(String name) {
         return this.toApplication(name, instanceRegistry.getInstances(name).filter(Instance::isRegistered))
             .filter(a -> !a.getInstances().isEmpty());

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/ApplicationRegistry.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/ApplicationRegistry.java
@@ -41,6 +41,8 @@ import static java.util.stream.Collectors.toMap;
 /**
  * Registry for all applications that should be managed/administrated by the Spring Boot Admin
  * server. Backed by an InstanceRegistry for persistence and an InstanceEventPublisher for events
+ *
+ * @author Dean de Bree
  */
 public class ApplicationRegistry {
 
@@ -82,12 +84,12 @@ public class ApplicationRegistry {
             .flatMap(instance -> instanceRegistry.deregister(instance.getId()));
     }
 
-    private Tuple2<String, Flux<Instance>> getApplicationForInstance(Instance instance) {
+    protected Tuple2<String, Flux<Instance>> getApplicationForInstance(Instance instance) {
         String name = instance.getRegistration().getName();
         return Tuples.of(name, instanceRegistry.getInstances(name).filter(Instance::isRegistered));
     }
 
-    private Mono<Application> toApplication(String name, Flux<Instance> instances) {
+    protected Mono<Application> toApplication(String name, Flux<Instance> instances) {
         return instances.collectList().map(instanceList -> {
             Application group = new Application(name);
             group.setInstances(instanceList);
@@ -100,7 +102,7 @@ public class ApplicationRegistry {
     }
 
     @Nullable
-    private BuildVersion getBuildVersion(List<Instance> instances) {
+    protected BuildVersion getBuildVersion(List<Instance> instances) {
         List<BuildVersion> versions = instances.stream()
             .map(Instance::getBuildVersion)
             .filter(Objects::nonNull)
@@ -146,7 +148,7 @@ public class ApplicationRegistry {
             .orElse(Tuples.of(STATUS_UNKNOWN, Instant.EPOCH));
     }
 
-    private Instant getMax(Instant t1, Instant t2) {
+    protected Instant getMax(Instant t1, Instant t2) {
         return t1.compareTo(t2) >= 0 ? t1 : t2;
     }
 

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/ApplicationRegistry.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/ApplicationRegistry.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2014-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.codecentric.boot.admin.server.services;
+
+import de.codecentric.boot.admin.server.domain.entities.Application;
+import de.codecentric.boot.admin.server.domain.entities.Instance;
+import de.codecentric.boot.admin.server.domain.values.BuildVersion;
+import de.codecentric.boot.admin.server.domain.values.InstanceId;
+import de.codecentric.boot.admin.server.domain.values.StatusInfo;
+import de.codecentric.boot.admin.server.eventstore.InstanceEventPublisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.util.function.Tuple2;
+import reactor.util.function.Tuples;
+
+import javax.annotation.Nullable;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static de.codecentric.boot.admin.server.domain.values.StatusInfo.STATUS_UNKNOWN;
+import static java.util.Comparator.naturalOrder;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
+
+/**
+ * Registry for all applications that should be managed/administrated by the Spring Boot Admin
+ * server. Backed by an InstanceRegistry for persistence and an InstanceEventPublisher for events
+ */
+public class ApplicationRegistry {
+
+    private final InstanceRegistry instanceRegistry;
+    private final InstanceEventPublisher instanceEventPublisher;
+
+    public ApplicationRegistry(InstanceRegistry instanceRegistry,
+                               InstanceEventPublisher instanceEventPublisher) {
+        this.instanceRegistry = instanceRegistry;
+        this.instanceEventPublisher = instanceEventPublisher;
+    }
+
+    /**
+     * Get a list of all registered instances.
+     *
+     * @return List of all instances.
+     */
+    public Flux<Application> getApplications() {
+        return instanceRegistry.getInstances()
+            .filter(Instance::isRegistered)
+            .groupBy(instance -> instance.getRegistration().getName())
+            .flatMap(grouped -> toApplication(grouped.key(), grouped), Integer.MAX_VALUE);
+    }
+
+    public Mono<Application> getApplication(String name) {
+        return this.toApplication(name, instanceRegistry.getInstances(name).filter(Instance::isRegistered))
+            .filter(a -> !a.getInstances().isEmpty());
+    }
+
+    public Flux<Application> getApplicationStream() {
+        return Flux.from(instanceEventPublisher)
+            .flatMap(event -> instanceRegistry.getInstance(event.getInstance()))
+            .map(this::getApplicationForInstance)
+            .flatMap(group -> toApplication(group.getT1(), group.getT2()));
+    }
+
+    public Flux<InstanceId> deregister(String name) {
+        return instanceRegistry.getInstances(name)
+            .flatMap(instance -> instanceRegistry.deregister(instance.getId()));
+    }
+
+    private Tuple2<String, Flux<Instance>> getApplicationForInstance(Instance instance) {
+        String name = instance.getRegistration().getName();
+        return Tuples.of(name, instanceRegistry.getInstances(name).filter(Instance::isRegistered));
+    }
+
+    private Mono<Application> toApplication(String name, Flux<Instance> instances) {
+        return instances.collectList().map(instanceList -> {
+            Application group = new Application(name);
+            group.setInstances(instanceList);
+            group.setBuildVersion(getBuildVersion(instanceList));
+            Tuple2<String, Instant> status = getStatus(instanceList);
+            group.setStatus(status.getT1());
+            group.setStatusTimestamp(status.getT2());
+            return group;
+        });
+    }
+
+    @Nullable
+    private BuildVersion getBuildVersion(List<Instance> instances) {
+        List<BuildVersion> versions = instances.stream()
+            .map(Instance::getBuildVersion)
+            .filter(Objects::nonNull)
+            .distinct()
+            .sorted()
+            .collect(toList());
+        if (versions.isEmpty()) {
+            return null;
+        } else if (versions.size() == 1) {
+            return versions.get(0);
+        } else {
+            return BuildVersion.valueOf(versions.get(0) + " ... " + versions.get(versions.size() - 1));
+        }
+    }
+
+    protected Tuple2<String, Instant> getStatus(List<Instance> instances) {
+        //TODO: Correct is just a second readmodel for groups
+        Map<String, Instant> statusWithTime = instances.stream()
+            .collect(toMap(instance -> instance.getStatusInfo().getStatus(),
+                Instance::getStatusTimestamp,
+                this::getMax
+            ));
+        if (statusWithTime.size() == 1) {
+            Map.Entry<String, Instant> e = statusWithTime.entrySet().iterator().next();
+            return Tuples.of(e.getKey(), e.getValue());
+        }
+
+        if (statusWithTime.containsKey(StatusInfo.STATUS_UP)) {
+            Instant oldestNonUp = statusWithTime.entrySet()
+                .stream()
+                .filter(e -> !StatusInfo.STATUS_UP.equals(e.getKey()))
+                .map(Map.Entry::getValue)
+                .min(naturalOrder())
+                .orElse(Instant.EPOCH);
+            Instant latest = getMax(oldestNonUp, statusWithTime.getOrDefault(StatusInfo.STATUS_UP, Instant.EPOCH));
+            return Tuples.of(StatusInfo.STATUS_RESTRICTED, latest);
+        }
+
+        return statusWithTime.entrySet()
+            .stream()
+            .min(Map.Entry.comparingByKey(StatusInfo.severity()))
+            .map(e -> Tuples.of(e.getKey(), e.getValue()))
+            .orElse(Tuples.of(STATUS_UNKNOWN, Instant.EPOCH));
+    }
+
+    private Instant getMax(Instant t1, Instant t2) {
+        return t1.compareTo(t2) >= 0 ? t1 : t2;
+    }
+
+}

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/ApplicationRegistry.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/ApplicationRegistry.java
@@ -56,7 +56,7 @@ public class ApplicationRegistry {
     /**
      * Get a list of all registered instances.
      *
-     * @return List of all instances.
+     * @return List of all the applications.
      */
     public Flux<Application> getApplications() {
         return instanceRegistry.getInstances()

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/ApplicationsController.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/ApplicationsController.java
@@ -16,23 +16,12 @@
 
 package de.codecentric.boot.admin.server.web;
 
-import de.codecentric.boot.admin.server.domain.entities.Instance;
-import de.codecentric.boot.admin.server.domain.values.BuildVersion;
-import de.codecentric.boot.admin.server.domain.values.StatusInfo;
-import de.codecentric.boot.admin.server.eventstore.InstanceEventPublisher;
-import de.codecentric.boot.admin.server.services.InstanceRegistry;
+import de.codecentric.boot.admin.server.domain.entities.Application;
+import de.codecentric.boot.admin.server.services.ApplicationRegistry;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.util.function.Tuple2;
-import reactor.util.function.Tuples;
 
 import java.time.Duration;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.MediaType;
@@ -42,11 +31,6 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.ResponseBody;
-
-import static de.codecentric.boot.admin.server.domain.values.StatusInfo.STATUS_UNKNOWN;
-import static java.util.Comparator.naturalOrder;
-import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toMap;
 
 /**
  * REST controller for controlling registration of managed instances.
@@ -58,132 +42,43 @@ public class ApplicationsController {
     private static final ServerSentEvent<?> PING = ServerSentEvent.builder().comment("ping").build();
     private static final Flux<ServerSentEvent<?>> PING_FLUX = Flux.interval(Duration.ZERO, Duration.ofSeconds(10L))
                                                                   .map(tick -> PING);
-    private final InstanceRegistry registry;
-    private final InstanceEventPublisher eventPublisher;
+    private final ApplicationRegistry registry;
 
-    public ApplicationsController(InstanceRegistry registry, InstanceEventPublisher eventPublisher) {
+    public ApplicationsController(ApplicationRegistry registry) {
         this.registry = registry;
-        this.eventPublisher = eventPublisher;
     }
 
     @GetMapping(path = "/applications", produces = MediaType.APPLICATION_JSON_VALUE)
     public Flux<Application> applications() {
-        return registry.getInstances()
-                       .filter(Instance::isRegistered)
-                       .groupBy(instance -> instance.getRegistration().getName())
-                       .flatMap(grouped -> toApplication(grouped.key(), grouped), Integer.MAX_VALUE);
+        return registry.getApplications();
     }
-
 
     @GetMapping(path = "/applications/{name}", produces = MediaType.APPLICATION_JSON_VALUE)
     public Mono<ResponseEntity<Application>> application(@PathVariable("name") String name) {
-        return this.toApplication(name, registry.getInstances(name).filter(Instance::isRegistered))
-                   .filter(a -> !a.getInstances().isEmpty())
+        return registry.getApplication(name)
                    .map(ResponseEntity::ok)
                    .defaultIfEmpty(ResponseEntity.notFound().build());
     }
 
     @GetMapping(path = "/applications", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public Flux<ServerSentEvent<Application>> applicationsStream() {
-        return Flux.from(eventPublisher)
-                   .flatMap(event -> registry.getInstance(event.getInstance()))
-                   .map(this::getApplicationForInstance)
-                   .flatMap(group -> toApplication(group.getT1(), group.getT2()))
-                   .map(application -> ServerSentEvent.builder(application).build())
-                   .mergeWith(ping());
+        return registry.getApplicationStream()
+            .map(application -> ServerSentEvent.builder(application).build())
+            .mergeWith(ping());
     }
 
     @DeleteMapping(path = "/applications/{name}")
     public Mono<ResponseEntity<Void>> unregister(@PathVariable("name") String name) {
         log.debug("Unregister application with name '{}'", name);
-        return registry.getInstances(name)
-                       .flatMap(instance -> registry.deregister(instance.getId()))
-                       .collectList()
-                       .map(deregistered -> !deregistered.isEmpty() ? ResponseEntity.noContent()
-                                                                                    .build() : ResponseEntity.notFound()
-                                                                                                             .build());
-    }
-
-    protected Tuple2<String, Flux<Instance>> getApplicationForInstance(Instance instance) {
-        String name = instance.getRegistration().getName();
-        return Tuples.of(name, registry.getInstances(name).filter(Instance::isRegistered));
-    }
-
-    protected Mono<Application> toApplication(String name, Flux<Instance> instances) {
-        return instances.collectList().map(instanceList -> {
-            Application group = new Application(name);
-            group.setInstances(instanceList);
-            group.setBuildVersion(getBuildVersion(instanceList));
-            Tuple2<String, Instant> status = getStatus(instanceList);
-            group.setStatus(status.getT1());
-            group.setStatusTimestamp(status.getT2());
-            return group;
-        });
-    }
-
-    @Nullable
-    protected BuildVersion getBuildVersion(List<Instance> instances) {
-        List<BuildVersion> versions = instances.stream()
-                                               .map(Instance::getBuildVersion)
-                                               .filter(Objects::nonNull)
-                                               .distinct()
-                                               .sorted()
-                                               .collect(toList());
-        if (versions.isEmpty()) {
-            return null;
-        } else if (versions.size() == 1) {
-            return versions.get(0);
-        } else {
-            return BuildVersion.valueOf(versions.get(0) + " ... " + versions.get(versions.size() - 1));
-        }
-    }
-
-    protected Tuple2<String, Instant> getStatus(List<Instance> instances) {
-        //TODO: Correct is just a second readmodel for groups
-        Map<String, Instant> statusWithTime = instances.stream()
-                                                       .collect(toMap(instance -> instance.getStatusInfo().getStatus(),
-                                                           Instance::getStatusTimestamp,
-                                                           this::getMax
-                                                       ));
-        if (statusWithTime.size() == 1) {
-            Map.Entry<String, Instant> e = statusWithTime.entrySet().iterator().next();
-            return Tuples.of(e.getKey(), e.getValue());
-        }
-
-        if (statusWithTime.containsKey(StatusInfo.STATUS_UP)) {
-            Instant oldestNonUp = statusWithTime.entrySet()
-                                                .stream()
-                                                .filter(e -> !StatusInfo.STATUS_UP.equals(e.getKey()))
-                                                .map(Map.Entry::getValue)
-                                                .min(naturalOrder())
-                                                .orElse(Instant.EPOCH);
-            Instant latest = getMax(oldestNonUp, statusWithTime.getOrDefault(StatusInfo.STATUS_UP, Instant.EPOCH));
-            return Tuples.of(StatusInfo.STATUS_RESTRICTED, latest);
-        }
-
-        return statusWithTime.entrySet()
-                             .stream()
-                             .min(Map.Entry.comparingByKey(StatusInfo.severity()))
-                             .map(e -> Tuples.of(e.getKey(), e.getValue()))
-                             .orElse(Tuples.of(STATUS_UNKNOWN, Instant.EPOCH));
-    }
-
-    private Instant getMax(Instant t1, Instant t2) {
-        return t1.compareTo(t2) >= 0 ? t1 : t2;
+        return registry.deregister(name)
+            .collectList()
+            .map(deregistered -> !deregistered.isEmpty()
+                ? ResponseEntity.noContent().build()
+                : ResponseEntity.notFound().build());
     }
 
     @SuppressWarnings("unchecked")
     private static <T> Flux<ServerSentEvent<T>> ping() {
         return (Flux<ServerSentEvent<T>>) (Flux) PING_FLUX;
-    }
-
-    @lombok.Data
-    public static class Application {
-        private final String name;
-        @Nullable
-        private BuildVersion buildVersion;
-        private String status = STATUS_UNKNOWN;
-        private Instant statusTimestamp = Instant.now();
-        private List<Instance> instances = new ArrayList<>();
     }
 }

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/services/ApplicationRegistryTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/services/ApplicationRegistryTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2014-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.codecentric.boot.admin.server.services;
+
+import de.codecentric.boot.admin.server.domain.entities.Application;
+import de.codecentric.boot.admin.server.domain.entities.Instance;
+import de.codecentric.boot.admin.server.domain.values.BuildVersion;
+import de.codecentric.boot.admin.server.domain.values.InstanceId;
+import de.codecentric.boot.admin.server.domain.values.Registration;
+import de.codecentric.boot.admin.server.eventstore.InstanceEventPublisher;
+import org.junit.Before;
+import org.junit.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ApplicationRegistryTest {
+
+    private InstanceRegistry instanceRegistry;
+    private InstanceEventPublisher instanceEventPublisher;
+
+    private ApplicationRegistry applicationRegistry;
+
+    @Before
+    public void setUp() {
+        instanceRegistry = mock(InstanceRegistry.class);
+        instanceEventPublisher = mock(InstanceEventPublisher.class);
+
+        applicationRegistry = new ApplicationRegistry(instanceRegistry, instanceEventPublisher);
+    }
+
+    @Test
+    public void getApplications_noRegisteredApplications() {
+        when(instanceRegistry.getInstances()).thenReturn(Flux.just());
+
+        StepVerifier.create(applicationRegistry.getApplications())
+            .verifyComplete();
+    }
+
+    @Test
+    public void getApplications_oneRegisteredAndOneUnregisteredApplication() {
+        Instance instance1 = getInstance("App1");
+        Instance instance2 = getInstance("App2").deregister();
+
+        when(instanceRegistry.getInstances()).thenReturn(Flux.just(instance1, instance2));
+
+        StepVerifier.create(applicationRegistry.getApplications())
+            .assertNext(app -> assertThat(app.getName()).isEqualTo("App1"))
+            .verifyComplete();
+    }
+
+    @Test
+    public void getApplications_allRegisteredApplications() {
+        Instance instance1 = getInstance("App1");
+        Instance instance2 = getInstance("App2");
+
+        when(instanceRegistry.getInstances()).thenReturn(Flux.just(instance1, instance2));
+
+        StepVerifier.create(applicationRegistry.getApplications())
+            .recordWith(ArrayList::new)
+            .thenConsumeWhile(a -> true)
+            .consumeRecordedWith(applications -> assertThat(applications.stream().map(Application::getName))
+                    .containsExactlyInAnyOrder("App1", "App2"))
+            .verifyComplete();
+    }
+
+    @Test
+    public void getApplication_noRegisteredApplications() {
+        when(instanceRegistry.getInstances(any(String.class))).thenReturn(Flux.just());
+
+        StepVerifier.create(applicationRegistry.getApplication("App1"))
+            .verifyComplete();
+    }
+
+    @Test
+    public void getApplication_noMatchingRegisteredApplications() {
+        when(instanceRegistry.getInstances("App2")).thenReturn(Flux.just(getInstance("App2")));
+        when(instanceRegistry.getInstances(any(String.class))).thenReturn(Flux.just());
+
+        StepVerifier.create(applicationRegistry.getApplication("App1"))
+            .verifyComplete();
+    }
+
+    @Test
+    public void getApplication_matchingUnregisteredApplications() {
+        Instance instance = getInstance("App1").deregister();
+        when(instanceRegistry.getInstances("App1")).thenReturn(Flux.just(instance));
+
+        StepVerifier.create(applicationRegistry.getApplication("App1"))
+            .verifyComplete();
+    }
+
+    @Test
+    public void getApplication_matchingRegisteredApplications() {
+        Instance instance = getInstance("App1");
+        when(instanceRegistry.getInstances("App1")).thenReturn(Flux.just(instance));
+
+        StepVerifier.create(applicationRegistry.getApplication("App1"))
+            .assertNext(app -> assertThat(app.getName()).isEqualTo("App1"))
+            .verifyComplete();
+    }
+
+    @Test
+    public void deregister() {
+        Instance instance1 = getInstance("App1");
+        InstanceId instance1Id = instance1.getId();
+
+        when(instanceRegistry.getInstances("App1")).thenReturn(Flux.just(instance1));
+        when(instanceRegistry.deregister(instance1Id)).thenReturn(Mono.just(instance1Id));
+
+        StepVerifier.create(applicationRegistry.deregister("App1"))
+            .assertNext(instanceId -> assertThat(instanceId).isEqualTo(instance1Id))
+            .verifyComplete();
+
+        verify(instanceRegistry).deregister(instance1Id);
+    }
+
+    @Test
+    public void getBuildVersion() {
+        Instance instance1 = getInstance("App1", "0.1");
+        Instance instance2 = getInstance("App2", "0.2");
+
+        //Empty list should return null:
+        assertThat(applicationRegistry.getBuildVersion(Collections.emptyList())).isNull();
+
+        //Single instance should return the version number:
+        assertThat(applicationRegistry.getBuildVersion(Collections.singletonList(instance1))).isEqualTo(BuildVersion.valueOf("0.1"));
+
+        //Multiple instances should return the version number range:
+        assertThat(applicationRegistry.getBuildVersion(Arrays.asList(instance1, instance2))).isEqualTo(BuildVersion.valueOf("0.1 ... 0.2"));
+    }
+
+    private Instance getInstance(String applicationName, String version) {
+        Registration registration = Registration
+            .create(applicationName, "http://localhost:8080/health")
+            .metadata("version", version)
+            .build();
+        InstanceId id = InstanceId.of("TEST" + applicationName);
+        return Instance.create(id).register(registration);
+    }
+
+    private Instance getInstance(String applicationName) {
+        return getInstance(applicationName, "FooBarVersion");
+    }
+
+}


### PR DESCRIPTION
Currently the `ApplicationsController` integrates directly with the `InstanceRegistry` to build a list of applications and the instances of each instance.
In this pull request I have pulled the logic out of the controller into a new `ApplicationRegistry` class. The reasoning here is that it should make it easier to alter the application list before it is sent to the frontend. 
This could be particularly useful in supporting minimum instance counts as request in #1033, and would also allow work on #1215 since the list of services could be injected into Flux of applications as they are generated.