### PR TITLE
Fix/401 redirect on actuator requests

### DIFF
--- a/spring-boot-admin-server-ui/src/main/frontend/services/instance.js
+++ b/spring-boot-admin-server-ui/src/main/frontend/services/instance.js
@@ -39,7 +39,7 @@ class Instance {
     });
     this.axios.interceptors.response.use(
       response => response,
-      redirectOn401(error => !isInstanceActuatorRequest(error.config.url))
+      redirectOn401(error => !isInstanceActuatorRequest(error.config.baseURL + error.config.url))
     );
   }
 

--- a/spring-boot-admin-server-ui/src/main/frontend/views/instances/details/details-cache.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/instances/details/details-cache.vue
@@ -61,9 +61,10 @@
   import sbaConfig from '@/sba-config';
   import subscribing from '@/mixins/subscribing';
   import Instance from '@/services/instance';
-  import {concatMap, timer} from '@/utils/rxjs';
+  import {concatMap, delay, retryWhen, timer} from '@/utils/rxjs';
   import moment from 'moment';
   import cacheChart from './cache-chart';
+  import {take} from 'rxjs/operators';
 
   export default {
     props: {
@@ -145,7 +146,13 @@
       createSubscription() {
         const vm = this;
         return timer(0, sbaConfig.uiSettings.pollTimer.cache)
-          .pipe(concatMap(vm.fetchMetrics))
+          .pipe(concatMap(vm.fetchMetrics), retryWhen(
+            err => {
+              return err.pipe(
+                delay(1000),
+                take(5)
+              )
+            }))
           .subscribe({
             next: data => {
               vm.hasLoaded = true;

--- a/spring-boot-admin-server-ui/src/main/frontend/views/instances/details/details-process.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/instances/details/details-process.vue
@@ -68,9 +68,10 @@
   import sbaConfig from '@/sba-config'
   import subscribing from '@/mixins/subscribing';
   import Instance from '@/services/instance';
-  import {concatMap, timer} from '@/utils/rxjs';
+  import {concatMap, delay, retryWhen, timer} from '@/utils/rxjs';
   import {toMillis} from '../metrics/metric';
   import processUptime from './process-uptime';
+  import {take} from 'rxjs/operators';
 
   export default {
     props: {
@@ -129,7 +130,13 @@
       createSubscription() {
         const vm = this;
         return timer(0, sbaConfig.uiSettings.pollTimer.process)
-          .pipe(concatMap(this.fetchCpuLoadMetrics))
+          .pipe(concatMap(this.fetchCpuLoadMetrics), retryWhen(
+            err => {
+              return err.pipe(
+                delay(1000),
+                take(5)
+              )
+            }))
           .subscribe({
             next: data => {
               vm.processCpuLoad = data.processCpuLoad;

--- a/spring-boot-admin-server-ui/src/main/frontend/views/instances/details/details-threads.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/instances/details/details-threads.vue
@@ -55,9 +55,10 @@
   import sbaConfig from '@/sba-config';
   import subscribing from '@/mixins/subscribing';
   import Instance from '@/services/instance';
-  import {concatMap, timer} from '@/utils/rxjs';
+  import {concatMap, delay, retryWhen, timer} from '@/utils/rxjs';
   import moment from 'moment';
   import threadsChart from './threads-chart';
+  import {take} from 'rxjs/operators';
 
   export default {
     props: {
@@ -89,7 +90,13 @@
       createSubscription() {
         const vm = this;
         return timer(0, sbaConfig.uiSettings.pollTimer.threads)
-          .pipe(concatMap(this.fetchMetrics))
+          .pipe(concatMap(this.fetchMetrics), retryWhen(
+            err => {
+              return err.pipe(
+                delay(1000),
+                take(5)
+              )
+            }))
           .subscribe({
             next: data => {
               vm.hasLoaded = true;

--- a/spring-boot-admin-server-ui/src/main/frontend/views/instances/metrics/metric.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/instances/metrics/metric.vue
@@ -66,10 +66,11 @@
 <script>
   import subscribing from '@/mixins/subscribing';
   import Instance from '@/services/instance';
-  import {concatMap, from, timer} from '@/utils/rxjs';
+  import {concatMap, delay, from, retryWhen, timer} from '@/utils/rxjs';
   import moment from 'moment';
   import prettyBytes from 'pretty-bytes';
   import i18n from '@/i18n';
+  import {take} from 'rxjs/operators';
 
   const formatDuration = (value, baseUnit) => {
     const duration = moment.duration(toMillis(value, baseUnit));
@@ -174,7 +175,13 @@
       createSubscription() {
         const vm = this;
         return timer(0, 2500)
-          .pipe(concatMap(vm.fetchAllTags))
+          .pipe(concatMap(vm.fetchAllTags), retryWhen(
+            err => {
+              return err.pipe(
+                delay(1000),
+                take(2)
+              )
+            }))
           .subscribe({
             next: () => {
             }


### PR DESCRIPTION
closes #1640, #1691 and probably some other issues connected to redirects to login.

I corrected the predicate inside the redirectOn401 (isInstanceActuatorRequest didn't include the baseUrl and so the predicate never matched).
However - the existance of this predicate suggests that there was previously a reaction to a 401 at actuator endpoints (still don't know why it occurs though).
I added a retry for the subscriptions and the UI seems to be working correctly with these adjustments.