### PR TITLE
Feature/show request content length and type in http traces

### DIFF
--- a/spring-boot-admin-server-ui/src/main/frontend/views/instances/httptrace/i18n.de.json
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/instances/httptrace/i18n.de.json
@@ -10,7 +10,8 @@
         "successful_requests": "Erfolgreiche Anfragen",
         "total_requests": "Anfragen insgesamt"
       },
-      "content_type": "Content-Type",
+      "content_type_response": "Response Content-Type",
+      "content_type_request": "Request Content-Type",
       "fetching_failed": "Das Laden der Tracing-Informationen ist fehlgeschlagen.",
       "limit": "Limit",
       "filter": {
@@ -19,7 +20,8 @@
         "server_errors": "Server-Fehler",
         "success": "erfolgreich"
       },
-      "length": "Größe",
+      "length_response": "Response Größe",
+      "length_request": "Request Größe",
       "method": "Methode",
       "no_traces_found": "Keine Traces gefunden.",
       "status": "Status",

--- a/spring-boot-admin-server-ui/src/main/frontend/views/instances/httptrace/i18n.en.json
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/instances/httptrace/i18n.en.json
@@ -10,7 +10,9 @@
         "successful_requests": "successful requests",
         "total_requests": "total requests"
       },
-      "content_type": "Content-Type",
+      "content_type_response": "Response Content-Type",
+      "content_type_request": "Request Content-Type",
+      "length_request": "Request Length",
       "fetching_failed": "Fetching traces failed.",
       "limit": "limit",
       "filter": {
@@ -19,7 +21,7 @@
         "server_errors": "server errors",
         "success": "success"
       },
-      "length": "Length",
+      "length_response": "Response Length",
       "method": "Method",
       "no_traces_found": "No traces found.",
       "status": "Status",

--- a/spring-boot-admin-server-ui/src/main/frontend/views/instances/httptrace/i18n.fr.json
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/instances/httptrace/i18n.fr.json
@@ -10,7 +10,9 @@
         "successful_requests": "requêtes en succès",
         "total_requests": "requêtes au total"
       },
-      "content_type": "Content-Type",
+      "content_type_response": "Response Content-Type",
+      "content_type_request": "Request Content-Type",
+      "length_request": "Request Longueur",
       "fetching_failed": "Echec de la récupération des traces HTTP.",
       "limit": "limite",
       "filter": {
@@ -19,7 +21,7 @@
         "server_errors": "Erreurs serveurs",
         "success": "succès"
       },
-      "length": "Longueur",
+      "length_response": "Longueur",
       "method": "Methodes",
       "no_traces_found": "Aucune traces trouvées.",
       "status": "Statut",

--- a/spring-boot-admin-server-ui/src/main/frontend/views/instances/httptrace/i18n.fr.json
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/instances/httptrace/i18n.fr.json
@@ -21,7 +21,7 @@
         "server_errors": "Erreurs serveurs",
         "success": "succès"
       },
-      "length_response": "Longueur",
+      "length_response": "Response Longueur",
       "method": "Methodes",
       "no_traces_found": "Aucune traces trouvées.",
       "status": "Statut",

--- a/spring-boot-admin-server-ui/src/main/frontend/views/instances/httptrace/i18n.is.json
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/instances/httptrace/i18n.is.json
@@ -10,7 +10,9 @@
         "successful_requests": "Farsælar fyrirspurnir",
         "total_requests": "Samtals fyrirspurnir"
       },
-      "content_type": "Content-Type",
+      "content_type_response": "Response Content-Type",
+      "content_type_request": "Request Content-Type",
+      "length_request": "Request Length",
       "fetching_failed": "Mistókst að sækja upplýsingar um HTTP spor.",
       "limit": "Takmörkun",
       "filter": {
@@ -19,7 +21,7 @@
         "server_errors": "Vandamál þjóns",
         "success": "farsælt"
       },
-      "length": "Stærð",
+      "length_response": "Response Stærð",
       "method": "Aðferð",
       "no_traces_found": "Fundið engin spor.",
       "status": "Staða",

