### PR TITLE
Make /actuator/health endpoint accessible in Reactive security example

### DIFF
--- a/spring-boot-admin-samples/spring-boot-admin-sample-reactive/src/main/java/de/codecentric/boot/admin/SpringBootAdminReactiveApplication.java
+++ b/spring-boot-admin-samples/spring-boot-admin-sample-reactive/src/main/java/de/codecentric/boot/admin/SpringBootAdminReactiveApplication.java
@@ -58,6 +58,7 @@ public class SpringBootAdminReactiveApplication {
 		return http
 				.authorizeExchange((authorizeExchange) -> authorizeExchange
 						.pathMatchers(this.adminServer.path("/assets/**")).permitAll()
+						.pathMatchers("/actuator/health/**").permitAll()
 						.pathMatchers(this.adminServer.path("/login")).permitAll().anyExchange().authenticated())
 				.formLogin((formLogin) -> formLogin.loginPage(this.adminServer.path("/login")))
 				.logout((logout) -> logout.logoutUrl(this.adminServer.path("/logout")))


### PR DESCRIPTION
This makes reactive security example somewhat on-par with servlet sample.

I spent an hour trying to do this in my app which uses custom spring.boot.admin.context-path, so I think it could be useful for others.

Maybe I'm wrong with this, but the trick is to understand that /actuator path is not affected by spring.boot.admin.context-path property in reactive application (difference from servlet app). 