### PR TITLE
Add ability to see old thread states in threaddump view

### DIFF
--- a/spring-boot-admin-server-ui/src/main/frontend/views/instances/threaddump/index.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/instances/threaddump/index.vue
@@ -88,21 +88,22 @@
                 threadId: thread.threadId,
                 threadState: thread.threadState,
                 threadName: thread.threadName,
-                details: thread,
                 timeline: [{
                   start: now,
                   end: now,
+                  details: thread,
                   threadState: thread.threadState,
                 }]
               });
             } else {
               const entry = vm.threads[thread.threadId];
-              entry.details = thread;
               if (entry.threadState !== thread.threadState) {
                 entry.threadState = thread.threadState;
+                entry.timeline[entry.timeline.length - 1].end = now;
                 entry.timeline.push({
-                  start: entry.timeline[entry.timeline.length - 1].end,
+                  start: now,
                   end: now,
+                  details: thread,
                   threadState: thread.threadState,
                 });
               } else {
@@ -115,7 +116,6 @@
         terminatedThreads.forEach(threadId => {
           const entry = vm.threads[threadId];
           entry.threadState = 'TERMINATED';
-          entry.details = null;
           entry.timeline[entry.timeline.length - 1].end = now;
         });
       },


### PR DESCRIPTION
For https://github.com/codecentric/spring-boot-admin/issues/1205
- Click on an old thread state to show the details at that point in time.
- Thread state will change color to indicate it is clicked
![Screencast 2019-10-25 20_17_56](https://user-images.githubusercontent.com/2431525/67613676-15bd5d00-f765-11e9-9663-a9898e1ca843.gif)
