### PR TITLE
Auth with configuration props

### DIFF
--- a/spring-boot-admin-docs/src/main/asciidoc/security.adoc
+++ b/spring-boot-admin-docs/src/main/asciidoc/security.adoc
@@ -57,6 +57,31 @@ spring.boot.admin.client:
         user.password: ${spring.security.user.password}
 ----
 
+==== SBA Server ====
+
+You can specify credentials via configuration properties in your admin server.
+
+TIP: You can use this in conjuction with https://cloud.spring.io/spring-cloud-kubernetes/1.1.x/reference/html/#secrets-propertysource[spring-cloud-kubernetes^] to pull credentials from https://kubernetes.io/docs/concepts/configuration/secret/[secrets^].
+
+To enable pulling credentials from properties you must set `spring.boot.admin.instance-auth.enabled` to `true`.
+
+NOTE: If your clients provide credentials via metadata (i.e., via service annotations), that metadata will be used instead of the properites.
+
+You can provide a default username and password by setting `spring.boot.admin.instance-auth.default-user-name` and `spring.boot.admin.instance-auth.default-user-password`. Optionally you can provide credentials for specific services (by name) using the `spring.boot.admin.instance-auth.service-map.*.user-name` pattern, replacing `*` with the service name.
+[source,yaml]
+.application.yml
+----
+spring.boot.admin:
+  instance-auth:
+    enabled: true
+    default-user-name: "${some.user.name.from.secret}"
+    default-user-password: "${some.user.password.from.secret}"
+    service-map:
+      my-sb-admin-service:
+        user-name: "${some.user.name.from.secret}"
+        user-password: "${some.user.password.from.secret}"
+----
+
 ==== Eureka ====
 [source,yaml]
 .application.yml

--- a/spring-boot-admin-docs/src/main/asciidoc/security.adoc
+++ b/spring-boot-admin-docs/src/main/asciidoc/security.adoc
@@ -63,7 +63,7 @@ You can specify credentials via configuration properties in your admin server.
 
 TIP: You can use this in conjuction with https://cloud.spring.io/spring-cloud-kubernetes/1.1.x/reference/html/#secrets-propertysource[spring-cloud-kubernetes^] to pull credentials from https://kubernetes.io/docs/concepts/configuration/secret/[secrets^].
 
-To enable pulling credentials from properties you must set `spring.boot.admin.instance-auth.enabled` to `true`.
+To enable pulling credentials from properties the `spring.boot.admin.instance-auth.enabled` property must be `true` (default).
 
 NOTE: If your clients provide credentials via metadata (i.e., via service annotations), that metadata will be used instead of the properites.
 
@@ -77,7 +77,10 @@ spring.boot.admin:
     default-user-name: "${some.user.name.from.secret}"
     default-user-password: "${some.user.password.from.secret}"
     service-map:
-      my-sb-admin-service:
+      my-first-service-to-monitor:
+        user-name: "${some.user.name.from.secret}"
+        user-password: "${some.user.password.from.secret}"
+      my-second-service-to-monitor:
         user-name: "${some.user.name.from.secret}"
         user-password: "${some.user.password.from.secret}"
 ----

