### PR TITLE
beans, configprops and mappings LegacyConverters

### DIFF
--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerInstanceWebClientConfiguration.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerInstanceWebClientConfiguration.java
@@ -186,6 +186,24 @@ public class AdminServerInstanceWebClientConfiguration {
 			return LegacyEndpointConverters.flyway();
 		}
 
+		@Bean
+		@ConditionalOnMissingBean(name = "beansLegacyEndpointConverter")
+		public LegacyEndpointConverter beansLegacyEndpointConverter() {
+			return LegacyEndpointConverters.beans();
+		}
+
+		@Bean
+		@ConditionalOnMissingBean(name = "configpropsLegacyEndpointConverter")
+		public LegacyEndpointConverter configpropsLegacyEndpointConverter() {
+			return LegacyEndpointConverters.configprops();
+		}
+
+		@Bean
+		@ConditionalOnMissingBean(name = "mappingsLegacyEndpointConverter")
+		public LegacyEndpointConverter mappingsLegacyEndpointConverter() {
+			return LegacyEndpointConverters.mappings();
+		}
+
 	}
 
 }

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/domain/values/Endpoint.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/domain/values/Endpoint.java
@@ -41,6 +41,12 @@ public final class Endpoint implements Serializable {
 
 	public static final String ACTUATOR_INDEX = "actuator-index";
 
+	public static final String BEANS = "beans";
+
+	public static final String CONFIGPROPS = "configprops";
+
+	public static final String MAPPINGS = "mappings";
+
 	private final String id;
 
 	private final String url;

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/config/AdminServerInstanceWebClientConfigurationTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/config/AdminServerInstanceWebClientConfigurationTest.java
@@ -53,7 +53,8 @@ public class AdminServerInstanceWebClientConfigurationTest {
 			assertThat(context).getBeanNames(LegacyEndpointConverter.class).containsExactly(
 					"healthLegacyEndpointConverter", "infoLegacyEndpointConverter", "envLegacyEndpointConverter",
 					"httptraceLegacyEndpointConverter", "threaddumpLegacyEndpointConverter",
-					"liquibaseLegacyEndpointConverter", "flywayLegacyEndpointConverter");
+					"liquibaseLegacyEndpointConverter", "flywayLegacyEndpointConverter", "beansLegacyEndpointConverter",
+					"configpropsLegacyEndpointConverter", "mappingsLegacyEndpointConverter");
 		});
 	}
 

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/web/client/LegacyEndpointConvertersTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/web/client/LegacyEndpointConvertersTest.java
@@ -130,6 +130,51 @@ public class LegacyEndpointConvertersTest {
 				.verifyComplete();
 	}
 
+	@Test
+	public void should_convert_beans() {
+		LegacyEndpointConverter converter = LegacyEndpointConverters.beans();
+		assertThat(converter.canConvert("beans")).isTrue();
+		assertThat(converter.canConvert("foo")).isFalse();
+
+		Flux<DataBuffer> legacyInput = this.read("beans-legacy.json");
+
+		Flux<Object> converted = converter.convert(legacyInput).transform(this::unmarshal);
+		Flux<Object> expected = this.read("beans-expected.json").transform(this::unmarshal);
+
+		StepVerifier.create(Flux.zip(converted, expected)).assertNext((t) -> assertThat(t.getT1()).isEqualTo(t.getT2()))
+				.verifyComplete();
+	}
+
+	@Test
+	public void should_convert_configprops() {
+		LegacyEndpointConverter converter = LegacyEndpointConverters.configprops();
+		assertThat(converter.canConvert("configprops")).isTrue();
+		assertThat(converter.canConvert("foo")).isFalse();
+
+		Flux<DataBuffer> legacyInput = this.read("configprops-legacy.json");
+
+		Flux<Object> converted = converter.convert(legacyInput).transform(this::unmarshal);
+		Flux<Object> expected = this.read("configprops-expected.json").transform(this::unmarshal);
+
+		StepVerifier.create(Flux.zip(converted, expected)).assertNext((t) -> assertThat(t.getT1()).isEqualTo(t.getT2()))
+				.verifyComplete();
+	}
+
+	@Test
+	public void should_convert_mappings() {
+		LegacyEndpointConverter converter = LegacyEndpointConverters.mappings();
+		assertThat(converter.canConvert("mappings")).isTrue();
+		assertThat(converter.canConvert("foo")).isFalse();
+
+		Flux<DataBuffer> legacyInput = this.read("mappings-legacy.json");
+
+		Flux<Object> converted = converter.convert(legacyInput).transform(this::unmarshal);
+		Flux<Object> expected = this.read("mappings-expected.json").transform(this::unmarshal);
+
+		StepVerifier.create(Flux.zip(converted, expected)).assertNext((t) -> assertThat(t.getT1()).isEqualTo(t.getT2()))
+				.verifyComplete();
+	}
+
 	private Flux<Object> unmarshal(Flux<DataBuffer> buffer) {
 		return decoder.decode(buffer, type, null, null);
 	}