--- a/spring-boot-admin-server-ui/src/main/frontend/views/instances/httptrace/i18n.ko.json
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/instances/httptrace/i18n.ko.json
@@ -10,7 +10,9 @@
         "successful_requests": "성공적인 요청",
         "total_requests": "전체 요청"
       },
-      "content_type": "Content-Type",
+      "content_type_response": "Response Content-Type",
+      "content_type_request": "Request Content-Type",
+      "length_request": "Request 길이",
       "fetching_failed": "트레이스 정보를 가져오는데 실패했습니다.",
       "limit": "제한",
       "filter": {
@@ -19,7 +21,7 @@
         "server_errors": "서버 에러",
         "success": "성공"
       },
-      "length": "길이",
+      "length_response": "Response 길이",
       "method": "Method",
       "no_traces_found": "트레이스 정보가 없습니다.",
       "status": "상태",

--- a/spring-boot-admin-server-ui/src/main/frontend/views/instances/httptrace/i18n.pt-BR.json
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/instances/httptrace/i18n.pt-BR.json
@@ -10,7 +10,9 @@
         "successful_requests": "Requisições sucedidas",
         "total_requests": "total de requisições"
       },
-      "content_type": "Content-Type",
+      "content_type_response": "Response Content-Type",
+      "content_type_request": "Request Content-Type",
+      "length_request": "Request Length",
       "fetching_failed": "Falha na busca de traces.",
       "limit": "limite",
       "filter": {
@@ -19,7 +21,7 @@
         "server_errors": "erros do servidor",
         "success": "sucesso"
       },
-      "length": "Tamanho",
+      "length_response": "Response Tamanho",
       "method": "Metodo",
       "no_traces_found": "Nenhum trace encontrado.",
       "status": "Status",

--- a/spring-boot-admin-server-ui/src/main/frontend/views/instances/httptrace/i18n.ru.json
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/instances/httptrace/i18n.ru.json
@@ -10,7 +10,9 @@
         "successful_requests": "успешные запросы",
         "total_requests": "всего запросов"
       },
-      "content_type": "Content-Type",
+      "content_type_response": "Response Content-Type",
+      "content_type_request": "Request Content-Type",
+      "length_request": "Request Длина",
       "fetching_failed": "Ошибка трассировки.",
       "limit": "ограничение",
       "filter": {
@@ -19,7 +21,7 @@
         "server_errors": "ошибки сервера",
         "success": "успех"
       },
-      "length": "Длина",
+      "length_response": "Response Длина",
       "method": "Метод",
       "no_traces_found": "Трассировка не найдена.",
       "status": "Статус",

--- a/spring-boot-admin-server-ui/src/main/frontend/views/instances/httptrace/i18n.zh-CN.json
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/instances/httptrace/i18n.zh-CN.json
@@ -10,7 +10,9 @@
         "successful_requests": "请求成功",
         "total_requests": "请求总数"
       },
-      "content_type": "内容类型",
+      "content_type_response": "Response 内容类型",
+      "content_type_request": "Request 内容类型",
+      "length_request": "Request 长度",
       "fetching_failed": "获取跟踪信息失败。",
       "limit": "limit",
       "filter": {
@@ -19,7 +21,7 @@
         "server_errors": "服务器错误",
         "success": "请求成功"
       },
-      "length": "长度",
+      "length_response": "Response 长度",
       "method": "方法",
       "no_traces_found": "没有跟踪信息。",
       "status": "状态",

--- a/spring-boot-admin-server-ui/src/main/frontend/views/instances/httptrace/i18n.zh-TW.json
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/instances/httptrace/i18n.zh-TW.json
@@ -10,7 +10,9 @@
         "successful_requests": "請求成功",
         "total_requests": "請求總數"
       },
-      "content_type": "內容類型",
+      "content_type_response": "Response 內容類型",
+      "content_type_request": "Request 內容類型",
+      "length_request": "Request 長度",
       "fetching_failed": "抓取追蹤信息失敗。",
       "limit": "limit",
       "filter": {
@@ -19,7 +21,7 @@
         "server_errors": "伺服器錯誤",
         "success": "請求成功"
       },
