### PR TITLE
NoArgConstructor for InstanceCredentials, so it can be loaded as ConfigurationProperties

### DIFF
--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/client/BasicAuthHttpHeaderProvider.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/client/BasicAuthHttpHeaderProvider.java
@@ -27,6 +27,7 @@ import org.springframework.util.Base64Utils;
 import org.springframework.util.StringUtils;
 
 import de.codecentric.boot.admin.server.domain.entities.Instance;
+import lombok.NoArgsConstructor;
 
 /**
  * Provides Basic Auth headers for the {@link Instance} using the metadata for "user.name"
@@ -103,6 +104,7 @@ public class BasicAuthHttpHeaderProvider implements HttpHeadersProvider {
 	}
 
 	@lombok.Data(staticConstructor = "of")
+	@NoArgsConstructor
 	public static class InstanceCredentials {
 
 		/**

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/client/BasicAuthHttpHeaderProvider.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/client/BasicAuthHttpHeaderProvider.java
@@ -27,7 +27,6 @@ import org.springframework.util.Base64Utils;
 import org.springframework.util.StringUtils;
 
 import de.codecentric.boot.admin.server.domain.entities.Instance;
-import lombok.NoArgsConstructor;
 
 /**
  * Provides Basic Auth headers for the {@link Instance} using the metadata for "user.name"
@@ -103,8 +102,9 @@ public class BasicAuthHttpHeaderProvider implements HttpHeadersProvider {
 		return null;
 	}
 
-	@lombok.Data(staticConstructor = "of")
-	@NoArgsConstructor
+	@lombok.Data
+	@lombok.NoArgsConstructor
+	@lombok.AllArgsConstructor
 	public static class InstanceCredentials {
 
 		/**

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/config/AdminServerPropertiesTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/config/AdminServerPropertiesTest.java
@@ -1,6 +1,20 @@
-package de.codecentric.boot.admin.server.config;
+/*
+ * Copyright 2014-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+package de.codecentric.boot.admin.server.config;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -9,24 +23,26 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @ExtendWith(SpringExtension.class)
-@EnableConfigurationProperties(value = AdminServerProperties.class)
+@EnableConfigurationProperties(AdminServerProperties.class)
 @TestPropertySource("classpath:server-config-test.properties")
 public class AdminServerPropertiesTest {
 
-    @Autowired
-    private AdminServerProperties serverConfig;
+	@Autowired
+	private AdminServerProperties serverConfig;
 
-    @Test
-    void testLoadConfigurationProperties() {
-    	
-    	assertEquals("/admin", serverConfig.getContextPath());
+	@Test
+	void testLoadConfigurationProperties() {
+		assertThat(serverConfig.getContextPath()).isEqualTo("/admin");
 
-    	assertEquals("admin", serverConfig.getInstanceAuth().getDefaultUserName());
-    	assertEquals("topsecret", serverConfig.getInstanceAuth().getDefaultPassword());
+		assertThat(serverConfig.getInstanceAuth().getDefaultUserName()).isEqualTo("admin");
+		assertThat(serverConfig.getInstanceAuth().getDefaultPassword()).isEqualTo("topsecret");
 
-    	assertEquals("me", serverConfig.getInstanceAuth().getServiceMap().get("my-service").getUserName());
-    	assertEquals("secret", serverConfig.getInstanceAuth().getServiceMap().get("my-service").getUserPassword());
-    }
-   
+		assertThat(serverConfig.getInstanceAuth().getServiceMap().get("my-service").getUserName()).isEqualTo("me");
+		assertThat(serverConfig.getInstanceAuth().getServiceMap().get("my-service").getUserPassword())
+				.isEqualTo("secret");
+	}
+
 }

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/config/AdminServerPropertiesTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/config/AdminServerPropertiesTest.java
@@ -1,0 +1,32 @@
+package de.codecentric.boot.admin.server.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@EnableConfigurationProperties(value = AdminServerProperties.class)
+@TestPropertySource("classpath:server-config-test.properties")
+public class AdminServerPropertiesTest {
+
+    @Autowired
+    private AdminServerProperties serverConfig;
+
+    @Test
+    void testLoadConfigurationProperties() {
+    	
+    	assertEquals("/admin", serverConfig.getContextPath());
+
+    	assertEquals("admin", serverConfig.getInstanceAuth().getDefaultUserName());
+    	assertEquals("topsecret", serverConfig.getInstanceAuth().getDefaultPassword());
+
+    	assertEquals("me", serverConfig.getInstanceAuth().getServiceMap().get("my-service").getUserName());
+    	assertEquals("secret", serverConfig.getInstanceAuth().getServiceMap().get("my-service").getUserPassword());
+    }
+   
+}

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/web/client/BasicAuthHttpHeaderProviderTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/web/client/BasicAuthHttpHeaderProviderTest.java
@@ -33,7 +33,7 @@ public class BasicAuthHttpHeaderProviderTest {
 	private final BasicAuthHttpHeaderProvider headersProvider = new BasicAuthHttpHeaderProvider();
 
 	private final BasicAuthHttpHeaderProvider headersProviderEnableInstanceAuth = new BasicAuthHttpHeaderProvider(
-			"client", "client", Collections.singletonMap("sb-admin-server", InstanceCredentials.of("admin", "admin")));
+			"client", "client", Collections.singletonMap("sb-admin-server", new InstanceCredentials("admin", "admin")));
 
 	@Test
 	public void test_auth_header() {

--- a/spring-boot-admin-server/src/test/resources/server-config-test.properties
+++ b/spring-boot-admin-server/src/test/resources/server-config-test.properties
@@ -1,0 +1,7 @@
+spring.boot.admin.contextPath=/admin
+
+spring.boot.admin.instance-auth.default-user-name=admin
+spring.boot.admin.instance-auth.default-password=topsecret
+
+spring.boot.admin.instance-auth.service-map.my-service.userName=me
+spring.boot.admin.instance-auth.service-map.my-service.userPassword=secret


### PR DESCRIPTION
Hi SBA Team,

InstanceCredentials should have a DefaultConstructor, as it is used as Spring ConfigurationProperties.

please see https://github.com/codecentric/spring-boot-admin/issues/1559

thanks,
Soeren