### PR TITLE
Allow creation of custom nested routed components

### DIFF
--- a/spring-boot-admin-server-ui/src/main/frontend/viewRegistry.js
+++ b/spring-boot-admin-server-ui/src/main/frontend/viewRegistry.js
@@ -70,7 +70,7 @@ export default class ViewRegistry {
         const children = this._toRoutes(views, v => v.parent === p.name);
         return ({
           path: p.path,
-          name: children.length === 0 ? p.name : undefined,
+          name: p.name,
           component: p.component,
           props: p.props,
           meta: {view: p},


### PR DESCRIPTION
Undefined name prevents creation of nested routed components, because the `router-link` in `sidebar` uses this name as target. Any (custom) instance view that is determined to have any children is therefore unclickable.

In fact I can't see any reason to have undefined name. Maybe there is some, but in such case I would like to know it to be able to design some workaround.