### PR TITLE
fix(#1576): add service instance decorator to support http/https defa…

### DIFF
--- a/spring-boot-admin-server-cloud/src/main/java/de/codecentric/boot/admin/server/cloud/discovery/InstanceDiscoveryListener.java
+++ b/spring-boot-admin-server-cloud/src/main/java/de/codecentric/boot/admin/server/cloud/discovery/InstanceDiscoveryListener.java
@@ -125,8 +125,8 @@ public class InstanceDiscoveryListener {
 		log.debug("Discovering new instances from DiscoveryClient");
 		Flux.fromIterable(discoveryClient.getServices()).filter(this::shouldRegisterService)
 				.flatMapIterable(discoveryClient::getInstances).filter(this::shouldRegisterInstanceBasedOnMetadata)
-				.flatMap(this::registerInstance).collect(Collectors.toSet()).flatMap(this::removeStaleInstances)
-				.subscribe((v) -> {
+				.map(ServiceInstanceDefaultPortDecorator::new).flatMap(this::registerInstance)
+				.collect(Collectors.toSet()).flatMap(this::removeStaleInstances).subscribe((v) -> {
 				}, (ex) -> log.error("Unexpected error.", ex));
 	}
 

--- a/spring-boot-admin-server-cloud/src/main/java/de/codecentric/boot/admin/server/cloud/discovery/ServiceInstanceDefaultPortDecorator.java
+++ b/spring-boot-admin-server-cloud/src/main/java/de/codecentric/boot/admin/server/cloud/discovery/ServiceInstanceDefaultPortDecorator.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2014-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.codecentric.boot.admin.server.cloud.discovery;
+
+import java.net.URI;
+import java.util.Map;
+
+import org.springframework.cloud.client.DefaultServiceInstance;
+import org.springframework.cloud.client.ServiceInstance;
+
+/**
+ * Decorates any {@link ServiceInstance} to add default http/https ports when not
+ * explicitly set in spring cloud discovery configuration properties. Only
+ * <code>getPort()</code> and <code>getUri()</code> functionality is extended, all other
+ * methods remains the same.
+ *
+ * @author Pepe Valverde
+ */
+public class ServiceInstanceDefaultPortDecorator implements ServiceInstance {
+
+	private final ServiceInstance serviceInstance;
+
+	public ServiceInstanceDefaultPortDecorator(ServiceInstance serviceInstance) {
+		this.serviceInstance = serviceInstance;
+	}
+
+	@Override
+	public String getInstanceId() {
+		return serviceInstance.getInstanceId();
+	}
+
+	@Override
+	public String getServiceId() {
+		return serviceInstance.getServiceId();
+	}
+
+	@Override
+	public String getHost() {
+		return serviceInstance.getHost();
+	}
+
+	@Override
+	public int getPort() {
+
+		if (serviceInstance.getPort() != -1) {
+			return serviceInstance.getPort();
+		}
+
+		return serviceInstance.isSecure() ? 443 : 80;
+	}
+
+	@Override
+	public boolean isSecure() {
+		return serviceInstance.isSecure();
+	}
+
+	@Override
+	public URI getUri() {
+		return DefaultServiceInstance.getUri(this);
+	}
+
+	@Override
+	public Map<String, String> getMetadata() {
+		return serviceInstance.getMetadata();
+	}
+
+	@Override
+	public String getScheme() {
+		return serviceInstance.getScheme();
+	}
+
+}


### PR DESCRIPTION
Alternative Pull Request to #2020 to fix #1576 

In this approach I added a **ServiceInstanceDefaultPortDecorator** to add default http/https ports funcionality to **ServiceIntance**.
ServiceInstances from discoveryClient are decorated in InstanceDiscoveryClient. DefaultServiceInstanceConverter is left untouched