-      "length": "長度",
+      "length_response": "Response 長度",
       "method": "方法",
       "no_traces_found": "沒有追蹤信息。",
       "status": "狀態",

--- a/spring-boot-admin-server-ui/src/main/frontend/views/instances/httptrace/index.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/instances/httptrace/index.vue
@@ -134,16 +134,32 @@ const addToFilter = (oldFilter, addedFilter) =>
       return `${this.timestamp.valueOf()}-${this.request.method}-${this.request.uri}`;
     }
 
-    get contentLength() {
-      const contentLength = this.response && this.response.headers['content-length'] && this.response.headers['content-length'][0];
+    get contentLengthResponse() {
+      return this.extractContentLength(this.response);
+    }
+
+    get contentLengthRequest() {
+      return this.extractContentLength(this.request);
+    }
+
+    extractContentLength(origin) {
+      const contentLength = origin && origin.headers['content-length'] && origin.headers['content-length'][0];
       if (contentLength && /^\d+$/.test(contentLength)) {
         return parseInt(contentLength);
       }
       return null;
     }
 
-    get contentType() {
-      const contentType = this.response &&  this.response.headers['content-type'] && this.response.headers['content-type'][0];
+    get contentTypeResponse() {
+      return this.extractContentType(this.response);
+    }
+
+    get contentTypeRequest() {
+      return this.extractContentType(this.request);
+    }
+
+    extractContentType(origin) {
+      const contentType = origin && origin.headers['content-type'] && origin.headers['content-type'][0];
       if (contentType) {
         const idx = contentType.indexOf(';');
         return idx >= 0 ? contentType.substring(0, idx) : contentType;

--- a/spring-boot-admin-server-ui/src/main/frontend/views/instances/httptrace/traces-list.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/instances/httptrace/traces-list.vue
@@ -22,8 +22,10 @@
         <th class="httptraces__trace-method" v-text="$t('instances.httptrace.method')" />
         <th class="httptraces__trace-uri" v-text="$t('instances.httptrace.uri')" />
         <th class="httptraces__trace-status" v-text="$t('instances.httptrace.status')" />
-        <th class="httptraces__trace-contentType" v-text="$t('instances.httptrace.content_type')" />
-        <th class="httptraces__trace-contentLength" v-text="$t('instances.httptrace.length')" />
+        <th class="httptraces__trace-contentType" v-text="$t('instances.httptrace.content_type_request')" />
+        <th class="httptraces__trace-contentLength" v-text="$t('instances.httptrace.length_request')" />
+        <th class="httptraces__trace-contentType" v-text="$t('instances.httptrace.content_type_response')" />
+        <th class="httptraces__trace-contentLength" v-text="$t('instances.httptrace.length_response')" />
         <th class="httptraces__trace-timeTaken" v-text="$t('instances.httptrace.time')" />
       </tr>
     </thead>
@@ -50,9 +52,13 @@
                   :class="{ 'is-muted' : trace.isPending(), 'is-success' : trace.isSuccess(), 'is-warning' : trace.isClientError(), 'is-danger' : trace.isServerError() }"
             />
           </td>
-          <td class="httptraces__trace-contentType" v-text="trace.contentType" />
+          <td class="httptraces__trace-contentType" v-text="trace.contentTypeRequest" />
           <td class="httptraces__trace-contentLength"
-              v-text="trace.contentLength ? prettyBytes(trace.contentLength) : ''"
+              v-text="trace.contentLengthRequest ? prettyBytes(trace.contentLengthRequest) : ''"
+          />
+          <td class="httptraces__trace-contentType" v-text="trace.contentTypeResponse" />
+          <td class="httptraces__trace-contentLength"
+              v-text="trace.contentLengthResponse ? prettyBytes(trace.contentLengthResponse) : ''"
           />
           <td class="httptraces__trace-timeTaken"
               v-text="trace.timeTaken !== null && typeof trace.timeTaken !== 'undefined' ? `${trace.timeTaken} ms` : ''"


### PR DESCRIPTION
Show request content-type and length in http-traces as proposed in https://github.com/codecentric/spring-boot-admin/issues/1287