### PR TITLE
Improved execution of grouped assertions

### DIFF
--- a/spring-boot-admin-client/src/test/java/de/codecentric/boot/admin/client/registration/CloudFoundryApplicationFactoryTest.java
+++ b/spring-boot-admin-client/src/test/java/de/codecentric/boot/admin/client/registration/CloudFoundryApplicationFactoryTest.java
@@ -30,6 +30,7 @@ import de.codecentric.boot.admin.client.config.InstanceProperties;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -63,9 +64,9 @@ public class CloudFoundryApplicationFactoryTest {
 
 		Application app = this.factory.createApplication();
 
-		assertThat(app.getManagementUrl()).isEqualTo("http://application/Uppercase/actuator");
-		assertThat(app.getHealthUrl()).isEqualTo("http://application/Uppercase/actuator/health");
-		assertThat(app.getServiceUrl()).isEqualTo("http://application/Uppercase/");
+		assertAll(() -> assertThat(app.getManagementUrl()).isEqualTo("http://application/Uppercase/actuator"),
+				() -> assertThat(app.getHealthUrl()).isEqualTo("http://application/Uppercase/actuator/health"),
+				() -> assertThat(app.getServiceUrl()).isEqualTo("http://application/Uppercase/"));
 	}
 
 	@Test
@@ -76,9 +77,9 @@ public class CloudFoundryApplicationFactoryTest {
 
 		Application app = this.factory.createApplication();
 
-		assertThat(app.getManagementUrl()).isEqualTo("https://serviceBaseUrl/actuator");
-		assertThat(app.getHealthUrl()).isEqualTo("https://serviceBaseUrl/actuator/health");
-		assertThat(app.getServiceUrl()).isEqualTo("https://serviceBaseUrl/");
+		assertAll(() -> assertThat(app.getManagementUrl()).isEqualTo("https://serviceBaseUrl/actuator"),
+				() -> assertThat(app.getHealthUrl()).isEqualTo("https://serviceBaseUrl/actuator/health"),
+				() -> assertThat(app.getServiceUrl()).isEqualTo("https://serviceBaseUrl/"));
 	}
 
 }

--- a/spring-boot-admin-client/src/test/java/de/codecentric/boot/admin/client/registration/CloudFoundryApplicationFactoryTest.java
+++ b/spring-boot-admin-client/src/test/java/de/codecentric/boot/admin/client/registration/CloudFoundryApplicationFactoryTest.java
@@ -16,6 +16,7 @@
 
 package de.codecentric.boot.admin.client.registration;
 
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
@@ -29,8 +30,6 @@ import de.codecentric.boot.admin.client.config.InstanceProperties;
 
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -64,9 +63,11 @@ public class CloudFoundryApplicationFactoryTest {
 
 		Application app = this.factory.createApplication();
 
-		assertAll(() -> assertThat(app.getManagementUrl()).isEqualTo("http://application/Uppercase/actuator"),
-				() -> assertThat(app.getHealthUrl()).isEqualTo("http://application/Uppercase/actuator/health"),
-				() -> assertThat(app.getServiceUrl()).isEqualTo("http://application/Uppercase/"));
+		SoftAssertions softly = new SoftAssertions();
+		softly.assertThat(app.getManagementUrl()).isEqualTo("http://application/Uppercase/actuator");
+		softly.assertThat(app.getHealthUrl()).isEqualTo("http://application/Uppercase/actuator/health");
+		softly.assertThat(app.getServiceUrl()).isEqualTo("http://application/Uppercase/");
+		softly.assertAll();
 	}
 
 	@Test
@@ -77,9 +78,11 @@ public class CloudFoundryApplicationFactoryTest {
 
 		Application app = this.factory.createApplication();
 
-		assertAll(() -> assertThat(app.getManagementUrl()).isEqualTo("https://serviceBaseUrl/actuator"),
-				() -> assertThat(app.getHealthUrl()).isEqualTo("https://serviceBaseUrl/actuator/health"),
-				() -> assertThat(app.getServiceUrl()).isEqualTo("https://serviceBaseUrl/"));
+		SoftAssertions softly = new SoftAssertions();
+		softly.assertThat(app.getManagementUrl()).isEqualTo("https://serviceBaseUrl/actuator");
+		softly.assertThat(app.getHealthUrl()).isEqualTo("https://serviceBaseUrl/actuator/health");
+		softly.assertThat(app.getServiceUrl()).isEqualTo("https://serviceBaseUrl/");
+		softly.assertAll();
 	}
 
 }


### PR DESCRIPTION
**Problem:**
A test method with many individual assertions stops being executed on the first failed assertion, which prevents the remaining ones' execution.

**Solution:**
Using the soft assertions feature, all assertions are executed, and all failures will be reported together. In this refactoring, no original assertion was changed.

**Result:**
_Before:_
```
assertThat(app.getManagementUrl()).isEqualTo("http://application/Uppercase/actuator");
assertThat(app.getHealthUrl()).isEqualTo("http://application/Uppercase/actuator/health");
assertThat(app.getServiceUrl()).isEqualTo("http://application/Uppercase/");
```

_After:_
```
SoftAssertions softly = new SoftAssertions();
softly.assertThat(app.getManagementUrl()).isEqualTo("http://application/Uppercase/actuator");
softly.assertThat(app.getHealthUrl()).isEqualTo("http://application/Uppercase/actuator/health");
softly.assertThat(app.getServiceUrl()).isEqualTo("http://application/Uppercase/");
softly.assertAll();
```