### PR TITLE
Emit event when scopes changes

### DIFF
--- a/spring-boot-admin-server-ui/src/main/frontend/views/instances/loggers/loggers.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/instances/loggers/loggers.vue
@@ -23,6 +23,7 @@
         <div class="control">
           <sba-toggle-scope-button v-if="instanceCount > 1"
                                    v-model="scope"
+                                   @changeScope="$emit('changeScope', $event)"
                                    :instance-count="instanceCount"
           />
         </div>


### PR DESCRIPTION
Hi,

when SbaToggleScopeButton is clicked on Logger.vue its own data its changing, but not logger/index.vue (its parent). This is preventing logger/index.vue to change the service from InstanceLoggers to ApplicationLoggers and vice versa. I've added one event $emit to communicate the parent this change.