### PR TITLE
Fix allow insecure access to Actuator endpoints

### DIFF
--- a/spring-boot-admin-samples/spring-boot-admin-sample-servlet/src/main/java/de/codecentric/boot/admin/SecuritySecureConfig.java
+++ b/spring-boot-admin-samples/spring-boot-admin-sample-servlet/src/main/java/de/codecentric/boot/admin/SecuritySecureConfig.java
@@ -50,6 +50,8 @@ public class SecuritySecureConfig extends WebSecurityConfigurerAdapter {
 
 		http.authorizeRequests(
 				(authorizeRequests) -> authorizeRequests.antMatchers(this.adminServer.path("/assets/**")).permitAll() // <1>
+						.antMatchers(this.adminServer.path("/actuator/info")).permitAll()
+						.antMatchers(this.adminServer.path("/actuator/health")).permitAll()
 						.antMatchers(this.adminServer.path("/login")).permitAll().anyRequest().authenticated() // <2>
 		).formLogin(
 				(formLogin) -> formLogin.loginPage(this.adminServer.path("/login")).successHandler(successHandler).and() // <3>


### PR DESCRIPTION
## Description
As of now, accessing any of the endpoints served by the spring-boot-actuator (e.g. `/actuator/health`) redirects the user/request to the login page. This prevents (for example) liveness and readiness Kubernetes probes to work.

The current fix sets those endpoints as `permitAll` in the security config.

## Note
There were some end of line comments with numbers `// <1>`, I don't know the logic behind them so just left the new entry without it.
