### PR TITLE
Replace custom views instead of appending them

### DIFF
--- a/spring-boot-admin-docs/src/main/asciidoc/customizing.adoc
+++ b/spring-boot-admin-docs/src/main/asciidoc/customizing.adoc
@@ -109,7 +109,10 @@ Registering the instance view works like for the top-level view with some additi
 include::{samples-dir}/spring-boot-admin-sample-custom-ui/src/index.js[tags=customization-ui-endpoint]
 ----
 <1> The parent must be 'instances' in order to render the new custom view for a single instance.
-<2> If you add a `isEnabled` callback you can figure out dynamically if the view should be show for the particular instance.
+<2> You can group views by assigning them to a group.
+<3> If you add a `isEnabled` callback you can figure out dynamically if the view should be show for the particular instance.
+
+NOTE: You can override default views by putting the same group and name as the one you want to override.
 
 === Customizing Header Logo and Title ===
 You can set custom information in the header (i.e. displaying staging information or company name) by using following configuration properties:

--- a/spring-boot-admin-samples/spring-boot-admin-sample-custom-ui/src/index.js
+++ b/spring-boot-admin-samples/spring-boot-admin-sample-custom-ui/src/index.js
@@ -41,8 +41,9 @@ SBA.use({
       path: 'custom',
       component: customEndpoint,
       label: 'Custom',
+      group: 'Group', // <2>
       order: 1000,
-      isEnabled: ({instance}) => instance.hasEndpoint('custom') // <2>
+      isEnabled: ({instance}) => instance.hasEndpoint('custom') // <3>
     });
   }
 });

--- a/spring-boot-admin-server-ui/babel.config.js
+++ b/spring-boot-admin-server-ui/babel.config.js
@@ -17,5 +17,10 @@
 module.exports = {
   presets: [
     '@vue/cli-plugin-babel/preset'
-  ]
+  ],
+  env: {
+    test: {
+      plugins: ['babel-plugin-transform-require-context']
+    }
+  }
 };

--- a/spring-boot-admin-server-ui/package-lock.json
+++ b/spring-boot-admin-server-ui/package-lock.json
@@ -7,7 +7,6 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
       "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-      "dev": true,
       "requires": {
         "@babel/highlight": "^7.8.3"
       }
@@ -321,7 +320,6 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
       "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
-      "dev": true,
       "requires": {
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
@@ -331,8 +329,7 @@
     "@babel/parser": {
       "version": "7.8.8",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.8.tgz",
-      "integrity": "sha512-mO5GWzBPsPf6865iIbzNE0AvkKF3NE+2S3eRUpE+FE07BOAkXh6G+GW/Pj01hhXjve1WScbaIO4UlY1JKeqCcA==",
-      "dev": true
+      "integrity": "sha512-mO5GWzBPsPf6865iIbzNE0AvkKF3NE+2S3eRUpE+FE07BOAkXh6G+GW/Pj01hhXjve1WScbaIO4UlY1JKeqCcA=="
     },
     "@babel/plugin-proposal-async-generator-functions": {
       "version": "7.8.3",
@@ -923,7 +920,6 @@
       "version": "7.8.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
       "integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.8.3",
         "@babel/parser": "^7.8.6",
@@ -968,7 +964,6 @@
       "version": "7.8.7",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.7.tgz",
       "integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
-      "dev": true,
       "requires": {
         "esutils": "^2.0.2",
         "lodash": "^4.17.13",
@@ -2418,7 +2413,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -2872,6 +2866,14 @@
         "babel-runtime": "^6.26.0",
         "babel-template": "^6.26.0",
         "babel-types": "^6.26.0"
+      }
+    },
+    "babel-plugin-transform-require-context": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-require-context/-/babel-plugin-transform-require-context-0.1.1.tgz",
+      "integrity": "sha512-4ceqYOtzgmq4/QsB8dP7pUrUOCjY/jrRYdt7YkIOWHxtGDQbcf6YZDyLCiPQf6KsEIcIbSQiTRXOsbLiuJfgNQ==",
+      "requires": {
+        "@babel/template": "7"
       }
     },
     "babel-plugin-transform-strict-mode": {
@@ -3666,7 +3668,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -4099,7 +4100,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -4107,8 +4107,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "color-string": {
       "version": "1.5.3",
@@ -5608,8 +5607,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "1.14.1",
@@ -6347,8 +6345,7 @@
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
     "etag": {
       "version": "1.8.1",
@@ -7822,8 +7819,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbols": {
       "version": "1.0.1",
@@ -14143,7 +14139,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -14401,8 +14396,7 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-      "dev": true
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
     },
     "to-object-path": {
       "version": "0.3.0",

--- a/spring-boot-admin-server-ui/package.json
+++ b/spring-boot-admin-server-ui/package.json
@@ -52,6 +52,7 @@
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^24.9.0",
+    "babel-plugin-transform-require-context": "^0.1.1",
     "eslint": "^6.8.0",
     "eslint-plugin-vue": "^6.2.2",
     "html-loader": "^0.5.5",

--- a/spring-boot-admin-server-ui/src/main/frontend/viewRegistry.js
+++ b/spring-boot-admin-server-ui/src/main/frontend/viewRegistry.js
@@ -16,6 +16,8 @@
 
 import {VIEW_GROUP} from './views';
 
+import remove from 'lodash/remove';
+
 const createTextVNode = (label) => {
   return {
     render() {
@@ -62,6 +64,12 @@ export default class ViewRegistry {
     }
 
     this._views.push(view);
+  }
+
+  _removeExistingView(view) {
+    remove(this._views, (v) => {
+      return v.name === view.name && v.group === view.group
+    });
   }
 
   _toRoutes(views, filter) {

--- a/spring-boot-admin-server-ui/src/main/frontend/viewRegistry.spec.js
+++ b/spring-boot-admin-server-ui/src/main/frontend/viewRegistry.spec.js
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2014-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import ViewRegistry from "./viewRegistry";
+
+describe('viewRegistry', () => {
+    describe('given view already in the registry', function () {
+
+
+        it('it should replace the existing one', async () => {
+            const viewRegistry = new ViewRegistry();
+
+            viewRegistry.addView(...[
+                {name: 'view', group: 'group'},
+                {name: 'duplicateView', group: 'group'},
+                {name: 'duplicateView', group: 'group'}
+            ])
+
+            expect(viewRegistry.views).toHaveLength(2);
+        });
+
+    });
+});


### PR DESCRIPTION
Closes #1324

Had to add a babel plugin for the test because of spring-boot-admin-server-ui/src/main/frontend/views/index.js:19 that is executed during the test. (require.context is not a function)

[Didnt find a better way to do it.](https://stackoverflow.com/questions/38332094/how-can-i-mock-webpacks-require-context-in-jest) Another solution would have been to move the GROUP_VIEW constant so the import of it would not trigger the require but it looked in the right place there.

Also, would you be interested to migrate your js code to ts ? I'd like to give a hand if so