### PR TITLE
fix(#1632): do not stop polling log file when rolled over

### DIFF
--- a/spring-boot-admin-server-ui/src/main/frontend/utils/rxjs.js
+++ b/spring-boot-admin-server-ui/src/main/frontend/utils/rxjs.js
@@ -17,9 +17,11 @@
 import {defer, tap} from 'rxjs';
 
 export {
-  throwError, of,
+  of,
   defer,
   concat,
+  catchError,
+  throwError,
   EMPTY,
   from,
   timer,


### PR DESCRIPTION
closes #1632 