### PR TITLE
Fix `sba-alert`'s rendering in absence of an error

### DIFF
--- a/spring-boot-admin-server-ui/src/main/frontend/components/sba-alert.spec.js
+++ b/spring-boot-admin-server-ui/src/main/frontend/components/sba-alert.spec.js
@@ -33,4 +33,18 @@ describe('sba-alert', () => {
     expect(screen.getByText('i am a error message')).toBeDefined();
     expect(screen.getByText('This is a caption')).toBeDefined();
   });
+
+  it('should render nothing', () => {
+    const props = {
+      title: 'This is a caption',
+    }
+    render(sbaAlert, {
+      props,
+      stubs: {
+        'font-awesome-icon': true
+      }
+    });
+
+    expect(screen.queryByText('This is a caption')).not.toBeInTheDocument();
+  });
 })

--- a/spring-boot-admin-server-ui/src/main/frontend/components/sba-alert.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/components/sba-alert.vue
@@ -15,7 +15,7 @@
   -->
 
 <template>
-  <div class="message" :class="alertClass" role="alert" v-if="hasError">
+  <div class="message" :class="alertClass" role="alert" v-if="hasError()">
     <div class="message-body">
       <strong>
         <font-awesome-icon :class="iconClass" icon="exclamation-triangle" />&nbsp;<span v-text="title" />


### PR DESCRIPTION
Noticed an error in the browser console after upgrading to SBA 2.5.0: `TypeError: Cannot read property 'message' of null`, since we were trying to access a property instead of calling the function.