### PR TITLE
Sync code style settings with checkstyle expectations (#1561)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,21 @@ trim_trailing_whitespace= true
 [*.java]
 indent_style = tab
 indent_size = 4
+ij_java_space_before_for_left_brace = true
+ij_java_keep_multiple_expressions_in_one_line = true
+ij_java_keep_simple_blocks_in_one_line = true
+ij_java_keep_simple_classes_in_one_line = true
+ij_java_else_on_new_line = true
+ij_java_catch_on_new_line = true
+ij_java_finally_on_new_line = true
+ij_java_align_multiline_method_parentheses = false
+ij_java_keep_blank_lines_before_right_brace = 1
+ij_java_blank_lines_after_class_header = 0
+ij_java_doc_enable_formatting = false
+ij_java_class_count_to_use_import_on_demand = 100
+ij_java_names_count_to_use_import_on_demand = 100
+ij_java_imports_layout = |,java.**,|,javax.**,|,*,org.springframework.**,|,de.codecentric.boot.admin.**,|,$*
+ij_java_layout_static_imports_separately = true
 
 [*.xml]
 indent_style = space

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,18 +1,52 @@
 # Contributing to Spring Boot Admin
 
-Contriubutions are highly welcome. Feel free to submit Pull Requests. Maybe watch out for tickets tagged with `ideal-for-contribution`, these tickets should always be a good starting point for contributing.   
+Contributions are highly welcome. Feel free to submit Pull Requests. Maybe watch out for tickets tagged with `ideal-for-contribution`, these tickets should always be a good starting point for contributing.
 
 You can find some hints for starting development in the [README](spring-boot-admin-server-ui/README.md) of `spring-boot-admin-server-ui`.
 
 ## Coding Conventions
 ### Java / Server
-We try to satisfy the [Code Style of Spring Framework](https://github.com/spring-projects/spring-framework/wiki/Code-Style). If you are using IntelliJ, you can find the needed settings [here](https://github.com/spring-projects/spring-framework/wiki/IntelliJ-IDEA-Editor-Settings).
+We try to satisfy the [Code Style of Spring Framework](https://github.com/spring-projects/spring-framework/wiki/Code-Style).
 
-The [Spring Java Format Plugins](https://github.com/spring-io/spring-javaformat) are added to the build. Checkstyle will enforce the consistency of the code. Nevertheless there are some disabled rules, due to backward compatibility. You can find these disabled rules in a comment in `src/checkstyle.xml`.
-
-If you are using IntelliJ, there is also a [formatter-plugin provided by Spring](https://github.com/spring-io/spring-javaformat#intellij-idea).
+The [Spring Java Format Plugin](https://github.com/spring-io/spring-javaformat) is added to the build. Checkstyle will enforce the consistency of the code. Nevertheless there are some disabled rules, due to backward compatibility. You can find these disabled rules in a comment in `src/checkstyle/checkstyle.xml`.
 
 Otherwise you can always run `mvn spring-javaformat:apply` to fix some basic errors, like indentation.
 
 ### JavaScript / Client
 tbd
+
+## Working with the code
+
+### Importing into IntelliJ
+
+The IntelliJ settings are based on the IntelliJ-IDEA-Editor-Settings from spring, but have been adapted slightly, you can find the original settings [here](https://github.com/spring-projects/spring-framework/wiki/IntelliJ-IDEA-Editor-Settings).
+
+The custom settings are stored in `.editorconfig` and are imported automatically by IntelliJ.
+
+If you are using IntelliJ, there is also a [formatter-plugin provided by Spring](https://github.com/spring-io/spring-javaformat#intellij-idea).
+
+(i) Plugin version x didn't not work in IntelliJ IDEA Ultimate 2020.3.
+
+
+#### Checkstyle Plugin
+
+This plugin scans Java files with the project's custom CheckStyle rules from within IDEA.
+
+Install and configure the Checkstyle Plugin, and enable the configuration file.
+
+##### Configuration
+Before the configuration file is configured, add the  `spring-javaformat-checkstyle` JAR to the Third-Party Checks.
+1. Preferences > Tools > Checkstyle > Third-Party Checks
+2. Add `~/.m2/repository/io/spring/javaformat/spring-javaformat-checkstyle/0.0.26/spring-javaformat-checkstyle-0.0.26.jar`
+
+##### Configuration File
+Add the configuration file and enabled it:
+1. Preferences > Tools > Checkstyle > Configuration File > +
+2. Add a Name, ex. Spring Boot Admin
+3. Use a local Checkstyle File, Browse to `src/checkstyle/checkstyle.xml` and click Next
+4. Enter the full path to the checkstyle header file: `<git repo>/src/checkstyle/checkstyle-header.txt`, click Finish
+5. Select the new configuration file to enable it
+
+### Importing into Eclipse
+
+TODO

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <flatten-maven-plugin.version>1.2.5</flatten-maven-plugin.version>
         <maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
         <checkstyle.version>8.37</checkstyle.version>
-        <spring-javaformat-checkstyle.version>0.0.25</spring-javaformat-checkstyle.version>
+        <spring-javaformat-checkstyle.version>0.0.26</spring-javaformat-checkstyle.version>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
     </properties>
     <modules>
@@ -159,14 +159,6 @@
                     <execution>
                         <id>checkstyle-validation</id>
                         <phase>validate</phase>
-                        <configuration>
-                            <configLocation>src/checkstyle/checkstyle.xml</configLocation>
-                            <headerLocation>src/checkstyle/checkstyle-header.txt</headerLocation>
-                            <encoding>UTF-8</encoding>
-                            <consoleOutput>true</consoleOutput>
-                            <failOnViolation>true</failOnViolation>
-                            <includeTestSourceDirectory>true</includeTestSourceDirectory>
-                        </configuration>
                         <goals>
                             <goal>check</goal>
                         </goals>


### PR DESCRIPTION
- updated spring-javaformat-checkstyle plugin and removed duplicate configuration
- added code style settings so IntelliJ formats code to match the checkstyle settings
- added documentation on working with IntelliJ

Closes #1561 