### PR TITLE
fix a problem caching requestbody

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- used dependencies versions -->
-        <spring-boot.version>2.3.0.RELEASE</spring-boot.version>
+        <spring-boot.version>2.3.1.RELEASE</spring-boot.version>
         <spring-cloud.version>2020.0.0-M1</spring-cloud.version>
         <wiremock.version>2.26.1</wiremock.version>
         <hazelcast-tests.version>3.12.6</hazelcast-tests.version>

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/reactive/InstancesProxyController.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/reactive/InstancesProxyController.java
@@ -102,9 +102,11 @@ public class InstancesProxyController {
 				.toUri();
 
 		Flux<DataBuffer> cachedBody = request.getBody().map((b) -> {
-			DataBuffer wrap = this.bufferFactory.wrap(b.asByteBuffer());
+			int readableByteCount = b.readableByteCount();
+			DataBuffer dataBuffer = this.bufferFactory.allocateBuffer(readableByteCount);
+			dataBuffer.write(b.asByteBuffer());
 			DataBufferUtils.release(b);
-			return wrap;
+			return dataBuffer;
 		}).cache();
 
 		return this.instanceWebProxy.forward(this.registry.getInstances(applicationName), uri, request.getMethod(),

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/web/reactive/DataBufferTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/web/reactive/DataBufferTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2014-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.codecentric.boot.admin.server.web.reactive;
+
+import java.nio.ByteBuffer;
+
+import io.netty.buffer.PooledByteBufAllocator;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DataBufferUtils;
+import org.springframework.core.io.buffer.DefaultDataBufferFactory;
+import org.springframework.core.io.buffer.NettyDataBufferFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test to illustrate the usage of how to cache org.springframework.http.ReactiveHttpInputMessage#getBody()
+ *
+ * @see InstancesProxyController#endpointProxy(java.lang.String, org.springframework.http.server.reactive.ServerHttpRequest)
+ */
+public class DataBufferTest {
+	@Test
+	public void testWrapByteBuffer() {
+
+		NettyDataBufferFactory bufferFactory = new NettyDataBufferFactory(PooledByteBufAllocator.DEFAULT);
+		String str = "test";
+		DataBuffer dataBuffer1 = bufferFactory.wrap(str.getBytes());
+		ByteBuffer byteBuffer1 = dataBuffer1.asByteBuffer();
+
+		DefaultDataBufferFactory defaultDataBufferFactory = new DefaultDataBufferFactory();
+		DataBuffer dataBuffer2 = defaultDataBufferFactory.wrap(byteBuffer1);
+		ByteBuffer byteBuffer2 = dataBuffer2.asByteBuffer();
+
+		// when DataBufferUtils.release(dataBuffer1); called (always need to when we subscribe the request body), will cause the undergroud bytes released
+		// So DefaultDataBufferFactory.wrap(java.nio.ByteBuffer) share the same bytes, so is not a good way to cache body.
+		assertThat(byteBuffer2.array()).isEqualTo(byteBuffer1.array());
+
+		assertThat(byteBuffer2.array().hashCode()).isEqualTo(byteBuffer1.array().hashCode());
+		assertThat(byteBuffer2.array().equals(byteBuffer2.array()));
+
+		// not safe to release dataBuffer1, if we need to use dataBuffer2 later
+		DataBufferUtils.release(dataBuffer1);
+	}
+
+	@Test
+	public void testWriteByteBuffer() {
+
+		NettyDataBufferFactory bufferFactory = new NettyDataBufferFactory(PooledByteBufAllocator.DEFAULT);
+		String str = "test";
+		DataBuffer dataBuffer1 = bufferFactory.wrap(str.getBytes());
+		ByteBuffer byteBuffer1 = dataBuffer1.asByteBuffer();
+
+		DefaultDataBufferFactory defaultDataBufferFactory = new DefaultDataBufferFactory();
+		int readableByteCount = dataBuffer1.readableByteCount();
+		DataBuffer dataBuffer2 = defaultDataBufferFactory.allocateBuffer(readableByteCount);
+		dataBuffer2.write(byteBuffer1);
+		ByteBuffer byteBuffer2 = dataBuffer2.asByteBuffer();
+
+		assertThat(byteBuffer2.array()).isEqualTo(byteBuffer1.array());
+		assertThat(byteBuffer2.array().hashCode()).isNotEqualTo(byteBuffer1.array().hashCode());
+		assertThat(byteBuffer2.array().equals(byteBuffer2.array()));
+
+		// safe to release dataBuffer1, if we need to use dataBuffer2 later
+		DataBufferUtils.release(dataBuffer1);
+
+	}
+}

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/web/reactive/DataBufferTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/web/reactive/DataBufferTest.java
@@ -28,11 +28,14 @@ import org.springframework.core.io.buffer.NettyDataBufferFactory;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Test to illustrate the usage of how to cache org.springframework.http.ReactiveHttpInputMessage#getBody()
+ * Test to illustrate the usage of how to cache
+ * org.springframework.http.ReactiveHttpInputMessage#getBody()
  *
- * @see InstancesProxyController#endpointProxy(java.lang.String, org.springframework.http.server.reactive.ServerHttpRequest)
+ * @see InstancesProxyController#endpointProxy(java.lang.String,
+ * org.springframework.http.server.reactive.ServerHttpRequest)
  */
 public class DataBufferTest {
+
 	@Test
 	public void testWrapByteBuffer() {
 
@@ -45,8 +48,10 @@ public class DataBufferTest {
 		DataBuffer dataBuffer2 = defaultDataBufferFactory.wrap(byteBuffer1);
 		ByteBuffer byteBuffer2 = dataBuffer2.asByteBuffer();
 
-		// when DataBufferUtils.release(dataBuffer1); called (always need to when we subscribe the request body), will cause the undergroud bytes released
-		// So DefaultDataBufferFactory.wrap(java.nio.ByteBuffer) share the same bytes, so is not a good way to cache body.
+		// when DataBufferUtils.release(dataBuffer1); called (always need to when we
+		// subscribe the request body), will cause the undergroud bytes released
+		// So DefaultDataBufferFactory.wrap(java.nio.ByteBuffer) share the same bytes, so
+		// is not a good way to cache body.
 		assertThat(byteBuffer2.array()).isEqualTo(byteBuffer1.array());
 
 		assertThat(byteBuffer2.array().hashCode()).isEqualTo(byteBuffer1.array().hashCode());
@@ -78,4 +83,5 @@ public class DataBufferTest {
 		DataBufferUtils.release(dataBuffer1);
 
 	}
+
 }


### PR DESCRIPTION
fix the bug: when using org.springframework.core.io.buffer.DataBufferFactory#wrap(java.nio.ByteBuffer), the underground ByteBuf is wrapped, it'll cause use the released ByteBuf. which can be reproduced use a large size object.
when not released as the last version, it also has the same problem when the body use more than once. Refer to org.springframework.core.codec.ByteBufferDecoder#decode
