### PR TITLE
Fix for #1638

### DIFF
--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/client/InstanceExchangeFilterFunctions.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/client/InstanceExchangeFilterFunctions.java
@@ -141,7 +141,7 @@ public final class InstanceExchangeFilterFunctions {
 		return response.mutate().headers((headers) -> {
 			headers.replace(HttpHeaders.CONTENT_TYPE, singletonList(ActuatorMediaType.V2_JSON));
 			headers.remove(HttpHeaders.CONTENT_LENGTH);
-		}).body(response.bodyToFlux(DataBuffer.class).transform(converter::convert)).build();
+		}).body(converter::convert).build();
 	}
 
 	public static InstanceExchangeFilterFunction setDefaultAcceptHeader() {

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/client/InstanceExchangeFilterFunctions.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/client/InstanceExchangeFilterFunctions.java
@@ -27,7 +27,6 @@ import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.actuate.endpoint.http.ActuatorMediaType;
-import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;


### PR DESCRIPTION
After upgrading to Spring Boot 2.4.x `LegacyEndpointConverter` was never called.
Switching to the `ClientResponse` builder method, which transforms the existing body directly, instead of changing the body and setting it in two steps, solves the problem.