--- a/spring-boot-admin-server/src/test/resources/de/codecentric/boot/admin/server/web/client/beans-expected.json
+++ b/spring-boot-admin-server/src/test/resources/de/codecentric/boot/admin/server/web/client/beans-expected.json
@@ -1,0 +1,42 @@
+{
+  "contexts": {
+    "sample-project:8080": {
+      "beans": {
+        "propertySourcesPlaceholderConfigurer": {
+          "aliases": [],
+          "bean": "propertySourcesPlaceholderConfigurer",
+          "dependencies": [],
+          "resource": "class path resource [org/springframework/boot/autoconfigure/context/PropertyPlaceholderAutoConfiguration.class]",
+          "scope": "singleton",
+          "type": "org.springframework.context.support.PropertySourcesPlaceholderConfigurer"
+        }
+      },
+      "contextName": "sample-project:8080",
+      "parentId": null
+    },
+    "sample-project:8080.child": {
+      "beans": {
+        "configClientProperties": {
+          "aliases": [],
+          "bean": "configClientProperties",
+          "dependencies": [],
+          "resource": "org.springframework.cloud.config.client.ConfigServiceBootstrapConfiguration",
+          "scope": "singleton",
+          "type": "org.springframework.cloud.config.client.ConfigClientProperties"
+        },
+        "configServicePropertySource": {
+          "aliases": [],
+          "bean": "configServicePropertySource",
+          "dependencies": [
+            "configClientProperties"
+          ],
+          "resource": "org.springframework.cloud.config.client.ConfigServiceBootstrapConfiguration",
+          "scope": "singleton",
+          "type": "org.springframework.cloud.config.client.ConfigServicePropertySourceLocator"
+        }
+      },
+      "contextName": "sample-project:8080.child",
+      "parentId": "sample-project:8080"
+    }
+  }
+}

--- a/spring-boot-admin-server/src/test/resources/de/codecentric/boot/admin/server/web/client/beans-legacy.json
+++ b/spring-boot-admin-server/src/test/resources/de/codecentric/boot/admin/server/web/client/beans-legacy.json
@@ -1,0 +1,40 @@
+[
+  {
+    "context": "sample-project:8080",
+    "parent": null,
+    "beans": [
+      {
+        "bean": "propertySourcesPlaceholderConfigurer",
+        "aliases": [],
+        "scope": "singleton",
+        "type": "org.springframework.context.support.PropertySourcesPlaceholderConfigurer",
+        "resource": "class path resource [org/springframework/boot/autoconfigure/context/PropertyPlaceholderAutoConfiguration.class]",
+        "dependencies": []
+      }
+    ]
+  },
+  {
+    "context": "sample-project:8080",
+    "parent": "sample-project:8080",
+    "beans": [
+      {
+        "bean": "configClientProperties",
+        "aliases": [],
+        "scope": "singleton",
+        "type": "org.springframework.cloud.config.client.ConfigClientProperties",
+        "resource": "org.springframework.cloud.config.client.ConfigServiceBootstrapConfiguration",
+        "dependencies": []
+      },
+      {
+        "bean": "configServicePropertySource",
+        "aliases": [],
+        "scope": "singleton",
+        "type": "org.springframework.cloud.config.client.ConfigServicePropertySourceLocator",
+        "resource": "org.springframework.cloud.config.client.ConfigServiceBootstrapConfiguration",
+        "dependencies": [
+          "configClientProperties"
+        ]
+      }
+    ]
+  }
+]

