### PR TITLE
fix: Add defensive code to prevent metadata containing null key.

### DIFF
--- a/spring-boot-admin-server-cloud/src/main/java/de/codecentric/boot/admin/server/cloud/discovery/DefaultServiceInstanceConverter.java
+++ b/spring-boot-admin-server-cloud/src/main/java/de/codecentric/boot/admin/server/cloud/discovery/DefaultServiceInstanceConverter.java
@@ -18,6 +18,7 @@ package de.codecentric.boot.admin.server.cloud.discovery;
 
 import java.net.URI;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -147,7 +148,9 @@ public class DefaultServiceInstanceConverter implements ServiceInstanceConverter
 	}
 
 	protected Map<String, String> getMetadata(ServiceInstance instance) {
-		return (instance.getMetadata() != null) ? instance.getMetadata() : emptyMap();
+		return (instance.getMetadata() != null) ? instance.getMetadata().entrySet().stream()
+				.filter((e) -> e.getKey() != null).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))
+				: emptyMap();
 	}
 
 	public void setManagementContextPath(String managementContextPath) {

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/domain/values/Tags.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/domain/values/Tags.java
@@ -78,11 +78,12 @@ public final class Tags implements Serializable {
 			}
 
 			String flatPrefix = prefix + ".";
-			return from(map.entrySet().stream().filter((e) -> e.getKey().toLowerCase().startsWith(flatPrefix))
+			return from(map.entrySet().stream().filter((e) -> e.getKey() != null)
+					.filter((e) -> e.getKey().toLowerCase().startsWith(flatPrefix))
 					.collect(toLinkedHashMap((e) -> e.getKey().substring(flatPrefix.length()), Map.Entry::getValue)));
 		}
 
-		return new Tags(map.entrySet().stream()
+		return new Tags(map.entrySet().stream().filter((e) -> e.getKey() != null)
 				.collect(toLinkedHashMap(Map.Entry::getKey, (e) -> Objects.toString(e.getValue()))));
 	}
 


### PR DESCRIPTION
I'm trying to use spring boot admin inside a k8s cluster.
Due to some weird setup out of my control  (k8s, spring-cloud-kubernetes, ...) when boot-admin retrieve instances, some of them contains a metadata map with empty key.
It's a pb because: 
* When building tags it generates exception that stop continuing to add instances.
* When serializing Registration, we'll get a Jackson error (cannot serialize null key)


