### PR TITLE
Update documnetation to include Python support using Pyctuator

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ codecentric's Spring Boot Admin
 
 This community project provides an admin interface for [Spring Boot <sup>®</sup>](http://projects.spring.io/spring-boot/ "Official Spring-Boot website") applications.
 
-It provides the following features for registered applications.
+Monitoring Python applications is available using [Pyctuator](https://github.com/SolarEdgeTech/pyctuator).
+
+Spring Boot Admin provides the following features for registered applications:
 
 * Show health status
 * Show details, like

--- a/spring-boot-admin-docs/src/main/asciidoc/getting-started.adoc
+++ b/spring-boot-admin-docs/src/main/asciidoc/getting-started.adoc
@@ -188,3 +188,48 @@ include::{samples-dir}/spring-boot-admin-sample-eureka/src/main/resources/applic
 See also {github-src}/spring-boot-admin-samples/spring-boot-admin-sample-eureka/[spring-boot-admin-sample-eureka].
 
 TIP: You can include the Spring Boot Admin Server to your Eureka server. Setup everything as described above and set `spring.boot.admin.context-path` to something different than `"/"` so that the Spring Boot Admin Server UI won't clash with Eureka's one.
+
+[[register-python-applications]]
+==== Registering Python Applications Using Pyctuator ====
+
+You can easily integrate Spring Boot Admin with https://flask.palletsprojects.com[Flask] or https://fastapi.tiangolo.com/[FastAPI] Python applications using the https://github.com/SolarEdgeTech/pyctuator[Pyctuator] project.
+
+
+The following steps uses Flask, but other web frameworks are supported as well. See Pyctuator's documentation for an updated list of supported frameworks and features.
+
+. Install the pyctuator package:
++
+[source,bash]
+----
+pip install pyctuator
+----
+
+. Enable pyctuator by pointing it to your Flask app and letting it know where Spring Boot Admin is running:
++
+[source,python]
+----
+import os
+from flask import Flask
+from pyctuator.pyctuator import Pyctuator
+
+app_name = "Flask App with Pyctuator"
+app = Flask(app_name)
+
+
+@app.route("/")
+def hello():
+    return "Hello World!"
+
+
+Pyctuator(
+    app,
+    app_name,
+    app_url="http://example-app.com",
+    pyctuator_endpoint_url="http://example-app.com/pyctuator",
+    registration_url=os.getenv("SPRING_BOOT_ADMIN_URL")
+)
+
+app.run()
+----
+
+For further details and examples, see Pyctuator's https://github.com/SolarEdgeTech/pyctuator/blob/master/README.md[documentation] and https://github.com/SolarEdgeTech/pyctuator/tree/master/examples[examples].

--- a/spring-boot-admin-docs/src/main/asciidoc/index.adoc
+++ b/spring-boot-admin-docs/src/main/asciidoc/index.adoc
@@ -19,6 +19,8 @@ codecentric's Spring Boot Admin is a community project to manage and monitor you
 The applications register with our Spring Boot Admin Client (via HTTP) or are discovered using Spring Cloud ^(R)^ (e.g. Eureka, Consul).
 The UI is just a Vue.js application on top of the Spring Boot Actuator endpoints.
 
+Support for Python applications is available using https://github.com/SolarEdgeTech/pyctuator[Pyctuator].
+
 include::getting-started.adoc[]
 
 include::client.adoc[]


### PR DESCRIPTION
The Pyctuator project allows integrating Python web applications with
Spring Boot Admin. This commit updates the documentation with a short
example and pointers to further documentation on Pyctuator's main
repository.

Resolves #1460 