### PR TITLE
💄 add icon margin to buttons to improve visuals

### DIFF
--- a/spring-boot-admin-server-ui/src/main/frontend/assets/css/base.scss
+++ b/spring-boot-admin-server-ui/src/main/frontend/assets/css/base.scss
@@ -56,6 +56,10 @@ pre.is-breakable {
   cursor: pointer;
 }
 
+.button > svg {
+  margin-right: 0.4em;
+}
+
 .button.is-icon {
   background: transparent;
   border-color: transparent;


### PR DESCRIPTION
This pull request aims to improve the appearance of icon buttons within the UI. This is the current styling:

**current styling**

![old](https://user-images.githubusercontent.com/822035/90950752-982db080-e44c-11ea-8c68-721797cc8e62.PNG)
the new styling adds spacing to make the buttons more appealing:

**proposed styling**

![new](https://user-images.githubusercontent.com/822035/90950759-a54a9f80-e44c-11ea-945e-569443d63f27.PNG)