### PR TITLE
misleading documentation for property instance-auth.default-password

### DIFF
--- a/spring-boot-admin-docs/src/main/asciidoc/security.adoc
+++ b/spring-boot-admin-docs/src/main/asciidoc/security.adoc
@@ -75,7 +75,7 @@ spring.boot.admin:
   instance-auth:
     enabled: true
     default-user-name: "${some.user.name.from.secret}"
-    default-user-password: "${some.user.password.from.secret}"
+    default-password: "${some.user.password.from.secret}"
     service-map:
       my-first-service-to-monitor:
         user-name: "${some.user.name.from.secret}"

--- a/spring-boot-admin-docs/src/main/asciidoc/server.adoc
+++ b/spring-boot-admin-docs/src/main/asciidoc/server.adoc
@@ -63,7 +63,7 @@ In addition when the reverse proxy terminates the https connection, it may be ne
 | A default user name used to authenticate to registered services. The `spring.boot.admin.instance-auth.enabled` property must be `true`.
 | `null`
 
-| spring.boot.admin.instance-auth.default-user-password
+| spring.boot.admin.instance-auth.default-password
 | A default user password used to authenticate to registered services. The `spring.boot.admin.instance-auth.enabled` property must be `true`.
 | `null`
 


### PR DESCRIPTION
Hi all,

just updated to v2.3.1 and activated instance authentification and found that the default-password property is named default-user-password in the documentation.
see AdminServerProperties

Thanks,
Soeren

