### PR TITLE
Handle `null` metaspace values explicitly when rendering memory charts

### DIFF
--- a/spring-boot-admin-server-ui/src/main/frontend/views/instances/details/mem-chart.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/instances/details/mem-chart.vue
@@ -90,7 +90,7 @@
           .attr('d', d3.area()
             .x(d => x(d.timestamp))
             .y0(y(0))
-            .y1(d => y(d.metaspace)));
+            .y1(d => y(d.metaspace || 0)));
         metaspace.exit().remove();
 
         //draw axis


### PR DESCRIPTION
After the upgrade to SBA 2.5.0, I noticed an error started to appear in the console when accessing the details page of an instance (notice the `NaN`), although rendering seems fine:

```
Error: <path> attribute d: Expected number, "M0,NaNL24.095068694…".
```

I tracked this down to the upgrade of the `d3-scale` library (as part of codecentric/spring-boot-admin@4b72b42), where in https://github.com/d3/d3-scale/pull/241 they started to treat `null` values as `undefined` which get coerced to `NaN`. Just like https://github.com/codecentric/spring-boot-admin/blob/9257bf233144fa342a2b963879a62e2a6bcdf7e6/spring-boot-admin-server-ui/src/main/frontend/views/instances/details/mem-chart.vue#L81, we should also handle `null` values explicitly here. This also resolves the errors in my local setup.