### PR TITLE
Allowing scheme to be set via metadata

### DIFF
--- a/spring-boot-admin-docs/src/main/asciidoc/server-discovery.adoc
+++ b/spring-boot-admin-docs/src/main/asciidoc/server-discovery.adoc
@@ -56,6 +56,10 @@ user.password
 | Credentials being used to access the endpoints.
 |
 
+| management.scheme
+| The scheme is substituted in the service URL and will be used for accessing the actuator endpoints.
+|
+
 | management.address
 | The address is substituted in the service URL and will be used for accessing the actuator endpoints.
 |

--- a/spring-boot-admin-server-cloud/src/main/java/de/codecentric/boot/admin/server/cloud/discovery/DefaultServiceInstanceConverter.java
+++ b/spring-boot-admin-server-cloud/src/main/java/de/codecentric/boot/admin/server/cloud/discovery/DefaultServiceInstanceConverter.java
@@ -34,8 +34,9 @@ import static org.springframework.util.StringUtils.isEmpty;
  * Converts any {@link ServiceInstance}s to {@link Instance}s. To customize the health- or
  * management-url for all instances you can set healthEndpointPath or
  * managementContextPath respectively. If you want to influence the url per service you
- * can add <code>management.context-path</code>, <code>management.port</code>,
- * <code>management.address</code> or <code>health.path</code> to the instances metadata.
+ * can add <code>management.scheme</code>,  <code>management.address</code>,
+ * <code>management.port</code>, <code>management.context-path</code>
+ * or <code>health.path</code> to the instances metadata.
  *
  * @author Johannes Edmeier
  */
@@ -43,11 +44,13 @@ public class DefaultServiceInstanceConverter implements ServiceInstanceConverter
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(DefaultServiceInstanceConverter.class);
 
+	private static final String KEY_MANAGEMENT_SCHEME = "management.scheme";
+
+	private static final String KEY_MANAGEMENT_ADDRESS = "management.address";
+
 	private static final String KEY_MANAGEMENT_PORT = "management.port";
 
 	private static final String KEY_MANAGEMENT_PATH = "management.context-path";
-
-	private static final String KEY_MANAGEMENT_ADDRESS = "management.address";
 
 	private static final String KEY_HEALTH_PATH = "health.path";
 
@@ -108,7 +111,11 @@ public class DefaultServiceInstanceConverter implements ServiceInstanceConverter
 	}
 
 	private String getManagementScheme(ServiceInstance instance) {
-		return this.getServiceUrl(instance).getScheme();
+		String managementServerScheme = instance.getMetadata().get(KEY_MANAGEMENT_SCHEME);
+		if (!isEmpty(managementServerScheme)) {
+			return managementServerScheme;
+		}
+		return getServiceUrl(instance).getScheme();
 	}
 
 	protected String getManagementHost(ServiceInstance instance) {

--- a/spring-boot-admin-server-cloud/src/main/java/de/codecentric/boot/admin/server/cloud/discovery/DefaultServiceInstanceConverter.java
+++ b/spring-boot-admin-server-cloud/src/main/java/de/codecentric/boot/admin/server/cloud/discovery/DefaultServiceInstanceConverter.java
@@ -34,9 +34,9 @@ import static org.springframework.util.StringUtils.isEmpty;
  * Converts any {@link ServiceInstance}s to {@link Instance}s. To customize the health- or
  * management-url for all instances you can set healthEndpointPath or
  * managementContextPath respectively. If you want to influence the url per service you
- * can add <code>management.scheme</code>,  <code>management.address</code>,
- * <code>management.port</code>, <code>management.context-path</code>
- * or <code>health.path</code> to the instances metadata.
+ * can add <code>management.scheme</code>, <code>management.address</code>,
+ * <code>management.port</code>, <code>management.context-path</code> or
+ * <code>health.path</code> to the instances metadata.
  *
  * @author Johannes Edmeier
  */

--- a/spring-boot-admin-server-cloud/src/test/java/de/codecentric/boot/admin/server/cloud/discovery/DefaultServiceInstanceConverterTest.java
+++ b/spring-boot-admin-server-cloud/src/test/java/de/codecentric/boot/admin/server/cloud/discovery/DefaultServiceInstanceConverterTest.java
@@ -62,17 +62,18 @@ public class DefaultServiceInstanceConverterTest {
 		ServiceInstance service = new DefaultServiceInstance("test-1", "test", "localhost", 80, false);
 		Map<String, String> metadata = new HashMap<>();
 		metadata.put("health.path", "ping");
-		metadata.put("management.context-path", "mgmt");
-		metadata.put("management.port", "1234");
+		metadata.put("management.scheme", "https");
 		metadata.put("management.address", "127.0.0.1");
+		metadata.put("management.port", "1234");
+		metadata.put("management.context-path", "mgmt");
 		service.getMetadata().putAll(metadata);
 
 		Registration registration = new DefaultServiceInstanceConverter().convert(service);
 
 		assertThat(registration.getName()).isEqualTo("test");
-		assertThat(registration.getServiceUrl()).isEqualTo("http://localhost:80");
-		assertThat(registration.getManagementUrl()).isEqualTo("http://127.0.0.1:1234/mgmt");
-		assertThat(registration.getHealthUrl()).isEqualTo("http://127.0.0.1:1234/mgmt/ping");
+		assertThat(registration.getServiceUrl()).isEqualTo("https://localhost:80");
+		assertThat(registration.getManagementUrl()).isEqualTo("https://127.0.0.1:1234/mgmt");
+		assertThat(registration.getHealthUrl()).isEqualTo("https://127.0.0.1:1234/mgmt/ping");
 		assertThat(registration.getMetadata()).isEqualTo(metadata);
 	}
 

--- a/spring-boot-admin-server-cloud/src/test/java/de/codecentric/boot/admin/server/cloud/discovery/DefaultServiceInstanceConverterTest.java
+++ b/spring-boot-admin-server-cloud/src/test/java/de/codecentric/boot/admin/server/cloud/discovery/DefaultServiceInstanceConverterTest.java
@@ -71,7 +71,7 @@ public class DefaultServiceInstanceConverterTest {
 		Registration registration = new DefaultServiceInstanceConverter().convert(service);
 
 		assertThat(registration.getName()).isEqualTo("test");
-		assertThat(registration.getServiceUrl()).isEqualTo("https://localhost:80");
+		assertThat(registration.getServiceUrl()).isEqualTo("http://localhost:80");
 		assertThat(registration.getManagementUrl()).isEqualTo("https://127.0.0.1:1234/mgmt");
 		assertThat(registration.getHealthUrl()).isEqualTo("https://127.0.0.1:1234/mgmt/ping");
 		assertThat(registration.getMetadata()).isEqualTo(metadata);


### PR DESCRIPTION
Currently, the `DefaultServiceInstanceConverter` is accessing the metadata to override the address, port and path for management access. There is not way to override the scheme, this is purely set based on `getServiceUrl`'s scheme.

With this change, the scheme is overridable too. Without setting `management.scheme` to override it, the previous behavior is not breaking.

All parts of the management address are now overridable in a consistent way. The existing test `should_convert_with_metadata` is updated to override all options now. The newly introduced option is referred to in the documentation.