### PR TITLE
fix handling 401 in actuator requests: distinguish between SBA security and target app actuator security.

### DIFF
--- a/spring-boot-admin-server-ui/src/main/frontend/services/instance.js
+++ b/spring-boot-admin-server-ui/src/main/frontend/services/instance.js
@@ -27,7 +27,9 @@ const actuatorMimeTypes = [
   'application/json'
 ].join(',');
 
-const isInstanceActuatorRequest = url => url.match(/^instances[/][^/]+[/]actuator([/].*)?$/);
+const isInstanceActuatorRequest = error => {
+  return error.response && error.response.headers['sba-proxy-response'] === 'sba-proxy-response';
+};
 
 class Instance {
   constructor({id, ...instance}) {
@@ -39,7 +41,7 @@ class Instance {
     });
     this.axios.interceptors.response.use(
       response => response,
-      redirectOn401(error => !isInstanceActuatorRequest(error.config.baseURL + error.config.url))
+      redirectOn401(error => !isInstanceActuatorRequest(error))
     );
   }
 

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/InstanceWebProxy.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/InstanceWebProxy.java
@@ -104,8 +104,11 @@ public class InstanceWebProxy {
 			log.trace("No Endpoint found for Proxy-Request for instance {} with URL '{}'", instance.getId(),
 					forwardRequest.getUri());
 			return responseHandler.apply(ClientResponse.create(HttpStatus.NOT_FOUND, this.strategies).build());
-		}).onErrorResume(WebClientRequestException.class, (ex) -> {
-			Throwable cause = ex.getCause();
+		}).onErrorResume((ex) -> {
+			Throwable cause = ex;
+			if (ex instanceof WebClientRequestException) {
+				cause = ex.getCause();
+			}
 			if (cause instanceof ReadTimeoutException || cause instanceof TimeoutException) {
 				log.trace("Timeout for Proxy-Request for instance {} with URL '{}'", instance.getId(),
 						forwardRequest.getUri());

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/reactive/InstancesProxyController.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/reactive/InstancesProxyController.java
@@ -50,6 +50,8 @@ import de.codecentric.boot.admin.server.web.client.InstanceWebClient;
 @AdminController
 public class InstancesProxyController {
 
+	private static final String PROXY_RESPONSE_HEADER = "sba-proxy-response";
+
 	private static final String INSTANCE_MAPPED_PATH = "/instances/{instanceId}/actuator/**";
 
 	private static final String APPLICATION_MAPPED_PATH = "/applications/{applicationName}/actuator/**";
@@ -86,6 +88,8 @@ public class InstancesProxyController {
 					response.setStatusCode(clientResponse.statusCode());
 					response.getHeaders()
 							.addAll(this.httpHeadersFilter.filterHeaders(clientResponse.headers().asHttpHeaders()));
+					response.getHeaders().add(PROXY_RESPONSE_HEADER, PROXY_RESPONSE_HEADER);
+					response.getHeaders().add("Access-Control-Expose-Headers", PROXY_RESPONSE_HEADER);
 					return response.writeAndFlushWith(clientResponse.body(BodyExtractors.toDataBuffers()).window(1));
 				});
 	}

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/servlet/InstancesProxyController.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/servlet/InstancesProxyController.java
@@ -21,6 +21,7 @@ import java.io.OutputStream;
 import java.net.URI;
 import java.util.Set;
 
+import javax.servlet.AsyncContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -84,24 +85,30 @@ public class InstancesProxyController {
 	@ResponseBody
 	@RequestMapping(path = INSTANCE_MAPPED_PATH, method = { RequestMethod.GET, RequestMethod.HEAD, RequestMethod.POST,
 			RequestMethod.PUT, RequestMethod.PATCH, RequestMethod.DELETE, RequestMethod.OPTIONS })
-	public void endpointProxy(@PathVariable("instanceId") String instanceId, HttpServletRequest servletRequest,
-			HttpServletResponse servletResponse) {
-		ServletServerHttpRequest request = new ServletServerHttpRequest(servletRequest);
-		Flux<DataBuffer> requestBody = DataBufferUtils.readInputStream(request::getBody, this.bufferFactory, 4096);
-		InstanceWebProxy.ForwardRequest fwdRequest = createForwardRequest(request, requestBody,
+	public void instanceProxy(@PathVariable("instanceId") String instanceId, HttpServletRequest servletRequest) {
+		// start async because we will commit from different thread.
+		// otherwise incorrect thread local objects (session and security context) will be stored.
+		// check for example org.springframework.security.web.context.HttpSessionSecurityContextRepository.SaveToSessionRequestWrapper.startAsync()
+		AsyncContext asyncContext = servletRequest.startAsync();
+		asyncContext.setTimeout(-1); // no timeout because instanceWebProxy will handle it for us
+		try {
+			ServletServerHttpRequest request = new ServletServerHttpRequest((HttpServletRequest) asyncContext.getRequest());
+			Flux<DataBuffer> requestBody = DataBufferUtils.readInputStream(request::getBody, this.bufferFactory, 4096);
+			InstanceWebProxy.ForwardRequest fwdRequest = createForwardRequest(request, requestBody,
 				this.adminContextPath + INSTANCE_MAPPED_PATH);
 
-		this.instanceWebProxy
+
+			this.instanceWebProxy
 				.forward(this.registry.getInstance(InstanceId.of(instanceId)), fwdRequest, (clientResponse) -> {
-					ServerHttpResponse response = new ServletServerHttpResponse(servletResponse);
+					ServerHttpResponse response = new ServletServerHttpResponse((HttpServletResponse) asyncContext.getResponse());
 					response.setStatusCode(clientResponse.statusCode());
 					response.getHeaders()
-							.addAll(this.httpHeadersFilter.filterHeaders(clientResponse.headers().asHttpHeaders()));
+						.addAll(this.httpHeadersFilter.filterHeaders(clientResponse.headers().asHttpHeaders()));
 					try {
 						OutputStream responseBody = response.getBody();
 						response.flush();
 						return clientResponse.body(BodyExtractors.toDataBuffers()).window(1)
-								.concatMap((body) -> writeAndFlush(body, responseBody)).then();
+							.concatMap((body) -> writeAndFlush(body, responseBody)).then();
 					}
 					catch (IOException ex) {
 						return Mono.error(ex);
@@ -111,6 +118,10 @@ public class InstancesProxyController {
 				// before any async dispatch otherwise the FrameworkServlet will add wrong
 				// Allow header for OPTIONS request
 				.block();
+		}
+		finally {
+			asyncContext.complete();
+		}
 	}
 
 	@ResponseBody

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/servlet/InstancesProxyController.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/servlet/InstancesProxyController.java
@@ -58,6 +58,8 @@ import de.codecentric.boot.admin.server.web.client.InstanceWebClient;
 @AdminController
 public class InstancesProxyController {
 
+	private static final String PROXY_RESPONSE_HEADER = "sba-proxy-response";
+
 	private static final String INSTANCE_MAPPED_PATH = "/instances/{instanceId}/actuator/**";
 
 	private static final String APPLICATION_MAPPED_PATH = "/applications/{applicationName}/actuator/**";
@@ -104,6 +106,8 @@ public class InstancesProxyController {
 					response.setStatusCode(clientResponse.statusCode());
 					response.getHeaders()
 						.addAll(this.httpHeadersFilter.filterHeaders(clientResponse.headers().asHttpHeaders()));
+					response.getHeaders().add(PROXY_RESPONSE_HEADER, PROXY_RESPONSE_HEADER);
+					response.getHeaders().add("Access-Control-Expose-Headers", PROXY_RESPONSE_HEADER);
 					try {
 						OutputStream responseBody = response.getBody();
 						response.flush();

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/web/AbstractInstancesProxyControllerIntegrationTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/web/AbstractInstancesProxyControllerIntegrationTest.java
@@ -72,7 +72,7 @@ public abstract class AbstractInstancesProxyControllerIntegrationTest {
 
 	@BeforeAll
 	public static void setUp() {
-		StepVerifier.setDefaultTimeout(Duration.ofSeconds(60));
+		StepVerifier.setDefaultTimeout(Duration.ofSeconds(600));
 	}
 
 	@AfterAll
@@ -121,9 +121,9 @@ public abstract class AbstractInstancesProxyControllerIntegrationTest {
 
 	@Test
 	public void should_return_status_504() {
-		// 502 on invalid response
-		this.client.get().uri("/instances/{instanceId}/actuator/invalid", this.instanceId).accept(ACTUATOR_V2_MEDIATYPE)
-				.exchange().expectStatus().isEqualTo(HttpStatus.BAD_GATEWAY);
+		// 504 on read timeout
+		this.client.get().uri("/instances/{instanceId}/actuator/timeout", this.instanceId).accept(ACTUATOR_V2_MEDIATYPE)
+			.exchange().expectStatus().isEqualTo(HttpStatus.GATEWAY_TIMEOUT);
 	}
 
 	@Test


### PR DESCRIPTION
**Note**: This PR based on #2018 , please review and merge #2018 first.

Example:
We want allow any user to access /applications.html but do not want to allow get heap dumps or inspect configuration properties.
Than we configure:
```
...("/applications").permitAll()
...("/instances/**").authenticated()
```

That when user open applications.html and then drill down to instance it will get 401.
This 401 should be handled and user should be redirected to login page.

But if user will get 401 from proxied request (target app security does not allow access endpoint) then no redirect should be performed.

To distinguish between SBA security and target app security I introduced new header. If it exists then user request bypassed SBA security and 401 was received from target app.