--- a/spring-boot-admin-server/src/test/resources/de/codecentric/boot/admin/server/web/client/configprops-expected.json
+++ b/spring-boot-admin-server/src/test/resources/de/codecentric/boot/admin/server/web/client/configprops-expected.json
@@ -1,0 +1,33 @@
+{
+  "contexts": {
+    "application": {
+      "beans": {
+        "spring.jpa-org.springframework.boot.autoconfigure.orm.jpa.JpaProperties": {
+          "prefix": "spring.jpa",
+          "properties": {
+            "error": "Cannot serialize 'spring.jpa'"
+          }
+        },
+        "endpoints-org.springframework.boot.actuate.endpoint.EndpointProperties": {
+          "prefix": "endpoints",
+          "properties": {
+            "enabled": true,
+            "sensitive": null
+          }
+        }
+      }
+    },
+    "parentContext": {
+      "beans": {
+        "spring.cloud.config-org.springframework.cloud.bootstrap.config.PropertySourceBootstrapProperties": {
+          "prefix": "spring.cloud.config",
+          "properties": {
+            "overrideSystemProperties": true,
+            "overrideNone": false,
+            "allowOverride": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/spring-boot-admin-server/src/test/resources/de/codecentric/boot/admin/server/web/client/configprops-legacy.json
+++ b/spring-boot-admin-server/src/test/resources/de/codecentric/boot/admin/server/web/client/configprops-legacy.json
@@ -1,0 +1,25 @@
+{
+  "spring.jpa-org.springframework.boot.autoconfigure.orm.jpa.JpaProperties": {
+    "prefix": "spring.jpa",
+    "properties": {
+      "error": "Cannot serialize 'spring.jpa'"
+    }
+  },
+  "endpoints-org.springframework.boot.actuate.endpoint.EndpointProperties": {
+    "prefix": "endpoints",
+    "properties": {
+      "enabled": true,
+      "sensitive": null
+    }
+  },
+  "parent": {
+    "spring.cloud.config-org.springframework.cloud.bootstrap.config.PropertySourceBootstrapProperties": {
+      "prefix": "spring.cloud.config",
+      "properties": {
+        "overrideSystemProperties": true,
+        "overrideNone": false,
+        "allowOverride": true
+      }
+    }
+  }
+}

--- a/spring-boot-admin-server/src/test/resources/de/codecentric/boot/admin/server/web/client/mappings-expected.json
+++ b/spring-boot-admin-server/src/test/resources/de/codecentric/boot/admin/server/web/client/mappings-expected.json
@@ -1,0 +1,85 @@
+{
+  "contexts": {
+    "application": {
+      "mappings": {
+        "dispatcherServlets": {
+          "dispatcherServlet": [
+            {
+              "details": {
+                "requestMappingConditions": {
+                  "consumes": [],
+                  "headers": [],
+                  "methods": [],
+                  "params": [],
+                  "patterns": [
+                    "/**/favicon.ico"
+                  ],
+                  "produces": []
+                }
+              },
+              "predicate": "/**/favicon.ico"
+            },
+            {
+              "details": {
+                "handlerMethod": {
+                  "className": "org.springframework.boot.autoconfigure.web.BasicErrorController",
+                  "descriptor": "(Ljavax/servlet/http/HttpServletRequest;)Lorg/springframework/http/ResponseEntity;",
+                  "name": "error"
+                },
+                "requestMappingConditions": {
+                  "consumes": [],
+                  "headers": [],
+                  "methods": [],
+                  "params": [],
+                  "patterns": [
+                    "/error"
+                  ],
+                  "produces": []
+                }
+              },
+              "predicate": "{[/error]}",
+              "handler": "public org.springframework.http.ResponseEntity<java.util.Map<java.lang.String, java.lang.Object>> org.springframework.boot.autoconfigure.web.BasicErrorController.error(javax.servlet.http.HttpServletRequest)"
+            },
+            {
+              "details": {
+                "handlerMethod": {
+                  "className": "org.springframework.boot.actuate.endpoint.mvc.LoggersMvcEndpoint",
+                  "descriptor": "(Ljava/lang/String;Ljava/util/Map;)Ljava/lang/Object;",
+                  "name": "set"
+                },
+                "requestMappingConditions": {
+                  "consumes": [
+                    {
+                      "mediaType": "application/vnd.spring-boot.actuator.v1+json"
+                    },
+                    {
+                      "mediaType": "application/json"
+                    }
+                  ],
+                  "headers": [],
+                  "methods": [
+                    "POST"
+                  ],
+                  "params": [],
+                  "patterns": [
+                    "/actuator/loggers/{name:.*}"
+                  ],
+                  "produces": [
+                    {
+                      "mediaType": "application/vnd.spring-boot.actuator.v1+json"
+                    },
+                    {
+                      "mediaType": "application/json"
+                    }
+                  ]
+                }
+              },
+              "predicate": "{[/actuator/loggers/{name:.*}],methods=[POST],consumes=[application/vnd.spring-boot.actuator.v1+json || application/json],produces=[application/vnd.spring-boot.actuator.v1+json || application/json]}",
+              "handler": "public java.lang.Object org.springframework.boot.actuate.endpoint.mvc.LoggersMvcEndpoint.set(java.lang.String,java.util.Map<java.lang.String, java.lang.String>)"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/spring-boot-admin-server/src/test/resources/de/codecentric/boot/admin/server/web/client/mappings-legacy.json
+++ b/spring-boot-admin-server/src/test/resources/de/codecentric/boot/admin/server/web/client/mappings-legacy.json
@@ -1,0 +1,13 @@
+{
+  "/**/favicon.ico": {
+    "bean": "faviconHandlerMapping"
+  },
+  "{[/error]}": {
+    "bean": "requestMappingHandlerMapping",
+    "method": "public org.springframework.http.ResponseEntity<java.util.Map<java.lang.String, java.lang.Object>> org.springframework.boot.autoconfigure.web.BasicErrorController.error(javax.servlet.http.HttpServletRequest)"
+  },
+  "{[/actuator/loggers/{name:.*}],methods=[POST],consumes=[application/vnd.spring-boot.actuator.v1+json || application/json],produces=[application/vnd.spring-boot.actuator.v1+json || application/json]}": {
+    "bean": "endpointHandlerMapping",
+    "method": "public java.lang.Object org.springframework.boot.actuate.endpoint.mvc.LoggersMvcEndpoint.set(java.lang.String,java.util.Map<java.lang.String, java.lang.String>)"
+  }
+}


### PR DESCRIPTION
This PR adds LegacyConverters for beans, configprops and mappings.

Tried to manipulate and transform legacy responses in a best effort manner. There may be edge cases and false positives for some of the transformations but all my current projects are working as expected.

Unit tests provided as well. I'd be happy to improve that path in case of future issues.

Linked Issue #1421