### PR TITLE
Allow creation of new Loggers (#1256)

### DIFF
--- a/spring-boot-admin-server-ui/src/main/frontend/views/instances/loggers/i18n.de.json
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/instances/loggers/i18n.de.json
@@ -11,6 +11,7 @@
         "configured": "konfiguriert"
       },
       "instance": "Instanz",
+      "new": "neuer Logger",
       "no_loggers_found": "Keine Logger gefunden.",
       "reset": "Zurücksetzen",
       "setting_loglevel_failed": "Fehler beim Setzen des Loglevels '{loglevel}' für den Logger '{logger}'."

--- a/spring-boot-admin-server-ui/src/main/frontend/views/instances/loggers/i18n.en.json
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/instances/loggers/i18n.en.json
@@ -11,6 +11,7 @@
         "configured": "configured"
       },
       "instance": "Instance",
+      "new": "new logger",
       "no_loggers_found": "No loggers found.",
       "reset": "Reset",
       "setting_loglevel_failed": "Setting {logger} to {loglevel} failed."

--- a/spring-boot-admin-server-ui/src/main/frontend/views/instances/loggers/loggers-list.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/instances/loggers/loggers-list.vue
@@ -20,6 +20,7 @@
       <tr v-for="logger in loggers.slice(0, this.visibleLimit)" :key="logger.name">
         <td>
           <span class="is-breakable" v-text="logger.name" />
+          <span class="is-breakable" v-if="logger.isNew" v-text="' ('+ $t('instances.loggers.new') + ')'" />
 
           <sba-logger-control class="is-pulled-right"
                               :level-options="levels"

--- a/spring-boot-admin-server-ui/src/main/frontend/views/instances/loggers/loggers.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/instances/loggers/loggers.vue
@@ -110,6 +110,20 @@
       ? addedFilter
       : (val, key) => oldFilter(val, key) && addedFilter(val, key);
 
+  const addLoggerCreationEntryIfLoggerNotPresent = (nameFilter, loggers) => {
+      if (nameFilter && !loggers.some(logger => logger.name === nameFilter)) {
+          loggers.unshift({
+              level:[{
+                  configuredLevel: null,
+                  effectiveLevel: null,
+                  instanceId: null
+              }],
+              name: nameFilter,
+              isNew: true
+          })
+      }
+  }
+
   export default {
     components: {LoggersList},
     directives: {sticksBelow},
@@ -141,7 +155,9 @@
     computed: {
       filteredLoggers() {
         const filterFn = this.getFilterFn();
-        return filterFn ? this.loggerConfig.loggers.filter(filterFn) : this.loggerConfig.loggers;
+        const filteredLoggers = filterFn ? this.loggerConfig.loggers.filter(filterFn) : this.loggerConfig.loggers;
+        addLoggerCreationEntryIfLoggerNotPresent(this.filter.name, filteredLoggers);
+        return filteredLoggers;
       }
     },
     watch: {


### PR DESCRIPTION
Yes, it's only an issue with Log4j2-Backend.

Logback is creating all loggers along the package-structure. (https://github.com/qos-ch/logback/blob/597b272384cc02f711dbdf6895763e256eddaa76/logback-classic/src/main/java/ch/qos/logback/classic/LoggerContext.java#L141-L142)

Log4j2 only exposes the explicit configured Loggers.

This PR allowes the creation/configuration of loggers (should fix #1256), even if they are not listed by the LoggersEndpoint. In case of Log4J2 you are creating a new logger-configuration. In case of Logback, it might not make any sense to create new loggers, but I see no problem in allowing it.

![new-logger](https://user-images.githubusercontent.com/1879911/66374874-44d57f80-e9ac-11e9-81dc-e11c49447d22.png)
