### PR TITLE
Fix sba-toggle-scope-button binding in sba-action-button-scoped

### DIFF
--- a/spring-boot-admin-server-ui/src/main/frontend/components/sba-action-button-scoped.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/components/sba-action-button-scoped.vue
@@ -19,7 +19,7 @@
     <div class="field-body">
       <sba-toggle-scope-button v-if="instanceCount > 1"
                                :instance-count="instanceCount"
-                               @changeScope="setScope"
+                               v-model="currentScope"
       />
       <div class="field has-icons-left">
         <sba-confirm-button class="button is-light"


### PR DESCRIPTION
Hi,

it seems there is an error in component SbaActionButtonScoped. It's binding the currentScope only one way (@event) but it's not passing its current value to the child. I've change it to use v-model as it's used in view logger.vue