--- a/spring-boot-admin-docs/src/main/asciidoc/security.adoc
+++ b/spring-boot-admin-docs/src/main/asciidoc/security.adoc
@@ -67,7 +67,7 @@ To enable pulling credentials from properties you must set `spring.boot.admin.in
 
 NOTE: If your clients provide credentials via metadata (i.e., via service annotations), that metadata will be used instead of the properites.
 
-You can provide a default username and password by setting `spring.boot.admin.instance-auth.default-user-name` and `spring.boot.admin.instance-auth.default-user-password`. Optionally you can provide credentials for specific services (by name) using the `spring.boot.admin.instance-auth.service-map.*.user-name` pattern, replacing `*` with the service name.
+You can provide a default username and password by setting `spring.boot.admin.instance-auth.default-user-name` and `spring.boot.admin.instance-auth.default-user-password`. Optionally you can provide credentials for specific services (by name) using the `spring.boot.admin.instance-auth.service-map.\*.user-name` pattern, replacing `*` with the service name.
 [source,yaml]
 .application.yml
 ----

--- a/spring-boot-admin-docs/src/main/asciidoc/server.adoc
+++ b/spring-boot-admin-docs/src/main/asciidoc/server.adoc
@@ -60,24 +60,24 @@ In addition when the reverse proxy terminates the https connection, it may be ne
 | `false`
 
 | spring.boot.admin.instance-auth.default-user-name
-| When enabled, a default user name used to authenticate to registered services.
+| A default user name used to authenticate to registered services. The `spring.boot.admin.instance-auth.enabled` property must be `true`.
 | `"client"`
 
 | spring.boot.admin.instance-auth.default-user-password
-| When enabled, a default user password used to authenticate to registered services.
+| A default user password used to authenticate to registered services. The `spring.boot.admin.instance-auth.enabled` property must be `true`.
 | `"client"`
 
 | spring.boot.admin.instance-auth.service-map.*.user-name
-| When enabled, a user name used to authenticate to the registered service with the specified name.
+| A user name used to authenticate to the registered service with the specified name. The `spring.boot.admin.instance-auth.enabled` property must be `true`.
 | 
 
 | spring.boot.admin.instance-auth.service-map.*.user-password
-| When enabled, a user password used to authenticate to the registered service with the specified name.
+| A user password used to authenticate to the registered service with the specified name. The `spring.boot.admin.instance-auth.enabled` property must be `true`.
 | 
 
 | spring.boot.admin.instance-proxy.ignored-headers
 |  Headers not to be forwarded when making requests to clients.
-| `"Cookie", "Set-Cookie", "Authorization"
+| `"Cookie", "Set-Cookie", "Authorization"`
 
 | spring.boot.admin.ui.public-url
 | Base url to use to build the base href in the ui.

--- a/spring-boot-admin-docs/src/main/asciidoc/server.adoc
+++ b/spring-boot-admin-docs/src/main/asciidoc/server.adoc
@@ -55,6 +55,26 @@ In addition when the reverse proxy terminates the https connection, it may be ne
   If the path differs from the id you can specify this as id:path (e.g. health:ping)..
 | `"health", "env", "metrics", "httptrace:trace", "threaddump:dump", "jolokia", "info", "logfile", "refresh", "flyway", "liquibase", "heapdump", "loggers", "auditevents"`
 
