### PR TITLE
Use OS-agnostic relpaths in dev configurations

### DIFF
--- a/spring-boot-admin-samples/spring-boot-admin-sample-custom-ui/README.md
+++ b/spring-boot-admin-samples/spring-boot-admin-sample-custom-ui/README.md
@@ -15,7 +15,7 @@ npm run watch
 2. Run a Spring Boot Admin Server instances with the template-location and resource-location pointing to the build output and disable caching:
 ```
 spring.boot.admin.ui.cache.no-cache: true
-spring.boot.admin.ui.extension-resource-locations: file:@project.basedir@/../spring-boot-admin-sample-custom-ui/target/dist/
+spring.boot.admin.ui.extension-resource-locations: file:../spring-boot-admin-sample-custom-ui/target/dist/
 spring.boot.admin.ui.cache-templates: false
 ```
 Or just start the [spring-boot-admin-sample-servlet](../spring-boot-admin-sample-servlet) project using the `dev` profile.

--- a/spring-boot-admin-samples/spring-boot-admin-sample-reactive/src/main/resources/application.yml
+++ b/spring-boot-admin-samples/spring-boot-admin-sample-reactive/src/main/resources/application.yml
@@ -35,8 +35,8 @@ spring:
       ui:
         cache:
           no-cache: true
-        template-location: file://@project.basedir@/../../spring-boot-admin-server-ui/target/dist/
-        resource-locations: file://@project.basedir@/../../spring-boot-admin-server-ui/target/dist/
+        template-location: file:../../spring-boot-admin-server-ui/target/dist/
+        resource-locations: file:../../spring-boot-admin-server-ui/target/dist/
         cache-templates: false
 
 ---

--- a/spring-boot-admin-samples/spring-boot-admin-sample-servlet/src/main/resources/application.yml
+++ b/spring-boot-admin-samples/spring-boot-admin-sample-servlet/src/main/resources/application.yml
@@ -58,10 +58,10 @@ spring:
       ui:
         cache:
           no-cache: true
-        template-location: file:@project.basedir@/../../spring-boot-admin-server-ui/target/dist/
-        resource-locations: file:@project.basedir@/../../spring-boot-admin-server-ui/target/dist/
+        template-location: file:../../spring-boot-admin-server-ui/target/dist/
+        resource-locations: file:../../spring-boot-admin-server-ui/target/dist/
         cache-templates: false
-        extension-resource-locations: file:@project.basedir@/../spring-boot-admin-sample-custom-ui/target/dist/
+        extension-resource-locations: file:../spring-boot-admin-sample-custom-ui/target/dist/
 
 ---
 

--- a/spring-boot-admin-server-ui/README.md
+++ b/spring-boot-admin-server-ui/README.md
@@ -15,8 +15,8 @@ npm run watch
 2. Run a Spring Boot Admin Server instances with the template-location and resource-location pointing to the build output and disable caching:
 ```
 spring.boot.admin.ui.cache.no-cache: true
-spring.boot.admin.ui.resource-locations: file:@project.basedir@/../../spring-boot-admin-server-ui/target/dist/
-spring.boot.admin.ui.template-location: file:@project.basedir@/../../spring-boot-admin-server-ui/target/dist/
+spring.boot.admin.ui.resource-locations: file:../../spring-boot-admin-server-ui/target/dist/
+spring.boot.admin.ui.template-location: file:../../spring-boot-admin-server-ui/target/dist/
 spring.boot.admin.ui.cache-templates: false
 ```
 Or just start the [spring-boot-admin-sample-servlet](../spring-boot-admin-samples/spring-boot-admin-sample-servlet)


### PR DESCRIPTION
Running a local development build as described in [Running Spring Boot Admin Server for development](https://github.com/codecentric/spring-boot-admin/blob/6e12776b9d3e80b00c443d3688f3703354b4bfe2/spring-boot-admin-server-ui/README.md#running-spring-boot-admin-server-for-development) doesn't work as expected on Windows, with most assets returning a 404. 

I suspect the cause is the absolute paths in the form of `@project.basedir@/../../spring-boot-admin-server-ui/target/dist/`, which resolve to something weird like `C:\\Users\\me\\<projectdir>\\../../spring-boot-admin-server-ui/target/dist/`.  
Using relative paths fixes the issue on Windows, and does not seem to affect existing behavior in *nix (tested on Windows 10 and Ubuntu 20.10).