### PR TITLE
Update spring boot to 2.5.6 and spring cloud to 2020.0.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,8 +35,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- used dependencies versions -->
-        <spring-boot.version>2.5.4</spring-boot.version>
-        <spring-cloud.version>2020.0.3</spring-cloud.version>
+        <spring-boot.version>2.5.6</spring-boot.version>
+        <spring-cloud.version>2020.0.4</spring-cloud.version>
         <wiremock.version>2.31.0</wiremock.version>
         <hazelcast-tests.version>4.2.2</hazelcast-tests.version>
         <findbugs-jsr305.version>3.0.2</findbugs-jsr305.version>


### PR DESCRIPTION
* Update spring boot to `2.5.6`
* Update spring cloud to `2020.0.4`
According to [documentation](https://spring.io/blog/2021/09/23/spring-cloud-2020-0-4-has-been-released), spring cloud `2020.0.4` is *compatible with spring boot 2.5.X*