+| spring.boot.admin.instance-auth.enabled
+| Enable pulling credentials from spring configuration properties
+| `false`
+
+| spring.boot.admin.instance-auth.default-user-name
+| When enabled, a default user name used to authenticate to registered services.
+| `"client"`
+
+| spring.boot.admin.instance-auth.default-user-password
+| When enabled, a default user password used to authenticate to registered services.
+| `"client"`
+
+| spring.boot.admin.instance-auth.service-map.*.user-name
+| When enabled, a user name used to authenticate to the registered service with the specified name.
+| 
+
+| spring.boot.admin.instance-auth.service-map.*.user-password
+| When enabled, a user password used to authenticate to the registered service with the specified name.
+| 
+
 | spring.boot.admin.instance-proxy.ignored-headers
 |  Headers not to be forwarded when making requests to clients.
 | `"Cookie", "Set-Cookie", "Authorization"

--- a/spring-boot-admin-docs/src/main/asciidoc/server.adoc
+++ b/spring-boot-admin-docs/src/main/asciidoc/server.adoc
@@ -57,15 +57,15 @@ In addition when the reverse proxy terminates the https connection, it may be ne
 
 | spring.boot.admin.instance-auth.enabled
 | Enable pulling credentials from spring configuration properties
-| `false`
+| `true`
 
 | spring.boot.admin.instance-auth.default-user-name
 | A default user name used to authenticate to registered services. The `spring.boot.admin.instance-auth.enabled` property must be `true`.
-| `"client"`
+| `null`
 
 | spring.boot.admin.instance-auth.default-user-password
 | A default user password used to authenticate to registered services. The `spring.boot.admin.instance-auth.enabled` property must be `true`.
-| `"client"`
+| `null`
 
 | spring.boot.admin.instance-auth.service-map.*.user-name
 | A user name used to authenticate to the registered service with the specified name. The `spring.boot.admin.instance-auth.enabled` property must be `true`.

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerInstanceWebClientConfiguration.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerInstanceWebClientConfiguration.java
@@ -137,8 +137,10 @@ public class AdminServerInstanceWebClientConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean
-		public BasicAuthHttpHeaderProvider basicAuthHttpHeadersProvider() {
-			return new BasicAuthHttpHeaderProvider();
+		public BasicAuthHttpHeaderProvider basicAuthHttpHeadersProvider(AdminServerProperties adminServerProperties) {
+			AdminServerProperties.InstanceAuthProperties instanceAuth = adminServerProperties.getInstanceAuth();
+			return BasicAuthHttpHeaderProvider.of(instanceAuth.isEnabled(), instanceAuth.getDefaultUserName(),
+					instanceAuth.getDefaultPassword(), instanceAuth.getServiceMap());
 		}
 
 	}

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerProperties.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerProperties.java
@@ -27,6 +27,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.convert.DurationUnit;
 
 import de.codecentric.boot.admin.server.web.PathUtils;
+import de.codecentric.boot.admin.server.web.client.BasicAuthHttpHeaderProvider.InstanceCredentials;
 
 import static java.util.Arrays.asList;
 
@@ -135,47 +136,30 @@ public class AdminServerProperties {
 		/**
 		 * Whether or not to use configuration properties as a source for instance
 		 * credentials <br/>
-		 * Default: false
+		 * Default: true
 		 */
-		private boolean enabled = false;
+		private boolean enabled = true;
 
 		/**
 		 * Default username used for authentication to each instance. Individual values
 		 * for specific instances can be overriden using
 		 * `spring.boot.admin.instance-auth.service-map.*.user-name`. <br/>
-		 * Default: client
+		 * Default: null
 		 */
-		private String defaultUserName = "client";
+		private String defaultUserName = null;
 
 		/**
 		 * Default userpassword used for authentication to each instance. Individual
 		 * values for specific instances can be overriden using
 		 * `spring.boot.admin.instance-auth.service-map.*.user-password`. <br/>
-		 * Default: client
+		 * Default: null
 		 */
-		private String defaultPassword = "client";
+		private String defaultPassword = null;
 
 		/**
 		 * Map of instance credentials per registered service name
 		 */
 		private Map<String, InstanceCredentials> serviceMap = new HashMap<>();
-
-	}
-
-	@lombok.Data(staticConstructor = "of")
-	public static class InstanceCredentials {
-
-		/**
-		 * user name for this instance
-		 */
-		@lombok.NonNull
-		private String userName;
-
-		/**
-		 * user password for this instance
-		 */
-		@lombok.NonNull
-		private String userPassword;
 
 	}
 

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerProperties.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerProperties.java
@@ -133,46 +133,50 @@ public class AdminServerProperties {
 	public static class InstanceAuthProperties {
 
 		/**
-		 * Whether or not to use configuration properties as a source for instance credentials
-		 * <br/>
+		 * Whether or not to use configuration properties as a source for instance
+		 * credentials <br/>
 		 * Default: false
 		 */
 		private boolean enabled = false;
 
 		/**
-		 * Default username used for authentication to each instance. Individual values for specific instances
-		 * can be overriden using `spring.boot.admin.instance-auth.service.*.user-name`.
-		 * <br/>
-		 * Default: admin
+		 * Default username used for authentication to each instance. Individual values
+		 * for specific instances can be overriden using
+		 * `spring.boot.admin.instance-auth.service-map.*.user-name`. <br/>
+		 * Default: client
 		 */
-		private String defaultUserName = "admin";
+		private String defaultUserName = "client";
 
 		/**
-		 * Default userpassword used for authentication to each instance. Individual values for specific instances
-		 * can be overriden using `spring.boot.admin.instance-auth.service.*.user-password`.
-		 * <br/>
-		 * Default: admin
+		 * Default userpassword used for authentication to each instance. Individual
+		 * values for specific instances can be overriden using
+		 * `spring.boot.admin.instance-auth.service-map.*.user-password`. <br/>
+		 * Default: client
 		 */
-		private String defaultPassword = "admin";
+		private String defaultPassword = "client";
 
 		/**
 		 * Map of instance credentials per registered service name
 		 */
-		private Map<String, InstanceCredentials> service = new HashMap<>();
+		private Map<String, InstanceCredentials> serviceMap = new HashMap<>();
+
 	}
 
-	@lombok.Data
+	@lombok.Data(staticConstructor = "of")
 	public static class InstanceCredentials {
 
 		/**
 		 * user name for this instance
 		 */
+		@lombok.NonNull
 		private String userName;
 
 		/**
 		 * user password for this instance
 		 */
+		@lombok.NonNull
 		private String userPassword;
+
 	}
 
 	@lombok.Data

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerProperties.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerProperties.java
@@ -42,6 +42,8 @@ public class AdminServerProperties {
 
 	private MonitorProperties monitor = new MonitorProperties();
 
+	private InstanceAuthProperties instanceAuth = new InstanceAuthProperties();
+
 	private InstanceProxyProperties instanceProxy = new InstanceProxyProperties();
 
 	/**
@@ -125,6 +127,52 @@ public class AdminServerProperties {
 		@DurationUnit(ChronoUnit.MILLIS)
 		private Map<String, Duration> timeout = new HashMap<>();
 
+	}
+
+	@lombok.Data
+	public static class InstanceAuthProperties {
+
+		/**
+		 * Whether or not to use configuration properties as a source for instance credentials
+		 * <br/>
+		 * Default: false
+		 */
+		private boolean enabled = false;
+
+		/**
+		 * Default username used for authentication to each instance. Individual values for specific instances
+		 * can be overriden using `spring.boot.admin.instance-auth.service.*.user-name`.
+		 * <br/>
+		 * Default: admin
+		 */
+		private String defaultUserName = "admin";
+
+		/**
+		 * Default userpassword used for authentication to each instance. Individual values for specific instances
+		 * can be overriden using `spring.boot.admin.instance-auth.service.*.user-password`.
+		 * <br/>
+		 * Default: admin
+		 */
+		private String defaultPassword = "admin";
+
+		/**
+		 * Map of instance credentials per registered service name
+		 */
+		private Map<String, InstanceCredentials> service = new HashMap<>();
+	}
+
+	@lombok.Data
+	public static class InstanceCredentials {
+
+		/**
+		 * user name for this instance
+		 */
+		private String userName;
+
+		/**
+		 * user password for this instance
+		 */
+		private String userPassword;
 	}
 
 	@lombok.Data

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/client/BasicAuthHttpHeaderProvider.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/client/BasicAuthHttpHeaderProvider.java
@@ -107,4 +107,5 @@ public class BasicAuthHttpHeaderProvider implements HttpHeadersProvider {
 		private String userPassword;
 
 	}
+
 }

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/client/BasicAuthHttpHeaderProvider.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/client/BasicAuthHttpHeaderProvider.java
@@ -25,7 +25,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.util.Base64Utils;
 import org.springframework.util.StringUtils;
 
-import de.codecentric.boot.admin.server.config.AdminServerProperties.InstanceCredentials;
 import de.codecentric.boot.admin.server.domain.entities.Instance;
 
 /**
@@ -92,4 +91,20 @@ public class BasicAuthHttpHeaderProvider implements HttpHeadersProvider {
 		return null;
 	}
 
+	@lombok.Data(staticConstructor = "of")
+	public static class InstanceCredentials {
+
+		/**
+		 * user name for this instance
+		 */
+		@lombok.NonNull
+		private String userName;
+
+		/**
+		 * user password for this instance
+		 */
+		@lombok.NonNull
+		private String userPassword;
+
+	}
 }

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/web/client/BasicAuthHttpHeaderProviderTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/web/client/BasicAuthHttpHeaderProviderTest.java
@@ -21,10 +21,10 @@ import java.util.Collections;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 
-import de.codecentric.boot.admin.server.config.AdminServerProperties.InstanceCredentials;
 import de.codecentric.boot.admin.server.domain.entities.Instance;
 import de.codecentric.boot.admin.server.domain.values.InstanceId;
 import de.codecentric.boot.admin.server.domain.values.Registration;
+import de.codecentric.boot.admin.server.web.client.BasicAuthHttpHeaderProvider.InstanceCredentials;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -32,7 +32,7 @@ public class BasicAuthHttpHeaderProviderTest {
 
 	private final BasicAuthHttpHeaderProvider headersProvider = new BasicAuthHttpHeaderProvider();
 
-	private final BasicAuthHttpHeaderProvider headersProvideEnableInstanceAuth = BasicAuthHttpHeaderProvider.of(true,
+	private final BasicAuthHttpHeaderProvider headersProviderEnableInstanceAuth = BasicAuthHttpHeaderProvider.of(true,
 			"client", "client", Collections.singletonMap("sb-admin-server", InstanceCredentials.of("admin", "admin")));
 
 	@Test
@@ -73,7 +73,7 @@ public class BasicAuthHttpHeaderProviderTest {
 	public void test_auth_instance_enabled_use_default_creds() {
 		Registration registration = Registration.create("foo", "http://health").name("xyz-server").build();
 		Instance instance = Instance.create(InstanceId.of("id")).register(registration);
-		assertThat(this.headersProvideEnableInstanceAuth.getHeaders(instance).get(HttpHeaders.AUTHORIZATION))
+		assertThat(this.headersProviderEnableInstanceAuth.getHeaders(instance).get(HttpHeaders.AUTHORIZATION))
 				.containsOnly("Basic Y2xpZW50OmNsaWVudA==");
 	}
 
@@ -81,7 +81,7 @@ public class BasicAuthHttpHeaderProviderTest {
 	public void test_auth_instance_enabled_use_service_specific_creds() {
 		Registration registration = Registration.create("foo", "http://health").name("sb-admin-server").build();
 		Instance instance = Instance.create(InstanceId.of("id")).register(registration);
-		assertThat(this.headersProvideEnableInstanceAuth.getHeaders(instance).get(HttpHeaders.AUTHORIZATION))
+		assertThat(this.headersProviderEnableInstanceAuth.getHeaders(instance).get(HttpHeaders.AUTHORIZATION))
 				.containsOnly("Basic YWRtaW46YWRtaW4=");
 	}
 
@@ -90,7 +90,7 @@ public class BasicAuthHttpHeaderProviderTest {
 		Registration registration = Registration.create("foo", "http://health").metadata("username", "test")
 				.metadata("userpassword", "drowssap").name("xyz-server").build();
 		Instance instance = Instance.create(InstanceId.of("id")).register(registration);
-		assertThat(this.headersProvideEnableInstanceAuth.getHeaders(instance).get(HttpHeaders.AUTHORIZATION))
+		assertThat(this.headersProviderEnableInstanceAuth.getHeaders(instance).get(HttpHeaders.AUTHORIZATION))
 				.containsOnly("Basic dGVzdDpkcm93c3NhcA==");
 	}
 

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/web/client/BasicAuthHttpHeaderProviderTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/web/client/BasicAuthHttpHeaderProviderTest.java
@@ -16,9 +16,12 @@
 
 package de.codecentric.boot.admin.server.web.client;
 
+import java.util.Collections;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 
+import de.codecentric.boot.admin.server.config.AdminServerProperties.InstanceCredentials;
 import de.codecentric.boot.admin.server.domain.entities.Instance;
 import de.codecentric.boot.admin.server.domain.values.InstanceId;
 import de.codecentric.boot.admin.server.domain.values.Registration;
@@ -28,6 +31,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class BasicAuthHttpHeaderProviderTest {
 
 	private final BasicAuthHttpHeaderProvider headersProvider = new BasicAuthHttpHeaderProvider();
+
+	private final BasicAuthHttpHeaderProvider headersProvideEnableInstanceAuth = BasicAuthHttpHeaderProvider.of(true,
+			"client", "client", Collections.singletonMap("sb-admin-server", InstanceCredentials.of("admin", "admin")));
 
 	@Test
 	public void test_auth_header() {
@@ -61,6 +67,31 @@ public class BasicAuthHttpHeaderProviderTest {
 		Registration registration = Registration.create("foo", "http://health").build();
 		Instance instance = Instance.create(InstanceId.of("id")).register(registration);
 		assertThat(this.headersProvider.getHeaders(instance)).isEmpty();
+	}
+
+	@Test
+	public void test_auth_instance_enabled_use_default_creds() {
+		Registration registration = Registration.create("foo", "http://health").name("xyz-server").build();
+		Instance instance = Instance.create(InstanceId.of("id")).register(registration);
+		assertThat(this.headersProvideEnableInstanceAuth.getHeaders(instance).get(HttpHeaders.AUTHORIZATION))
+				.containsOnly("Basic Y2xpZW50OmNsaWVudA==");
+	}
+
+	@Test
+	public void test_auth_instance_enabled_use_service_specific_creds() {
+		Registration registration = Registration.create("foo", "http://health").name("sb-admin-server").build();
+		Instance instance = Instance.create(InstanceId.of("id")).register(registration);
+		assertThat(this.headersProvideEnableInstanceAuth.getHeaders(instance).get(HttpHeaders.AUTHORIZATION))
+				.containsOnly("Basic YWRtaW46YWRtaW4=");
+	}
+
+	@Test
+	public void test_auth_instance_enabled_use_metadata_over_props() {
+		Registration registration = Registration.create("foo", "http://health").metadata("username", "test")
+				.metadata("userpassword", "drowssap").name("xyz-server").build();
+		Instance instance = Instance.create(InstanceId.of("id")).register(registration);
+		assertThat(this.headersProvideEnableInstanceAuth.getHeaders(instance).get(HttpHeaders.AUTHORIZATION))
+				.containsOnly("Basic dGVzdDpkcm93c3NhcA==");
 	}
 
 }


### PR DESCRIPTION
Use configuration properties as source for instance credentials.  This will allow a more secure way to provide credentials when using spring cloud kubernetes discovery.