### PR TITLE
Fix for downloading ThreadDump file

### DIFF
--- a/spring-boot-admin-server-ui/src/main/frontend/services/instance.js
+++ b/spring-boot-admin-server-ui/src/main/frontend/services/instance.js
@@ -181,7 +181,7 @@ class Instance {
   }
 
   async downloadThreaddump() {
-    const res = await axios.get(uri`actuator/threaddump`, {headers: {'Accept': 'text/plain'}});
+    const res = await this.axios.get(uri`actuator/threaddump`, {headers: {'Accept': 'text/plain'}});
     const blob = new Blob([res.data], {type: 'text/plain;charset=utf-8'});
     saveAs(blob, this.registration.name + '-threaddump.txt');
   }


### PR DESCRIPTION
Use the axios object (which sets the baseUrl) instead of the axios module itself.

Related to: #1338  #1341