### PR TITLE
fix(#1576): support http/https default ports in service discovery

### DIFF
--- a/spring-boot-admin-server-cloud/src/main/java/de/codecentric/boot/admin/server/cloud/discovery/DefaultServiceInstanceConverter.java
+++ b/spring-boot-admin-server-cloud/src/main/java/de/codecentric/boot/admin/server/cloud/discovery/DefaultServiceInstanceConverter.java
@@ -144,6 +144,12 @@ public class DefaultServiceInstanceConverter implements ServiceInstanceConverter
 	}
 
 	protected URI getServiceUrl(ServiceInstance instance) {
+
+		if (instance.getPort() == -1) {
+			return UriComponentsBuilder.newInstance().scheme(instance.isSecure() ? "https" : "http")
+					.host(instance.getHost()).build().toUri();
+		}
+
 		return instance.getUri();
 	}
 


### PR DESCRIPTION
Fixes #1576 . When no port is explicitly set in the configuration, the **ServiceInstance** object received by spring cloud discovery in **InstanceDiscoveryListener** does not return a valid **URI** objet:
```
URI uri = serviceInstance.getURI();
uri.getPort() -> -1
uri.getHost() -> null
```
This URI is used within **DefaultServiceInstanceConverter** and ends failing.

With the commit when port is -1 the URI is built from the ServiceInstance, using default ports, instead of relying in serviceInstance.getURI()