### PR TITLE
Upgrade spring cloud dependencies to 2020.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 
         <!-- used dependencies versions -->
         <spring-boot.version>2.4.3</spring-boot.version>
-        <spring-cloud.version>2020.0.0-M3</spring-cloud.version>
+        <spring-cloud.version>2020.0.1</spring-cloud.version>
         <wiremock.version>2.27.2</wiremock.version>
         <hazelcast-tests.version>4.0.3</hazelcast-tests.version>
         <findbugs-jsr305.version>3.0.2</findbugs-jsr305.version>

--- a/spring-boot-admin-server-cloud/pom.xml
+++ b/spring-boot-admin-server-cloud/pom.xml
@@ -61,10 +61,22 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!-- Optional Kuberneteds Discovery Client -->
+        <!-- Optional Kubernetes Discovery using Official Kubernetes Client -->
         <dependency>
             <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-kubernetes</artifactId>
+            <artifactId>spring-cloud-starter-kubernetes-client</artifactId>
+            <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-web</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- Optional Kubernetes Discovery using Fabric 8 Kubernetes Java Client -->
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-kubernetes-fabric8</artifactId>
             <optional>true</optional>
             <exclusions>
                 <exclusion>

--- a/spring-boot-admin-server-cloud/src/test/java/de/codecentric/boot/admin/server/cloud/AdminApplicationDiscoveryTest.java
+++ b/spring-boot-admin-server-cloud/src/test/java/de/codecentric/boot/admin/server/cloud/AdminApplicationDiscoveryTest.java
@@ -31,6 +31,7 @@ import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.cloud.client.DefaultServiceInstance;
 import org.springframework.cloud.client.discovery.event.InstanceRegisteredEvent;
 import org.springframework.cloud.client.discovery.simple.SimpleDiscoveryProperties;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -66,7 +67,7 @@ public class AdminApplicationDiscoveryTest {
 		this.instance = new SpringApplicationBuilder().sources(TestAdminApplication.class)
 				.web(WebApplicationType.REACTIVE).run("--server.port=0", "--management.endpoints.web.base-path=/mgmt",
 						"--endpoints.health.enabled=true", "--info.test=foobar", "--eureka.client.enabled=false",
-						"--spring.cloud.kubernetes.discovery.enabled=false");
+						"--spring.cloud.kubernetes.enabled=false", "--spring.cloud.kubernetes.discovery.enabled=false");
 
 		this.simpleDiscovery = this.instance.getBean(SimpleDiscoveryProperties.class);
 
@@ -96,7 +97,7 @@ public class AdminApplicationDiscoveryTest {
 		// We register the instance by setting static values for the SimpleDiscoveryClient
 		// and issuing a
 		// InstanceRegisteredEvent that makes sure the instance gets registered.
-		SimpleDiscoveryProperties.SimpleServiceInstance serviceInstance = new SimpleDiscoveryProperties.SimpleServiceInstance();
+		DefaultServiceInstance serviceInstance = new DefaultServiceInstance();
 		serviceInstance.setServiceId("Test-Instance");
 		serviceInstance.setUri(URI.create("http://localhost:" + this.port));
 		serviceInstance.getMetadata().put("management.context-path", "/mgmt");


### PR DESCRIPTION
Use `2020.0.1` (last) instead of `2020.0.0-M3`.
This also brings kubernetes [fabric8 client](https://github.com/fabric8io/kubernetes-client) handle alongside with [official one](https://github.com/kubernetes-client/java)

Close #1644