### PR TITLE
IBM J9 compatibility for memory metrics

### DIFF
--- a/spring-boot-admin-server-ui/src/main/frontend/views/instances/details/details-memory.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/instances/details/details-memory.vue
@@ -91,6 +91,7 @@
       error: null,
       current: null,
       chartData: [],
+      memoryIds: []
     }),
     computed: {
       name() {
@@ -104,12 +105,24 @@
         }
       }
     },
+    created() {
+      this.fetchMemoryIds();
+    },
     methods: {
       prettyBytes,
+      hasMemoryId(id) {
+        return this.memoryIds && this.memoryIds.includes(id);
+      },
+      async fetchMemoryIds() {
+        const response = await this.instance.fetchMetric('jvm.memory.used');
+        this.memoryIds = response.data.availableTags
+          .find((availableTag) => availableTag.tag === "id")
+          .values;
+      },
       async fetchMetrics() {
         const responseMax = this.instance.fetchMetric('jvm.memory.max', {area: this.type});
         const responseUsed = this.instance.fetchMetric('jvm.memory.used', {area: this.type});
-        const responeMetaspace = this.type === 'nonheap'
+        const responeMetaspace = this.type === 'nonheap' && this.hasMemoryId('Metaspace')
           ? this.instance.fetchMetric('jvm.memory.used', {area: this.type, id: 'Metaspace'})
           : null;
         const responseCommitted = this.instance.fetchMetric('jvm.memory.committed', {area: this.type});


### PR DESCRIPTION
IBM J9 on IBM i (and certainly on other platforms) doesn't support Metaspace introspection.
It causes and error fetching nonhead memory infos.

I conditioned the Metaspace fetching if it's not available on actuator.
