### PR TITLE
do not invoke next filter accidentally by preparing fallback

### DIFF
--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/client/InstanceWebClient.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/client/InstanceWebClient.java
@@ -62,9 +62,11 @@ public class InstanceWebClient {
 	}
 
 	private static ExchangeFilterFunction toExchangeFilterFunction(InstanceExchangeFilterFunction filter) {
-		return (request, next) -> request.attribute(ATTRIBUTE_INSTANCE).filter(Instance.class::isInstance)
-				.map(Instance.class::cast).map((instance) -> filter.filter(instance, request, next))
-				.orElse(next.exchange(request));
+		return (request, next) -> request.attribute(ATTRIBUTE_INSTANCE)
+			.filter(Instance.class::isInstance)
+			.map(Instance.class::cast)
+			.map((instance) -> filter.filter(instance, request, next))
+			.orElseGet(() -> next.exchange(request));
 	}
 
 	public static class Builder {


### PR DESCRIPTION
The fallback solution for not having an instance is to skip
the filter and invoke the next one.
This fallback is already executed during preparation of the
Optional, so the next filter is getting triggered even if not needed.

Solution is to wrap the invocation of the next filter in a lambda
which is only executed when needed.