### PR TITLE
fix(style): Wrap division in calc

### DIFF
--- a/spring-boot-admin-server-ui/src/main/frontend/views/applications/applications-list-item.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/applications/applications-list-item.vue
@@ -332,7 +332,7 @@ export default {
       opacity: 0;
       transition: all $easing $speed;
       will-change: opacity;
-      margin-right: ($gap / 2);
+      margin-right: calc(#{$gap} / 2);
       display: flex;
 
       *:hover > &,
@@ -341,8 +341,8 @@ export default {
       }
 
       & > * {
-        width: ($gap / 2);
-        height: ($gap / 2);
+        width: calc(#{$gap} / 2);
+        height: calc(#{$gap} / 2);
       }
     }
   }

--- a/spring-boot-admin-server-ui/src/main/frontend/views/applications/instances-list.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/applications/instances-list.vue
@@ -88,8 +88,8 @@
       }
 
       & > * {
-        width: ($gap / 2);
-        height: ($gap / 2);
+        width: calc(#{$gap} / 2);
+        height: calc(#{$gap} / 2);
       }
     }
   }

--- a/spring-boot-admin-server-ui/src/main/frontend/views/instances/logfile/index.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/instances/logfile/index.vue
@@ -181,7 +181,7 @@ export default {
 
   &-actions {
     top: $navbar-height-px;
-    right: ($gap /2);
+    right: calc(#{$gap} / 2);
     display: flex;
     align-items: center;
     justify-content: flex-end;


### PR DESCRIPTION
Hi,

this fixes deprecation warnings for using math calculations without wrapping them in calc.

Kind regards
Thomas 