### PR TITLE
spring-cloud-aws filterProperty js fix

### DIFF
--- a/spring-boot-admin-server-ui/src/main/frontend/views/instances/env/index.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/instances/env/index.vue
@@ -76,7 +76,7 @@
   import sbaEnvManager from './env-manager';
 
   const filterProperty = (needle) => (property, name) => {
-    return name.toString().toLowerCase().includes(needle) || property.value.toString().toLowerCase().includes(needle);
+    return name.toString().toLowerCase().includes(needle) || (property.hasOwnProperty('value') && property.value.toString().toLowerCase().includes(needle));
   };
   const filterProperties = (needle, properties) => pickBy(properties, filterProperty(needle));
   const filterPropertySource = (needle) => (propertySource) => {


### PR DESCRIPTION
spring-cloud-aws provides instanceData configurations which are missing value properties. This breaks the filtering throwing "TypeError: Cannot read property 'toString' of undefined" of the property.value.toString(). Resolved to check for value property.

Data back from /actuator/env when using spring-cloud-aws:

`{
      "name": "InstanceData",
      "properties": {
        "ami-manifest-path": {
          "value": "(unknown)"
        },
        "public-ipv4": {},
        "profile": {
          "value": "default-hvm"
        },
}`

Notice public-ipv4 is missing value property. 

Wondering if this could be backported to the 2.1.x branch as well?