### PR TITLE
Upgrade to spring boot 2.7.0 and spring cloud 2021.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <description>Spring Boot Admin</description>
     <url>https://github.com/codecentric/spring-boot-admin/</url>
     <properties>
-        <revision>2.6.6-SNAPSHOT</revision>
+        <revision>2.7.0-SNAPSHOT</revision>
         <java.version>1.8</java.version>
 
         <maven.compiler.source>${java.version}</maven.compiler.source>
@@ -36,10 +36,10 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- used dependencies versions -->
-        <spring-boot.version>2.6.7</spring-boot.version>
-        <spring-cloud.version>2021.0.2</spring-cloud.version>
+        <spring-boot.version>2.7.0</spring-boot.version>
+        <spring-cloud.version>2021.0.3</spring-cloud.version>
         <wiremock.version>2.32.0</wiremock.version>
-        <hazelcast-tests.version>4.2.4</hazelcast-tests.version>
+        <hazelcast-tests.version>5.1.1</hazelcast-tests.version>
         <findbugs-jsr305.version>3.0.2</findbugs-jsr305.version>
         <awaitility.version>4.1.1</awaitility.version>
         <testcontainers.version>1.16.3</testcontainers.version>

--- a/spring-boot-admin-client/src/main/java/de/codecentric/boot/admin/client/config/SpringBootAdminClientAutoConfiguration.java
+++ b/spring-boot-admin-client/src/main/java/de/codecentric/boot/admin/client/config/SpringBootAdminClientAutoConfiguration.java
@@ -26,6 +26,7 @@ import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointAu
 import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
 import org.springframework.boot.actuate.autoconfigure.web.server.ManagementServerProperties;
 import org.springframework.boot.actuate.endpoint.web.PathMappedEndpoints;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -60,11 +61,10 @@ import de.codecentric.boot.admin.client.registration.metadata.StartupDateMetadat
 import static org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type;
 import static org.springframework.web.reactive.function.client.ExchangeFilterFunctions.basicAuthentication;
 
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration(after = { WebEndpointAutoConfiguration.class, RestTemplateAutoConfiguration.class,
+	WebClientAutoConfiguration.class })
 @ConditionalOnWebApplication
 @Conditional(SpringBootAdminClientEnabledCondition.class)
-@AutoConfigureAfter({ WebEndpointAutoConfiguration.class, RestTemplateAutoConfiguration.class,
-		WebClientAutoConfiguration.class })
 @EnableConfigurationProperties({ ClientProperties.class, InstanceProperties.class, ServerProperties.class,
 		ManagementServerProperties.class })
 public class SpringBootAdminClientAutoConfiguration {

--- a/spring-boot-admin-client/src/main/java/de/codecentric/boot/admin/client/config/SpringBootAdminClientAutoConfiguration.java
+++ b/spring-boot-admin-client/src/main/java/de/codecentric/boot/admin/client/config/SpringBootAdminClientAutoConfiguration.java
@@ -62,7 +62,7 @@ import static org.springframework.boot.autoconfigure.condition.ConditionalOnWebA
 import static org.springframework.web.reactive.function.client.ExchangeFilterFunctions.basicAuthentication;
 
 @AutoConfiguration(after = { WebEndpointAutoConfiguration.class, RestTemplateAutoConfiguration.class,
-	WebClientAutoConfiguration.class })
+		WebClientAutoConfiguration.class })
 @ConditionalOnWebApplication
 @Conditional(SpringBootAdminClientEnabledCondition.class)
 @EnableConfigurationProperties({ ClientProperties.class, InstanceProperties.class, ServerProperties.class,

--- a/spring-boot-admin-client/src/main/java/de/codecentric/boot/admin/client/config/SpringBootAdminClientCloudFoundryAutoConfiguration.java
+++ b/spring-boot-admin-client/src/main/java/de/codecentric/boot/admin/client/config/SpringBootAdminClientCloudFoundryAutoConfiguration.java
@@ -23,7 +23,7 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
 import org.springframework.boot.actuate.autoconfigure.web.server.ManagementServerProperties;
 import org.springframework.boot.actuate.endpoint.web.PathMappedEndpoints;
-import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnCloudPlatform;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
@@ -32,7 +32,6 @@ import org.springframework.boot.cloud.CloudPlatform;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
 
 import de.codecentric.boot.admin.client.registration.CloudFoundryApplicationFactory;
@@ -40,12 +39,11 @@ import de.codecentric.boot.admin.client.registration.metadata.CloudFoundryMetada
 import de.codecentric.boot.admin.client.registration.metadata.CompositeMetadataContributor;
 import de.codecentric.boot.admin.client.registration.metadata.MetadataContributor;
 
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration(before = SpringBootAdminClientAutoConfiguration.class)
 @ConditionalOnWebApplication
 @ConditionalOnCloudPlatform(CloudPlatform.CLOUD_FOUNDRY)
 @Conditional(SpringBootAdminClientEnabledCondition.class)
 @EnableConfigurationProperties(CloudFoundryApplicationProperties.class)
-@AutoConfigureBefore({ SpringBootAdminClientAutoConfiguration.class })
 public class SpringBootAdminClientCloudFoundryAutoConfiguration {
 
 	@Bean

--- a/spring-boot-admin-client/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-admin-client/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  de.codecentric.boot.admin.client.config.SpringBootAdminClientAutoConfiguration,\
-  de.codecentric.boot.admin.client.config.SpringBootAdminClientCloudFoundryAutoConfiguration

--- a/spring-boot-admin-client/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-boot-admin-client/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,2 @@
+de.codecentric.boot.admin.client.config.SpringBootAdminClientAutoConfiguration
+de.codecentric.boot.admin.client.config.SpringBootAdminClientCloudFoundryAutoConfiguration

--- a/spring-boot-admin-server-cloud/src/main/java/de/codecentric/boot/admin/server/cloud/config/AdminServerDiscoveryAutoConfiguration.java
+++ b/spring-boot-admin-server-cloud/src/main/java/de/codecentric/boot/admin/server/cloud/config/AdminServerDiscoveryAutoConfiguration.java
@@ -42,8 +42,8 @@ import de.codecentric.boot.admin.server.domain.entities.InstanceRepository;
 import de.codecentric.boot.admin.server.services.InstanceRegistry;
 
 @AutoConfiguration(after = AdminServerAutoConfiguration.class,
-	afterName = {"org.springframework.cloud.netflix.eureka.EurekaClientAutoConfiguration",
-		"org.springframework.cloud.client.discovery.simple.SimpleDiscoveryClientAutoConfiguration"})
+		afterName = { "org.springframework.cloud.netflix.eureka.EurekaClientAutoConfiguration",
+				"org.springframework.cloud.client.discovery.simple.SimpleDiscoveryClientAutoConfiguration" })
 @ConditionalOnSingleCandidate(DiscoveryClient.class)
 @ConditionalOnBean(AdminServerMarkerConfiguration.Marker.class)
 @ConditionalOnProperty(prefix = "spring.boot.admin.discovery", name = "enabled", matchIfMissing = true)

--- a/spring-boot-admin-server-cloud/src/main/java/de/codecentric/boot/admin/server/cloud/config/AdminServerDiscoveryAutoConfiguration.java
+++ b/spring-boot-admin-server-cloud/src/main/java/de/codecentric/boot/admin/server/cloud/config/AdminServerDiscoveryAutoConfiguration.java
@@ -17,7 +17,7 @@
 package de.codecentric.boot.admin.server.cloud.config;
 
 import com.netflix.discovery.EurekaClient;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.AnyNestedCondition;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -41,13 +41,12 @@ import de.codecentric.boot.admin.server.config.AdminServerMarkerConfiguration;
 import de.codecentric.boot.admin.server.domain.entities.InstanceRepository;
 import de.codecentric.boot.admin.server.services.InstanceRegistry;
 
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration(after = AdminServerAutoConfiguration.class,
+	afterName = {"org.springframework.cloud.netflix.eureka.EurekaClientAutoConfiguration",
+		"org.springframework.cloud.client.discovery.simple.SimpleDiscoveryClientAutoConfiguration"})
 @ConditionalOnSingleCandidate(DiscoveryClient.class)
 @ConditionalOnBean(AdminServerMarkerConfiguration.Marker.class)
 @ConditionalOnProperty(prefix = "spring.boot.admin.discovery", name = "enabled", matchIfMissing = true)
-@AutoConfigureAfter(value = AdminServerAutoConfiguration.class,
-		name = { "org.springframework.cloud.netflix.eureka.EurekaClientAutoConfiguration",
-				"org.springframework.cloud.client.discovery.simple.SimpleDiscoveryClientAutoConfiguration" })
 public class AdminServerDiscoveryAutoConfiguration {
 
 	@Bean

--- a/spring-boot-admin-server-cloud/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-admin-server-cloud/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  de.codecentric.boot.admin.server.cloud.config.AdminServerDiscoveryAutoConfiguration

--- a/spring-boot-admin-server-cloud/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-boot-admin-server-cloud/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+de.codecentric.boot.admin.server.cloud.config.AdminServerDiscoveryAutoConfiguration

--- a/spring-boot-admin-server-ui/src/main/java/de/codecentric/boot/admin/server/ui/config/AdminServerUiAutoConfiguration.java
+++ b/spring-boot-admin-server-ui/src/main/java/de/codecentric/boot/admin/server/ui/config/AdminServerUiAutoConfiguration.java
@@ -24,7 +24,7 @@ import java.util.stream.Stream;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
@@ -53,10 +53,9 @@ import de.codecentric.boot.admin.server.ui.web.UiController.Settings;
 
 import static java.util.Arrays.asList;
 
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration(after = AdminServerWebConfiguration.class)
 @Conditional(SpringBootAdminServerEnabledCondition.class)
 @ConditionalOnBean(AdminServerMarkerConfiguration.Marker.class)
-@AutoConfigureAfter(AdminServerWebConfiguration.class)
 @EnableConfigurationProperties(AdminServerUiProperties.class)
 public class AdminServerUiAutoConfiguration {
 

--- a/spring-boot-admin-server-ui/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-admin-server-ui/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  de.codecentric.boot.admin.server.ui.config.AdminServerUiAutoConfiguration

--- a/spring-boot-admin-server-ui/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-boot-admin-server-ui/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+de.codecentric.boot.admin.server.ui.config.AdminServerUiAutoConfiguration

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerAutoConfiguration.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerAutoConfiguration.java
@@ -104,7 +104,8 @@ public class AdminServerAutoConfiguration {
 	public EndpointDetector endpointDetector(InstanceRepository instanceRepository,
 			InstanceWebClient.Builder instanceWebClientBuilder) {
 		InstanceWebClient instanceWebClient = instanceWebClientBuilder.build();
-		ChainingStrategy strategy = new ChainingStrategy(new QueryIndexEndpointStrategy(instanceWebClient, new ApiMediaTypeHandler()),
+		ChainingStrategy strategy = new ChainingStrategy(
+				new QueryIndexEndpointStrategy(instanceWebClient, new ApiMediaTypeHandler()),
 				new ProbeEndpointsStrategy(instanceWebClient, this.adminServerProperties.getProbedEndpoints()));
 		return new EndpointDetector(instanceRepository, strategy);
 	}

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerAutoConfiguration.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerAutoConfiguration.java
@@ -17,7 +17,7 @@
 package de.codecentric.boot.admin.server.config;
 
 import org.reactivestreams.Publisher;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -25,7 +25,6 @@ import org.springframework.boot.autoconfigure.web.reactive.function.client.WebCl
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
 
 import de.codecentric.boot.admin.server.domain.entities.InstanceRepository;
@@ -34,6 +33,7 @@ import de.codecentric.boot.admin.server.domain.events.InstanceEvent;
 import de.codecentric.boot.admin.server.eventstore.InMemoryEventStore;
 import de.codecentric.boot.admin.server.eventstore.InstanceEventPublisher;
 import de.codecentric.boot.admin.server.eventstore.InstanceEventStore;
+import de.codecentric.boot.admin.server.services.ApiMediaTypeHandler;
 import de.codecentric.boot.admin.server.services.ApplicationRegistry;
 import de.codecentric.boot.admin.server.services.EndpointDetectionTrigger;
 import de.codecentric.boot.admin.server.services.EndpointDetector;
@@ -49,12 +49,11 @@ import de.codecentric.boot.admin.server.services.endpoints.ProbeEndpointsStrateg
 import de.codecentric.boot.admin.server.services.endpoints.QueryIndexEndpointStrategy;
 import de.codecentric.boot.admin.server.web.client.InstanceWebClient;
 
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration(after = WebClientAutoConfiguration.class)
 @Conditional(SpringBootAdminServerEnabledCondition.class)
 @ConditionalOnBean(AdminServerMarkerConfiguration.Marker.class)
 @EnableConfigurationProperties(AdminServerProperties.class)
 @ImportAutoConfiguration({ AdminServerInstanceWebClientConfiguration.class, AdminServerWebConfiguration.class })
-@AutoConfigureAfter({ WebClientAutoConfiguration.class })
 @Lazy(false)
 public class AdminServerAutoConfiguration {
 
@@ -88,7 +87,7 @@ public class AdminServerAutoConfiguration {
 	@ConditionalOnMissingBean
 	public StatusUpdater statusUpdater(InstanceRepository instanceRepository,
 			InstanceWebClient.Builder instanceWebClientBulder) {
-		return new StatusUpdater(instanceRepository, instanceWebClientBulder.build());
+		return new StatusUpdater(instanceRepository, instanceWebClientBulder.build(), new ApiMediaTypeHandler());
 	}
 
 	@Bean(initMethod = "start", destroyMethod = "stop")
@@ -105,7 +104,7 @@ public class AdminServerAutoConfiguration {
 	public EndpointDetector endpointDetector(InstanceRepository instanceRepository,
 			InstanceWebClient.Builder instanceWebClientBuilder) {
 		InstanceWebClient instanceWebClient = instanceWebClientBuilder.build();
-		ChainingStrategy strategy = new ChainingStrategy(new QueryIndexEndpointStrategy(instanceWebClient),
+		ChainingStrategy strategy = new ChainingStrategy(new QueryIndexEndpointStrategy(instanceWebClient, new ApiMediaTypeHandler()),
 				new ProbeEndpointsStrategy(instanceWebClient, this.adminServerProperties.getProbedEndpoints()));
 		return new EndpointDetector(instanceRepository, strategy);
 	}
@@ -121,7 +120,7 @@ public class AdminServerAutoConfiguration {
 	@ConditionalOnMissingBean
 	public InfoUpdater infoUpdater(InstanceRepository instanceRepository,
 			InstanceWebClient.Builder instanceWebClientBuilder) {
-		return new InfoUpdater(instanceRepository, instanceWebClientBuilder.build());
+		return new InfoUpdater(instanceRepository, instanceWebClientBuilder.build(), new ApiMediaTypeHandler());
 	}
 
 	@Bean(initMethod = "start", destroyMethod = "stop")

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerCloudFoundryAutoConfiguration.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerCloudFoundryAutoConfiguration.java
@@ -16,12 +16,11 @@
 
 package de.codecentric.boot.admin.server.config;
 
-import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnCloudPlatform;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.cloud.CloudPlatform;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
 
 import de.codecentric.boot.admin.server.services.CloudFoundryInstanceIdGenerator;
@@ -29,9 +28,8 @@ import de.codecentric.boot.admin.server.services.HashingInstanceUrlIdGenerator;
 import de.codecentric.boot.admin.server.services.InstanceIdGenerator;
 import de.codecentric.boot.admin.server.web.client.CloudFoundryHttpHeaderProvider;
 
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration(before = { AdminServerAutoConfiguration.class })
 @ConditionalOnCloudPlatform(CloudPlatform.CLOUD_FOUNDRY)
-@AutoConfigureBefore({ AdminServerAutoConfiguration.class })
 @Lazy(false)
 public class AdminServerCloudFoundryAutoConfiguration {
 

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerHazelcastAutoConfiguration.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerHazelcastAutoConfiguration.java
@@ -41,7 +41,7 @@ import de.codecentric.boot.admin.server.notify.NotificationTrigger;
 import de.codecentric.boot.admin.server.notify.Notifier;
 
 @AutoConfiguration(before = { AdminServerAutoConfiguration.class, AdminServerNotifierAutoConfiguration.class },
-	after = HazelcastAutoConfiguration.class)
+		after = HazelcastAutoConfiguration.class)
 @ConditionalOnBean(AdminServerMarkerConfiguration.Marker.class)
 @ConditionalOnSingleCandidate(HazelcastInstance.class)
 @ConditionalOnProperty(prefix = "spring.boot.admin.hazelcast", name = "enabled", matchIfMissing = true)

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerHazelcastAutoConfiguration.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerHazelcastAutoConfiguration.java
@@ -22,8 +22,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.map.IMap;
 import org.reactivestreams.Publisher;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
-import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -41,12 +40,11 @@ import de.codecentric.boot.admin.server.notify.HazelcastNotificationTrigger;
 import de.codecentric.boot.admin.server.notify.NotificationTrigger;
 import de.codecentric.boot.admin.server.notify.Notifier;
 
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration(before = { AdminServerAutoConfiguration.class, AdminServerNotifierAutoConfiguration.class },
+	after = HazelcastAutoConfiguration.class)
 @ConditionalOnBean(AdminServerMarkerConfiguration.Marker.class)
 @ConditionalOnSingleCandidate(HazelcastInstance.class)
 @ConditionalOnProperty(prefix = "spring.boot.admin.hazelcast", name = "enabled", matchIfMissing = true)
-@AutoConfigureBefore({ AdminServerAutoConfiguration.class, AdminServerNotifierAutoConfiguration.class })
-@AutoConfigureAfter(HazelcastAutoConfiguration.class)
 @Lazy(false)
 public class AdminServerHazelcastAutoConfiguration {
 

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerNotifierAutoConfiguration.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerNotifierAutoConfiguration.java
@@ -26,7 +26,7 @@ import org.apache.http.client.CredentialsProvider;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.reactivestreams.Publisher;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -70,9 +70,8 @@ import de.codecentric.boot.admin.server.notify.TelegramNotifier;
 import de.codecentric.boot.admin.server.notify.filter.FilteringNotifier;
 import de.codecentric.boot.admin.server.notify.filter.web.NotificationFilterController;
 
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration(after = MailSenderAutoConfiguration.class)
 @EnableConfigurationProperties(NotifierProxyProperties.class)
-@AutoConfigureAfter({ MailSenderAutoConfiguration.class })
 public class AdminServerNotifierAutoConfiguration {
 
 	private static RestTemplate createNotifierRestTemplate(NotifierProxyProperties proxyProperties) {

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/ApiMediaTypeHandler.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/ApiMediaTypeHandler.java
@@ -24,10 +24,8 @@ import org.springframework.http.MediaType;
 public class ApiMediaTypeHandler {
 
 	public boolean isApiMediaType(MediaType mediaType) {
-		return Stream.of(ApiVersion.values())
-			.map(ApiVersion::getProducedMimeType)
-			.anyMatch((mimeType) -> mimeType.isCompatibleWith(mediaType));
+		return Stream.of(ApiVersion.values()).map(ApiVersion::getProducedMimeType)
+				.anyMatch((mimeType) -> mimeType.isCompatibleWith(mediaType));
 	}
-
 
 }

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/ApiMediaTypeHandler.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/ApiMediaTypeHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,20 @@
  * limitations under the License.
  */
 
-package de.codecentric.boot.admin.server.utils;
+package de.codecentric.boot.admin.server.services;
 
-import org.springframework.boot.actuate.endpoint.http.ActuatorMediaType;
+import java.util.stream.Stream;
 
-public final class MediaType {
+import org.springframework.boot.actuate.endpoint.ApiVersion;
+import org.springframework.http.MediaType;
 
-	public static final org.springframework.http.MediaType ACTUATOR_V1_MEDIATYPE = org.springframework.http.MediaType
-			.parseMediaType("application/vnd.spring-boot.actuator.v1+json");
+public class ApiMediaTypeHandler {
 
-	public static final org.springframework.http.MediaType ACTUATOR_V2_MEDIATYPE = org.springframework.http.MediaType
-			.parseMediaType(ActuatorMediaType.V2_JSON);
-
-	private MediaType() {
+	public boolean isApiMediaType(MediaType mediaType) {
+		return Stream.of(ApiVersion.values())
+			.map(ApiVersion::getProducedMimeType)
+			.anyMatch((mimeType) -> mimeType.isCompatibleWith(mediaType));
 	}
+
 
 }

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/InfoUpdater.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/InfoUpdater.java
@@ -52,7 +52,8 @@ public class InfoUpdater {
 
 	private final ApiMediaTypeHandler apiMediaTypeHandler;
 
-	public InfoUpdater(InstanceRepository repository, InstanceWebClient instanceWebClient, ApiMediaTypeHandler apiMediaTypeHandler) {
+	public InfoUpdater(InstanceRepository repository, InstanceWebClient instanceWebClient,
+			ApiMediaTypeHandler apiMediaTypeHandler) {
 		this.repository = repository;
 		this.instanceWebClient = instanceWebClient;
 		this.apiMediaTypeHandler = apiMediaTypeHandler;
@@ -77,10 +78,9 @@ public class InfoUpdater {
 	}
 
 	protected Mono<Info> convertInfo(Instance instance, ClientResponse response) {
-		if (response.statusCode().is2xxSuccessful()
-			&& response.headers().contentType()
-			.filter((mt) -> mt.isCompatibleWith(MediaType.APPLICATION_JSON) || this.apiMediaTypeHandler.isApiMediaType(mt))
-			.isPresent()) {
+		if (response.statusCode().is2xxSuccessful() && response.headers().contentType().filter(
+				(mt) -> mt.isCompatibleWith(MediaType.APPLICATION_JSON) || this.apiMediaTypeHandler.isApiMediaType(mt))
+				.isPresent()) {
 			return response.bodyToMono(RESPONSE_TYPE).map(Info::from).defaultIfEmpty(Info.empty());
 		}
 		log.info("Couldn't retrieve info for {}: {}", instance, response.statusCode());

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/InfoUpdater.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/InfoUpdater.java
@@ -33,8 +33,6 @@ import de.codecentric.boot.admin.server.domain.values.Info;
 import de.codecentric.boot.admin.server.domain.values.InstanceId;
 import de.codecentric.boot.admin.server.web.client.InstanceWebClient;
 
-import static de.codecentric.boot.admin.server.utils.MediaType.ACTUATOR_V2_MEDIATYPE;
-
 /**
  * The StatusUpdater is responsible for updating the status of all or a single application
  * querying the healthUrl.
@@ -52,9 +50,12 @@ public class InfoUpdater {
 
 	private final InstanceWebClient instanceWebClient;
 
-	public InfoUpdater(InstanceRepository repository, InstanceWebClient instanceWebClient) {
+	private final ApiMediaTypeHandler apiMediaTypeHandler;
+
+	public InfoUpdater(InstanceRepository repository, InstanceWebClient instanceWebClient, ApiMediaTypeHandler apiMediaTypeHandler) {
 		this.repository = repository;
 		this.instanceWebClient = instanceWebClient;
+		this.apiMediaTypeHandler = apiMediaTypeHandler;
 	}
 
 	public Mono<Void> updateInfo(InstanceId id) {
@@ -76,9 +77,10 @@ public class InfoUpdater {
 	}
 
 	protected Mono<Info> convertInfo(Instance instance, ClientResponse response) {
-		if (response.statusCode().is2xxSuccessful() && response.headers().contentType().map(
-				(mt) -> mt.isCompatibleWith(MediaType.APPLICATION_JSON) || mt.isCompatibleWith(ACTUATOR_V2_MEDIATYPE))
-				.orElse(false)) {
+		if (response.statusCode().is2xxSuccessful()
+			&& response.headers().contentType()
+			.filter((mt) -> mt.isCompatibleWith(MediaType.APPLICATION_JSON) || this.apiMediaTypeHandler.isApiMediaType(mt))
+			.isPresent()) {
 			return response.bodyToMono(RESPONSE_TYPE).map(Info::from).defaultIfEmpty(Info.empty());
 		}
 		log.info("Couldn't retrieve info for {}: {}", instance, response.statusCode());

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/StatusUpdater.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/StatusUpdater.java
@@ -57,7 +57,8 @@ public class StatusUpdater {
 
 	private final ApiMediaTypeHandler apiMediaTypeHandler;
 
-	public StatusUpdater(InstanceRepository repository, InstanceWebClient instanceWebClient, ApiMediaTypeHandler apiMediaTypeHandler) {
+	public StatusUpdater(InstanceRepository repository, InstanceWebClient instanceWebClient,
+			ApiMediaTypeHandler apiMediaTypeHandler) {
 		this.repository = repository;
 		this.instanceWebClient = instanceWebClient;
 		this.apiMediaTypeHandler = apiMediaTypeHandler;
@@ -81,9 +82,9 @@ public class StatusUpdater {
 	}
 
 	protected Mono<StatusInfo> convertStatusInfo(ClientResponse response) {
-		boolean hasCompatibleContentType = response.headers().contentType()
-			.filter((mt) -> mt.isCompatibleWith(MediaType.APPLICATION_JSON) || this.apiMediaTypeHandler.isApiMediaType(mt))
-			.isPresent();
+		boolean hasCompatibleContentType = response.headers().contentType().filter(
+				(mt) -> mt.isCompatibleWith(MediaType.APPLICATION_JSON) || this.apiMediaTypeHandler.isApiMediaType(mt))
+				.isPresent();
 
 		StatusInfo statusInfoFromStatus = this.getStatusInfoFromStatus(response.statusCode(), emptyMap());
 		if (hasCompatibleContentType) {

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/StatusUpdater.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/StatusUpdater.java
@@ -36,7 +36,6 @@ import de.codecentric.boot.admin.server.domain.values.InstanceId;
 import de.codecentric.boot.admin.server.domain.values.StatusInfo;
 import de.codecentric.boot.admin.server.web.client.InstanceWebClient;
 
-import static de.codecentric.boot.admin.server.utils.MediaType.ACTUATOR_V2_MEDIATYPE;
 import static java.util.Collections.emptyMap;
 
 /**
@@ -56,9 +55,12 @@ public class StatusUpdater {
 
 	private final InstanceWebClient instanceWebClient;
 
-	public StatusUpdater(InstanceRepository repository, InstanceWebClient instanceWebClient) {
+	private final ApiMediaTypeHandler apiMediaTypeHandler;
+
+	public StatusUpdater(InstanceRepository repository, InstanceWebClient instanceWebClient, ApiMediaTypeHandler apiMediaTypeHandler) {
 		this.repository = repository;
 		this.instanceWebClient = instanceWebClient;
+		this.apiMediaTypeHandler = apiMediaTypeHandler;
 	}
 
 	public Mono<Void> updateStatus(InstanceId id) {
@@ -79,9 +81,9 @@ public class StatusUpdater {
 	}
 
 	protected Mono<StatusInfo> convertStatusInfo(ClientResponse response) {
-		Boolean hasCompatibleContentType = response.headers().contentType().map(
-				(mt) -> mt.isCompatibleWith(MediaType.APPLICATION_JSON) || mt.isCompatibleWith(ACTUATOR_V2_MEDIATYPE))
-				.orElse(false);
+		boolean hasCompatibleContentType = response.headers().contentType()
+			.filter((mt) -> mt.isCompatibleWith(MediaType.APPLICATION_JSON) || this.apiMediaTypeHandler.isApiMediaType(mt))
+			.isPresent();
 
 		StatusInfo statusInfoFromStatus = this.getStatusInfoFromStatus(response.statusCode(), emptyMap());
 		if (hasCompatibleContentType) {

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/endpoints/QueryIndexEndpointStrategy.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/endpoints/QueryIndexEndpointStrategy.java
@@ -28,8 +28,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.actuate.endpoint.http.ActuatorMediaType;
-import org.springframework.http.MediaType;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import reactor.core.publisher.Mono;
 
@@ -38,6 +36,7 @@ import de.codecentric.boot.admin.server.domain.values.Endpoint;
 import de.codecentric.boot.admin.server.domain.values.Endpoints;
 import de.codecentric.boot.admin.server.domain.values.InstanceId;
 import de.codecentric.boot.admin.server.domain.values.Registration;
+import de.codecentric.boot.admin.server.services.ApiMediaTypeHandler;
 import de.codecentric.boot.admin.server.web.client.InstanceWebClient;
 
 public class QueryIndexEndpointStrategy implements EndpointDetectionStrategy {
@@ -46,10 +45,11 @@ public class QueryIndexEndpointStrategy implements EndpointDetectionStrategy {
 
 	private final InstanceWebClient instanceWebClient;
 
-	private static final MediaType actuatorMediaType = MediaType.parseMediaType(ActuatorMediaType.V2_JSON);
+	private final ApiMediaTypeHandler apiMediaTypeHandler;
 
-	public QueryIndexEndpointStrategy(InstanceWebClient instanceWebClient) {
+	public QueryIndexEndpointStrategy(InstanceWebClient instanceWebClient, ApiMediaTypeHandler apiMediaTypeHandler) {
 		this.instanceWebClient = instanceWebClient;
+		this.apiMediaTypeHandler = apiMediaTypeHandler;
 	}
 
 	@Override
@@ -79,7 +79,9 @@ public class QueryIndexEndpointStrategy implements EndpointDetectionStrategy {
 				return response.releaseBody().then(Mono.empty());
 			}
 
-			if (!response.headers().contentType().map(actuatorMediaType::isCompatibleWith).orElse(false)) {
+			if (!response.headers().contentType()
+				.filter(this.apiMediaTypeHandler::isApiMediaType)
+				.isPresent()) {
 				log.debug("Querying actuator-index for instance {} on '{}' failed with incompatible Content-Type '{}'.",
 						instance.getId(), managementUrl,
 						response.headers().contentType().map(Objects::toString).orElse("(missing)"));

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/endpoints/QueryIndexEndpointStrategy.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/endpoints/QueryIndexEndpointStrategy.java
@@ -79,9 +79,7 @@ public class QueryIndexEndpointStrategy implements EndpointDetectionStrategy {
 				return response.releaseBody().then(Mono.empty());
 			}
 
-			if (!response.headers().contentType()
-				.filter(this.apiMediaTypeHandler::isApiMediaType)
-				.isPresent()) {
+			if (!response.headers().contentType().filter(this.apiMediaTypeHandler::isApiMediaType).isPresent()) {
 				log.debug("Querying actuator-index for instance {} on '{}' failed with incompatible Content-Type '{}'.",
 						instance.getId(), managementUrl,
 						response.headers().contentType().map(Objects::toString).orElse("(missing)"));

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/client/InstanceExchangeFilterFunctions.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/client/InstanceExchangeFilterFunctions.java
@@ -26,7 +26,7 @@ import java.util.stream.Stream;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.actuate.endpoint.http.ActuatorMediaType;
+import org.springframework.boot.actuate.endpoint.ApiVersion;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
@@ -43,23 +43,24 @@ import de.codecentric.boot.admin.server.domain.values.InstanceId;
 import de.codecentric.boot.admin.server.web.client.cookies.PerInstanceCookieStore;
 import de.codecentric.boot.admin.server.web.client.exception.ResolveEndpointException;
 
-import static de.codecentric.boot.admin.server.utils.MediaType.ACTUATOR_V1_MEDIATYPE;
-import static de.codecentric.boot.admin.server.utils.MediaType.ACTUATOR_V2_MEDIATYPE;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
-import static org.springframework.http.MediaType.APPLICATION_JSON;
 
 public final class InstanceExchangeFilterFunctions {
 
-	private static final Logger log = LoggerFactory.getLogger(InstanceExchangeFilterFunctions.class);
-
 	public static final String ATTRIBUTE_ENDPOINT = "endpointId";
 
-	@SuppressWarnings("deprecation") // We need to support Spring Boot 1.x apps...
-	private static final List<MediaType> DEFAULT_ACCEPT_MEDIATYPES = asList(ACTUATOR_V2_MEDIATYPE,
-			ACTUATOR_V1_MEDIATYPE, MediaType.APPLICATION_JSON);
+	private static final Logger log = LoggerFactory.getLogger(InstanceExchangeFilterFunctions.class);
 
-	private static final List<MediaType> DEFAULT_LOGFILE_ACCEPT_MEDIATYPES = singletonList(MediaType.TEXT_PLAIN);
+	private static final List<MediaType> DEFAULT_LOGFILE_ACCEPT_MEDIA_TYPES = singletonList(MediaType.TEXT_PLAIN);
+
+	static MediaType V1_ACTUATOR_JSON = MediaType.valueOf("application/vnd.spring-boot.actuator.v1+json");
+
+	private static final List<MediaType> DEFAULT_ACCEPT_MEDIA_TYPES = asList(
+		new MediaType(ApiVersion.V3.getProducedMimeType()),
+		new MediaType(ApiVersion.V2.getProducedMimeType()),
+		V1_ACTUATOR_JSON, MediaType.APPLICATION_JSON
+	);
 
 	private InstanceExchangeFilterFunctions() {
 	}
@@ -136,13 +137,13 @@ public final class InstanceExchangeFilterFunctions {
 
 	private static Boolean isLegacyResponse(ClientResponse response) {
 		return response.headers().contentType()
-				.map((t) -> ACTUATOR_V1_MEDIATYPE.isCompatibleWith(t) || APPLICATION_JSON.isCompatibleWith(t))
-				.orElse(false);
+			.filter((t) -> V1_ACTUATOR_JSON.isCompatibleWith(t) || MediaType.APPLICATION_JSON.isCompatibleWith(t))
+			.isPresent();
 	}
 
 	private static ClientResponse convertLegacyResponse(LegacyEndpointConverter converter, ClientResponse response) {
 		return response.mutate().headers((headers) -> {
-			headers.replace(HttpHeaders.CONTENT_TYPE, singletonList(ActuatorMediaType.V2_JSON));
+			headers.replace(HttpHeaders.CONTENT_TYPE, singletonList(ApiVersion.LATEST.getProducedMimeType().toString()));
 			headers.remove(HttpHeaders.CONTENT_LENGTH);
 		}).body(converter::convert).build();
 	}
@@ -152,8 +153,8 @@ public final class InstanceExchangeFilterFunctions {
 			if (request.headers().getAccept().isEmpty()) {
 				Boolean isRequestForLogfile = request.attribute(ATTRIBUTE_ENDPOINT).map(Endpoint.LOGFILE::equals)
 						.orElse(false);
-				List<MediaType> acceptedHeaders = isRequestForLogfile ? DEFAULT_LOGFILE_ACCEPT_MEDIATYPES
-						: DEFAULT_ACCEPT_MEDIATYPES;
+				List<MediaType> acceptedHeaders = isRequestForLogfile ? DEFAULT_LOGFILE_ACCEPT_MEDIA_TYPES
+						: DEFAULT_ACCEPT_MEDIA_TYPES;
 				request = ClientRequest.from(request).headers((headers) -> headers.setAccept(acceptedHeaders)).build();
 			}
 			return next.exchange(request);

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/client/InstanceExchangeFilterFunctions.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/client/InstanceExchangeFilterFunctions.java
@@ -57,10 +57,8 @@ public final class InstanceExchangeFilterFunctions {
 	static MediaType V1_ACTUATOR_JSON = MediaType.valueOf("application/vnd.spring-boot.actuator.v1+json");
 
 	private static final List<MediaType> DEFAULT_ACCEPT_MEDIA_TYPES = asList(
-		new MediaType(ApiVersion.V3.getProducedMimeType()),
-		new MediaType(ApiVersion.V2.getProducedMimeType()),
-		V1_ACTUATOR_JSON, MediaType.APPLICATION_JSON
-	);
+			new MediaType(ApiVersion.V3.getProducedMimeType()), new MediaType(ApiVersion.V2.getProducedMimeType()),
+			V1_ACTUATOR_JSON, MediaType.APPLICATION_JSON);
 
 	private InstanceExchangeFilterFunctions() {
 	}
@@ -137,13 +135,14 @@ public final class InstanceExchangeFilterFunctions {
 
 	private static Boolean isLegacyResponse(ClientResponse response) {
 		return response.headers().contentType()
-			.filter((t) -> V1_ACTUATOR_JSON.isCompatibleWith(t) || MediaType.APPLICATION_JSON.isCompatibleWith(t))
-			.isPresent();
+				.filter((t) -> V1_ACTUATOR_JSON.isCompatibleWith(t) || MediaType.APPLICATION_JSON.isCompatibleWith(t))
+				.isPresent();
 	}
 
 	private static ClientResponse convertLegacyResponse(LegacyEndpointConverter converter, ClientResponse response) {
 		return response.mutate().headers((headers) -> {
-			headers.replace(HttpHeaders.CONTENT_TYPE, singletonList(ApiVersion.LATEST.getProducedMimeType().toString()));
+			headers.replace(HttpHeaders.CONTENT_TYPE,
+					singletonList(ApiVersion.LATEST.getProducedMimeType().toString()));
 			headers.remove(HttpHeaders.CONTENT_LENGTH);
 		}).body(converter::convert).build();
 	}

--- a/spring-boot-admin-server/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-admin-server/src/main/resources/META-INF/spring.factories
@@ -1,5 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  de.codecentric.boot.admin.server.config.AdminServerAutoConfiguration,\
-  de.codecentric.boot.admin.server.config.AdminServerNotifierAutoConfiguration,\
-  de.codecentric.boot.admin.server.config.AdminServerHazelcastAutoConfiguration,\
-  de.codecentric.boot.admin.server.config.AdminServerCloudFoundryAutoConfiguration

--- a/spring-boot-admin-server/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-boot-admin-server/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,4 @@
+de.codecentric.boot.admin.server.config.AdminServerAutoConfiguration
+de.codecentric.boot.admin.server.config.AdminServerNotifierAutoConfiguration
+de.codecentric.boot.admin.server.config.AdminServerHazelcastAutoConfiguration
+de.codecentric.boot.admin.server.config.AdminServerCloudFoundryAutoConfiguration

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/domain/values/InfoTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/domain/values/InfoTest.java
@@ -20,6 +20,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import org.assertj.core.data.MapEntry;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -32,10 +33,10 @@ public class InfoTest {
 		map.put("z", "1");
 		map.put("x", "2");
 
-		Iterator<?> iter = Info.from(map).getValues().entrySet().iterator();
+		Iterator<Map.Entry<String, Object>> iterator = Info.from(map).getValues().entrySet().iterator();
 
-		assertThat(iter.next()).hasFieldOrPropertyWithValue("key", "z").hasFieldOrPropertyWithValue("value", "1");
-		assertThat(iter.next()).hasFieldOrPropertyWithValue("key", "x").hasFieldOrPropertyWithValue("value", "2");
+		assertThat(iterator.next()).isEqualTo(MapEntry.entry("z", "1"));
+		assertThat(iterator.next()).isEqualTo(MapEntry.entry("x", "2"));
 	}
 
 }

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/services/InfoUpdaterTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/services/InfoUpdaterTest.java
@@ -62,6 +62,8 @@ public class InfoUpdaterTest {
 
 	private InstanceRepository repository;
 
+	private final ApiMediaTypeHandler apiMediaTypeHandler = new ApiMediaTypeHandler();
+
 	@BeforeEach
 	public void setup() {
 		this.eventStore = new InMemoryEventStore();
@@ -69,7 +71,8 @@ public class InfoUpdaterTest {
 		this.updater = new InfoUpdater(this.repository,
 				InstanceWebClient.builder().filter(rewriteEndpointUrl())
 						.filter(retry(0, singletonMap(Endpoint.INFO, 1)))
-						.filter(timeout(Duration.ofSeconds(2), emptyMap())).build());
+						.filter(timeout(Duration.ofSeconds(2), emptyMap())).build(),
+			this.apiMediaTypeHandler);
 		this.wireMock.start();
 	}
 
@@ -152,7 +155,7 @@ public class InfoUpdaterTest {
 
 	@Test
 	public void should_clear_info_on_exception() {
-		this.updater = new InfoUpdater(this.repository, InstanceWebClient.builder().build());
+		this.updater = new InfoUpdater(this.repository, InstanceWebClient.builder().build(), this.apiMediaTypeHandler);
 
 		// given
 		Instance instance = Instance.create(InstanceId.of("onl"))

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/services/InfoUpdaterTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/services/InfoUpdaterTest.java
@@ -72,7 +72,7 @@ public class InfoUpdaterTest {
 				InstanceWebClient.builder().filter(rewriteEndpointUrl())
 						.filter(retry(0, singletonMap(Endpoint.INFO, 1)))
 						.filter(timeout(Duration.ofSeconds(2), emptyMap())).build(),
-			this.apiMediaTypeHandler);
+				this.apiMediaTypeHandler);
 		this.wireMock.start();
 	}
 

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/services/StatusUpdaterTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/services/StatusUpdaterTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.actuate.endpoint.http.ActuatorMediaType;
+import org.springframework.boot.actuate.endpoint.ApiVersion;
 import org.springframework.http.MediaType;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -91,7 +91,8 @@ public class StatusUpdaterTest {
 		this.updater = new StatusUpdater(this.repository,
 				InstanceWebClient.builder().filter(rewriteEndpointUrl())
 						.filter(retry(0, singletonMap(Endpoint.HEALTH, 1)))
-						.filter(timeout(Duration.ofSeconds(2), emptyMap())).build());
+						.filter(timeout(Duration.ofSeconds(2), emptyMap())).build(),
+			new ApiMediaTypeHandler());
 	}
 
 	@AfterEach
@@ -102,7 +103,7 @@ public class StatusUpdaterTest {
 	@Test
 	public void should_change_status_to_down() {
 		String body = "{ \"status\" : \"UP\", \"details\" : { \"foo\" : \"bar\" } }";
-		this.wireMock.stubFor(get("/health").willReturn(okForContentType(ActuatorMediaType.V2_JSON, body)
+		this.wireMock.stubFor(get("/health").willReturn(okForContentType(ApiVersion.LATEST.getProducedMimeType().toString(), body)
 				.withHeader("Content-Length", Integer.toString(body.length()))));
 
 		StepVerifier.create(this.eventStore).expectSubscription()

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/services/StatusUpdaterTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/services/StatusUpdaterTest.java
@@ -92,7 +92,7 @@ public class StatusUpdaterTest {
 				InstanceWebClient.builder().filter(rewriteEndpointUrl())
 						.filter(retry(0, singletonMap(Endpoint.HEALTH, 1)))
 						.filter(timeout(Duration.ofSeconds(2), emptyMap())).build(),
-			new ApiMediaTypeHandler());
+				new ApiMediaTypeHandler());
 	}
 
 	@AfterEach
@@ -103,8 +103,9 @@ public class StatusUpdaterTest {
 	@Test
 	public void should_change_status_to_down() {
 		String body = "{ \"status\" : \"UP\", \"details\" : { \"foo\" : \"bar\" } }";
-		this.wireMock.stubFor(get("/health").willReturn(okForContentType(ApiVersion.LATEST.getProducedMimeType().toString(), body)
-				.withHeader("Content-Length", Integer.toString(body.length()))));
+		this.wireMock.stubFor(
+				get("/health").willReturn(okForContentType(ApiVersion.LATEST.getProducedMimeType().toString(), body)
+						.withHeader("Content-Length", Integer.toString(body.length()))));
 
 		StepVerifier.create(this.eventStore).expectSubscription()
 				.then(() -> StepVerifier.create(this.updater.updateStatus(this.instance.getId())).verifyComplete())

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/services/endpoints/QueryIndexEndpointStrategyTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/services/endpoints/QueryIndexEndpointStrategyTest.java
@@ -25,7 +25,7 @@ import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.actuate.endpoint.http.ActuatorMediaType;
+import org.springframework.boot.actuate.endpoint.ApiVersion;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -37,6 +37,7 @@ import de.codecentric.boot.admin.server.domain.values.Endpoint;
 import de.codecentric.boot.admin.server.domain.values.Endpoints;
 import de.codecentric.boot.admin.server.domain.values.InstanceId;
 import de.codecentric.boot.admin.server.domain.values.Registration;
+import de.codecentric.boot.admin.server.services.ApiMediaTypeHandler;
 import de.codecentric.boot.admin.server.web.client.InstanceWebClient;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
@@ -57,6 +58,8 @@ import static java.util.Collections.singletonMap;
 public class QueryIndexEndpointStrategyTest {
 
 	public WireMockServer wireMock = new WireMockServer(wireMockConfig().dynamicPort().dynamicHttpsPort());
+
+	private final ApiMediaTypeHandler apiMediaTypeHandler = new ApiMediaTypeHandler();
 
 	private InstanceWebClient instanceWebClient = InstanceWebClient.builder()
 			.webClient(WebClient.builder().clientConnector(httpConnector())).filter(rewriteEndpointUrl())
@@ -85,9 +88,9 @@ public class QueryIndexEndpointStrategyTest {
 				+ "/mgmt\"},\"metrics\":{\"templated\":false,\"href\":\"" + host
 				+ "/mgmt/stats\"},\"info\":{\"templated\":false,\"href\":\"" + host + "/mgmt/info\"}}}";
 
-		this.wireMock.stubFor(get("/mgmt").willReturn(ok(body).withHeader("Content-Type", ActuatorMediaType.V2_JSON)));
+		this.wireMock.stubFor(get("/mgmt").willReturn(ok(body).withHeader("Content-Type", ApiVersion.LATEST.getProducedMimeType().toString())));
 
-		QueryIndexEndpointStrategy strategy = new QueryIndexEndpointStrategy(this.instanceWebClient);
+		QueryIndexEndpointStrategy strategy = new QueryIndexEndpointStrategy(this.instanceWebClient, this.apiMediaTypeHandler);
 
 		// when
 		StepVerifier.create(strategy.detectEndpoints(instance))
@@ -108,9 +111,9 @@ public class QueryIndexEndpointStrategyTest {
 				+ "/mgmt\"},\"metrics\":{\"templated\":false,\"href\":\"" + host
 				+ "/mgmt/stats\"},\"info\":{\"templated\":false,\"href\":\"" + host + "/mgmt/info\"}}}";
 
-		this.wireMock.stubFor(get("/mgmt").willReturn(ok(body).withHeader("Content-Type", ActuatorMediaType.V2_JSON)));
+		this.wireMock.stubFor(get("/mgmt").willReturn(ok(body).withHeader("Content-Type", ApiVersion.LATEST.getProducedMimeType().toString())));
 
-		QueryIndexEndpointStrategy strategy = new QueryIndexEndpointStrategy(this.instanceWebClient);
+		QueryIndexEndpointStrategy strategy = new QueryIndexEndpointStrategy(this.instanceWebClient, this.apiMediaTypeHandler);
 
 		// when
 		String secureHost = "https://localhost:" + this.wireMock.httpsPort();
@@ -129,9 +132,9 @@ public class QueryIndexEndpointStrategyTest {
 
 		String body = "{\"_links\":{}}";
 		this.wireMock
-				.stubFor(get("/mgmt").willReturn(okJson(body).withHeader("Content-Type", ActuatorMediaType.V2_JSON)));
+				.stubFor(get("/mgmt").willReturn(okJson(body).withHeader("Content-Type", ApiVersion.LATEST.getProducedMimeType().toString())));
 
-		QueryIndexEndpointStrategy strategy = new QueryIndexEndpointStrategy(this.instanceWebClient);
+		QueryIndexEndpointStrategy strategy = new QueryIndexEndpointStrategy(this.instanceWebClient, this.apiMediaTypeHandler);
 
 		// when
 		StepVerifier.create(strategy.detectEndpoints(instance))
@@ -147,7 +150,7 @@ public class QueryIndexEndpointStrategyTest {
 
 		this.wireMock.stubFor(get("/mgmt").willReturn(notFound()));
 
-		QueryIndexEndpointStrategy strategy = new QueryIndexEndpointStrategy(this.instanceWebClient);
+		QueryIndexEndpointStrategy strategy = new QueryIndexEndpointStrategy(this.instanceWebClient, this.apiMediaTypeHandler);
 
 		// when
 		StepVerifier.create(strategy.detectEndpoints(instance))
@@ -163,7 +166,7 @@ public class QueryIndexEndpointStrategyTest {
 
 		this.wireMock.stubFor(get("/mgmt").willReturn(aResponse().withFault(Fault.EMPTY_RESPONSE)));
 
-		QueryIndexEndpointStrategy strategy = new QueryIndexEndpointStrategy(this.instanceWebClient);
+		QueryIndexEndpointStrategy strategy = new QueryIndexEndpointStrategy(this.instanceWebClient, this.apiMediaTypeHandler);
 
 		// when
 		StepVerifier.create(strategy.detectEndpoints(instance))
@@ -180,7 +183,7 @@ public class QueryIndexEndpointStrategyTest {
 		String body = "HELLOW WORLD";
 		this.wireMock.stubFor(get("/mgmt").willReturn(ok(body).withHeader("Content-Type", MediaType.TEXT_PLAIN_VALUE)));
 
-		QueryIndexEndpointStrategy strategy = new QueryIndexEndpointStrategy(this.instanceWebClient);
+		QueryIndexEndpointStrategy strategy = new QueryIndexEndpointStrategy(this.instanceWebClient, this.apiMediaTypeHandler);
 
 		// when
 		StepVerifier.create(strategy.detectEndpoints(instance))
@@ -195,7 +198,7 @@ public class QueryIndexEndpointStrategyTest {
 				.register(Registration.create("test", this.wireMock.url("/app/health"))
 						.managementUrl(this.wireMock.url("/app")).serviceUrl(this.wireMock.url("/app")).build());
 
-		QueryIndexEndpointStrategy strategy = new QueryIndexEndpointStrategy(this.instanceWebClient);
+		QueryIndexEndpointStrategy strategy = new QueryIndexEndpointStrategy(this.instanceWebClient, this.apiMediaTypeHandler);
 
 		// when/then
 		StepVerifier.create(strategy.detectEndpoints(instance)).verifyComplete();
@@ -214,9 +217,9 @@ public class QueryIndexEndpointStrategyTest {
 				.willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER)).willSetStateTo("recovered"));
 
 		this.wireMock.stubFor(get("/mgmt").inScenario("retry").whenScenarioStateIs("recovered")
-				.willReturn(ok(body).withHeader("Content-Type", ActuatorMediaType.V2_JSON)));
+				.willReturn(ok(body).withHeader("Content-Type", ApiVersion.LATEST.getProducedMimeType().toString())));
 
-		QueryIndexEndpointStrategy strategy = new QueryIndexEndpointStrategy(this.instanceWebClient);
+		QueryIndexEndpointStrategy strategy = new QueryIndexEndpointStrategy(this.instanceWebClient, this.apiMediaTypeHandler);
 
 		// when
 		StepVerifier.create(strategy.detectEndpoints(instance))

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/services/endpoints/QueryIndexEndpointStrategyTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/services/endpoints/QueryIndexEndpointStrategyTest.java
@@ -88,9 +88,11 @@ public class QueryIndexEndpointStrategyTest {
 				+ "/mgmt\"},\"metrics\":{\"templated\":false,\"href\":\"" + host
 				+ "/mgmt/stats\"},\"info\":{\"templated\":false,\"href\":\"" + host + "/mgmt/info\"}}}";
 
-		this.wireMock.stubFor(get("/mgmt").willReturn(ok(body).withHeader("Content-Type", ApiVersion.LATEST.getProducedMimeType().toString())));
+		this.wireMock.stubFor(get("/mgmt")
+				.willReturn(ok(body).withHeader("Content-Type", ApiVersion.LATEST.getProducedMimeType().toString())));
 
-		QueryIndexEndpointStrategy strategy = new QueryIndexEndpointStrategy(this.instanceWebClient, this.apiMediaTypeHandler);
+		QueryIndexEndpointStrategy strategy = new QueryIndexEndpointStrategy(this.instanceWebClient,
+				this.apiMediaTypeHandler);
 
 		// when
 		StepVerifier.create(strategy.detectEndpoints(instance))
@@ -111,9 +113,11 @@ public class QueryIndexEndpointStrategyTest {
 				+ "/mgmt\"},\"metrics\":{\"templated\":false,\"href\":\"" + host
 				+ "/mgmt/stats\"},\"info\":{\"templated\":false,\"href\":\"" + host + "/mgmt/info\"}}}";
 
-		this.wireMock.stubFor(get("/mgmt").willReturn(ok(body).withHeader("Content-Type", ApiVersion.LATEST.getProducedMimeType().toString())));
+		this.wireMock.stubFor(get("/mgmt")
+				.willReturn(ok(body).withHeader("Content-Type", ApiVersion.LATEST.getProducedMimeType().toString())));
 
-		QueryIndexEndpointStrategy strategy = new QueryIndexEndpointStrategy(this.instanceWebClient, this.apiMediaTypeHandler);
+		QueryIndexEndpointStrategy strategy = new QueryIndexEndpointStrategy(this.instanceWebClient,
+				this.apiMediaTypeHandler);
 
 		// when
 		String secureHost = "https://localhost:" + this.wireMock.httpsPort();
@@ -131,10 +135,11 @@ public class QueryIndexEndpointStrategyTest {
 				.create("test", this.wireMock.url("/mgmt/health")).managementUrl(this.wireMock.url("/mgmt")).build());
 
 		String body = "{\"_links\":{}}";
-		this.wireMock
-				.stubFor(get("/mgmt").willReturn(okJson(body).withHeader("Content-Type", ApiVersion.LATEST.getProducedMimeType().toString())));
+		this.wireMock.stubFor(get("/mgmt").willReturn(
+				okJson(body).withHeader("Content-Type", ApiVersion.LATEST.getProducedMimeType().toString())));
 
-		QueryIndexEndpointStrategy strategy = new QueryIndexEndpointStrategy(this.instanceWebClient, this.apiMediaTypeHandler);
+		QueryIndexEndpointStrategy strategy = new QueryIndexEndpointStrategy(this.instanceWebClient,
+				this.apiMediaTypeHandler);
 
 		// when
 		StepVerifier.create(strategy.detectEndpoints(instance))
@@ -150,7 +155,8 @@ public class QueryIndexEndpointStrategyTest {
 
 		this.wireMock.stubFor(get("/mgmt").willReturn(notFound()));
 
-		QueryIndexEndpointStrategy strategy = new QueryIndexEndpointStrategy(this.instanceWebClient, this.apiMediaTypeHandler);
+		QueryIndexEndpointStrategy strategy = new QueryIndexEndpointStrategy(this.instanceWebClient,
+				this.apiMediaTypeHandler);
 
 		// when
 		StepVerifier.create(strategy.detectEndpoints(instance))
@@ -166,7 +172,8 @@ public class QueryIndexEndpointStrategyTest {
 
 		this.wireMock.stubFor(get("/mgmt").willReturn(aResponse().withFault(Fault.EMPTY_RESPONSE)));
 
-		QueryIndexEndpointStrategy strategy = new QueryIndexEndpointStrategy(this.instanceWebClient, this.apiMediaTypeHandler);
+		QueryIndexEndpointStrategy strategy = new QueryIndexEndpointStrategy(this.instanceWebClient,
+				this.apiMediaTypeHandler);
 
 		// when
 		StepVerifier.create(strategy.detectEndpoints(instance))
@@ -183,7 +190,8 @@ public class QueryIndexEndpointStrategyTest {
 		String body = "HELLOW WORLD";
 		this.wireMock.stubFor(get("/mgmt").willReturn(ok(body).withHeader("Content-Type", MediaType.TEXT_PLAIN_VALUE)));
 
-		QueryIndexEndpointStrategy strategy = new QueryIndexEndpointStrategy(this.instanceWebClient, this.apiMediaTypeHandler);
+		QueryIndexEndpointStrategy strategy = new QueryIndexEndpointStrategy(this.instanceWebClient,
+				this.apiMediaTypeHandler);
 
 		// when
 		StepVerifier.create(strategy.detectEndpoints(instance))
@@ -198,7 +206,8 @@ public class QueryIndexEndpointStrategyTest {
 				.register(Registration.create("test", this.wireMock.url("/app/health"))
 						.managementUrl(this.wireMock.url("/app")).serviceUrl(this.wireMock.url("/app")).build());
 
-		QueryIndexEndpointStrategy strategy = new QueryIndexEndpointStrategy(this.instanceWebClient, this.apiMediaTypeHandler);
+		QueryIndexEndpointStrategy strategy = new QueryIndexEndpointStrategy(this.instanceWebClient,
+				this.apiMediaTypeHandler);
 
 		// when/then
 		StepVerifier.create(strategy.detectEndpoints(instance)).verifyComplete();
@@ -219,7 +228,8 @@ public class QueryIndexEndpointStrategyTest {
 		this.wireMock.stubFor(get("/mgmt").inScenario("retry").whenScenarioStateIs("recovered")
 				.willReturn(ok(body).withHeader("Content-Type", ApiVersion.LATEST.getProducedMimeType().toString())));
 
-		QueryIndexEndpointStrategy strategy = new QueryIndexEndpointStrategy(this.instanceWebClient, this.apiMediaTypeHandler);
+		QueryIndexEndpointStrategy strategy = new QueryIndexEndpointStrategy(this.instanceWebClient,
+				this.apiMediaTypeHandler);
 
 		// when
 		StepVerifier.create(strategy.detectEndpoints(instance))

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/web/AbstractInstancesProxyControllerIntegrationTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/web/AbstractInstancesProxyControllerIntegrationTest.java
@@ -57,7 +57,8 @@ import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 
 public abstract class AbstractInstancesProxyControllerIntegrationTest {
 
-	private static final String ACTUATOR_CONTENT_TYPE = ApiVersion.LATEST.getProducedMimeType().toString() + ";charset=UTF-8";
+	private static final String ACTUATOR_CONTENT_TYPE = ApiVersion.LATEST.getProducedMimeType().toString()
+			+ ";charset=UTF-8";
 
 	private static final ParameterizedTypeReference<Map<String, Object>> RESPONSE_TYPE = new ParameterizedTypeReference<Map<String, Object>>() {
 	};
@@ -100,39 +101,45 @@ public abstract class AbstractInstancesProxyControllerIntegrationTest {
 	@Test
 	public void should_return_status_503() {
 		// 503 on invalid instance
-		this.client.get().uri("/instances/{instanceId}/actuator/info", "UNKNOWN").accept(new MediaType(ApiVersion.LATEST.getProducedMimeType()))
-				.exchange().expectStatus().isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+		this.client.get().uri("/instances/{instanceId}/actuator/info", "UNKNOWN")
+				.accept(new MediaType(ApiVersion.LATEST.getProducedMimeType())).exchange().expectStatus()
+				.isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
 	}
 
 	@Test
 	public void should_return_status_404() {
 		// 404 on non-existent endpoint
 		this.client.get().uri("/instances/{instanceId}/actuator/not-exist", this.instanceId)
-				.accept(new MediaType(ApiVersion.LATEST.getProducedMimeType())).exchange().expectStatus().isEqualTo(HttpStatus.NOT_FOUND);
+				.accept(new MediaType(ApiVersion.LATEST.getProducedMimeType())).exchange().expectStatus()
+				.isEqualTo(HttpStatus.NOT_FOUND);
 	}
 
 	@Test
 	public void should_return_status_502() {
 		// 502 on invalid response
-		this.client.get().uri("/instances/{instanceId}/actuator/invalid", this.instanceId).accept(new MediaType(ApiVersion.LATEST.getProducedMimeType()))
-				.exchange().expectStatus().isEqualTo(HttpStatus.BAD_GATEWAY);
+		this.client.get().uri("/instances/{instanceId}/actuator/invalid", this.instanceId)
+				.accept(new MediaType(ApiVersion.LATEST.getProducedMimeType())).exchange().expectStatus()
+				.isEqualTo(HttpStatus.BAD_GATEWAY);
 	}
 
 	@Test
 	public void should_return_status_504() {
 		// 502 on invalid response
-		this.client.get().uri("/instances/{instanceId}/actuator/invalid", this.instanceId).accept(new MediaType(ApiVersion.LATEST.getProducedMimeType()))
-				.exchange().expectStatus().isEqualTo(HttpStatus.BAD_GATEWAY);
+		this.client.get().uri("/instances/{instanceId}/actuator/invalid", this.instanceId)
+				.accept(new MediaType(ApiVersion.LATEST.getProducedMimeType())).exchange().expectStatus()
+				.isEqualTo(HttpStatus.BAD_GATEWAY);
 	}
 
 	@Test
 	public void should_forward_requests() {
-		this.client.options().uri("/instances/{instanceId}/actuator/env", this.instanceId).accept(new MediaType(ApiVersion.LATEST.getProducedMimeType()))
-				.exchange().expectStatus().isEqualTo(HttpStatus.OK).expectHeader()
+		this.client.options().uri("/instances/{instanceId}/actuator/env", this.instanceId)
+				.accept(new MediaType(ApiVersion.LATEST.getProducedMimeType())).exchange().expectStatus()
+				.isEqualTo(HttpStatus.OK).expectHeader()
 				.valueEquals(ALLOW, HttpMethod.HEAD.name(), HttpMethod.GET.name(), HttpMethod.OPTIONS.name());
 
-		this.client.get().uri("/instances/{instanceId}/actuator/test", this.instanceId).accept(new MediaType(ApiVersion.LATEST.getProducedMimeType()))
-				.exchange().expectStatus().isEqualTo(HttpStatus.OK).expectBody().json("{ \"foo\" : \"bar\" }");
+		this.client.get().uri("/instances/{instanceId}/actuator/test", this.instanceId)
+				.accept(new MediaType(ApiVersion.LATEST.getProducedMimeType())).exchange().expectStatus()
+				.isEqualTo(HttpStatus.OK).expectBody().json("{ \"foo\" : \"bar\" }");
 
 		this.client.post().uri("/instances/{instanceId}/actuator/post", this.instanceId).bodyValue("PAYLOAD").exchange()
 				.expectStatus().isEqualTo(HttpStatus.OK);
@@ -149,8 +156,8 @@ public abstract class AbstractInstancesProxyControllerIntegrationTest {
 	@Test
 	public void should_forward_requests_with_spaces_in_path() {
 		this.client.get().uri("/instances/{instanceId}/actuator/test/has spaces", this.instanceId)
-				.accept(new MediaType(ApiVersion.LATEST.getProducedMimeType())).exchange().expectStatus().isEqualTo(HttpStatus.OK).expectBody()
-				.json("{ \"foo\" : \"bar-with-spaces\" }");
+				.accept(new MediaType(ApiVersion.LATEST.getProducedMimeType())).exchange().expectStatus()
+				.isEqualTo(HttpStatus.OK).expectBody().json("{ \"foo\" : \"bar-with-spaces\" }");
 
 		this.wireMock.verify(getRequestedFor(urlEqualTo("/instance1/test/has%20spaces")));
 	}
@@ -159,7 +166,8 @@ public abstract class AbstractInstancesProxyControllerIntegrationTest {
 	public void should_forward_requests_to_mutliple_instances() {
 		String instance2Id = registerInstance("/instance2");
 
-		this.client.get().uri("applications/test/actuator/test").accept(new MediaType(ApiVersion.LATEST.getProducedMimeType())).exchange().expectStatus()
+		this.client.get().uri("applications/test/actuator/test")
+				.accept(new MediaType(ApiVersion.LATEST.getProducedMimeType())).exchange().expectStatus()
 				.isEqualTo(HttpStatus.OK).expectBody()
 				.jsonPath("$[?(@.instanceId == '" + this.instanceId + "')].status").isEqualTo(200)
 				.jsonPath("$[?(@.instanceId == '" + this.instanceId + "')].body").isEqualTo("{ \"foo\" : \"bar\" }")
@@ -197,8 +205,8 @@ public abstract class AbstractInstancesProxyControllerIntegrationTest {
 							"\"timeout\": { \"href\": \"" + managementUrl + "/timeout\", \"templated\": false }" +
 							" } }";
 		//@formatter:on
-		this.wireMock.stubFor(get(urlEqualTo(managementPath + "/health"))
-				.willReturn(ok("{ \"status\" : \"UP\" }").withHeader(CONTENT_TYPE, ApiVersion.LATEST.getProducedMimeType().toString())));
+		this.wireMock.stubFor(get(urlEqualTo(managementPath + "/health")).willReturn(ok("{ \"status\" : \"UP\" }")
+				.withHeader(CONTENT_TYPE, ApiVersion.LATEST.getProducedMimeType().toString())));
 		this.wireMock.stubFor(get(urlEqualTo(managementPath + "/info"))
 				.willReturn(ok("{ }").withHeader(CONTENT_TYPE, ACTUATOR_CONTENT_TYPE)));
 		this.wireMock.stubFor(options(urlEqualTo(managementPath + "/env")).willReturn(

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/web/AbstractInstancesProxyControllerIntegrationTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/web/AbstractInstancesProxyControllerIntegrationTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.actuate.endpoint.http.ActuatorMediaType;
+import org.springframework.boot.actuate.endpoint.ApiVersion;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
@@ -51,14 +51,13 @@ import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.serverError;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static de.codecentric.boot.admin.server.utils.MediaType.ACTUATOR_V2_MEDIATYPE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.HttpHeaders.ALLOW;
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 
 public abstract class AbstractInstancesProxyControllerIntegrationTest {
 
-	private static final String ACTUATOR_CONTENT_TYPE = ActuatorMediaType.V2_JSON + ";charset=UTF-8";
+	private static final String ACTUATOR_CONTENT_TYPE = ApiVersion.LATEST.getProducedMimeType().toString() + ";charset=UTF-8";
 
 	private static final ParameterizedTypeReference<Map<String, Object>> RESPONSE_TYPE = new ParameterizedTypeReference<Map<String, Object>>() {
 	};
@@ -101,7 +100,7 @@ public abstract class AbstractInstancesProxyControllerIntegrationTest {
 	@Test
 	public void should_return_status_503() {
 		// 503 on invalid instance
-		this.client.get().uri("/instances/{instanceId}/actuator/info", "UNKNOWN").accept(ACTUATOR_V2_MEDIATYPE)
+		this.client.get().uri("/instances/{instanceId}/actuator/info", "UNKNOWN").accept(new MediaType(ApiVersion.LATEST.getProducedMimeType()))
 				.exchange().expectStatus().isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
 	}
 
@@ -109,30 +108,30 @@ public abstract class AbstractInstancesProxyControllerIntegrationTest {
 	public void should_return_status_404() {
 		// 404 on non-existent endpoint
 		this.client.get().uri("/instances/{instanceId}/actuator/not-exist", this.instanceId)
-				.accept(ACTUATOR_V2_MEDIATYPE).exchange().expectStatus().isEqualTo(HttpStatus.NOT_FOUND);
+				.accept(new MediaType(ApiVersion.LATEST.getProducedMimeType())).exchange().expectStatus().isEqualTo(HttpStatus.NOT_FOUND);
 	}
 
 	@Test
 	public void should_return_status_502() {
 		// 502 on invalid response
-		this.client.get().uri("/instances/{instanceId}/actuator/invalid", this.instanceId).accept(ACTUATOR_V2_MEDIATYPE)
+		this.client.get().uri("/instances/{instanceId}/actuator/invalid", this.instanceId).accept(new MediaType(ApiVersion.LATEST.getProducedMimeType()))
 				.exchange().expectStatus().isEqualTo(HttpStatus.BAD_GATEWAY);
 	}
 
 	@Test
 	public void should_return_status_504() {
 		// 502 on invalid response
-		this.client.get().uri("/instances/{instanceId}/actuator/invalid", this.instanceId).accept(ACTUATOR_V2_MEDIATYPE)
+		this.client.get().uri("/instances/{instanceId}/actuator/invalid", this.instanceId).accept(new MediaType(ApiVersion.LATEST.getProducedMimeType()))
 				.exchange().expectStatus().isEqualTo(HttpStatus.BAD_GATEWAY);
 	}
 
 	@Test
 	public void should_forward_requests() {
-		this.client.options().uri("/instances/{instanceId}/actuator/env", this.instanceId).accept(ACTUATOR_V2_MEDIATYPE)
+		this.client.options().uri("/instances/{instanceId}/actuator/env", this.instanceId).accept(new MediaType(ApiVersion.LATEST.getProducedMimeType()))
 				.exchange().expectStatus().isEqualTo(HttpStatus.OK).expectHeader()
 				.valueEquals(ALLOW, HttpMethod.HEAD.name(), HttpMethod.GET.name(), HttpMethod.OPTIONS.name());
 
-		this.client.get().uri("/instances/{instanceId}/actuator/test", this.instanceId).accept(ACTUATOR_V2_MEDIATYPE)
+		this.client.get().uri("/instances/{instanceId}/actuator/test", this.instanceId).accept(new MediaType(ApiVersion.LATEST.getProducedMimeType()))
 				.exchange().expectStatus().isEqualTo(HttpStatus.OK).expectBody().json("{ \"foo\" : \"bar\" }");
 
 		this.client.post().uri("/instances/{instanceId}/actuator/post", this.instanceId).bodyValue("PAYLOAD").exchange()
@@ -150,7 +149,7 @@ public abstract class AbstractInstancesProxyControllerIntegrationTest {
 	@Test
 	public void should_forward_requests_with_spaces_in_path() {
 		this.client.get().uri("/instances/{instanceId}/actuator/test/has spaces", this.instanceId)
-				.accept(ACTUATOR_V2_MEDIATYPE).exchange().expectStatus().isEqualTo(HttpStatus.OK).expectBody()
+				.accept(new MediaType(ApiVersion.LATEST.getProducedMimeType())).exchange().expectStatus().isEqualTo(HttpStatus.OK).expectBody()
 				.json("{ \"foo\" : \"bar-with-spaces\" }");
 
 		this.wireMock.verify(getRequestedFor(urlEqualTo("/instance1/test/has%20spaces")));
@@ -160,7 +159,7 @@ public abstract class AbstractInstancesProxyControllerIntegrationTest {
 	public void should_forward_requests_to_mutliple_instances() {
 		String instance2Id = registerInstance("/instance2");
 
-		this.client.get().uri("applications/test/actuator/test").accept(ACTUATOR_V2_MEDIATYPE).exchange().expectStatus()
+		this.client.get().uri("applications/test/actuator/test").accept(new MediaType(ApiVersion.LATEST.getProducedMimeType())).exchange().expectStatus()
 				.isEqualTo(HttpStatus.OK).expectBody()
 				.jsonPath("$[?(@.instanceId == '" + this.instanceId + "')].status").isEqualTo(200)
 				.jsonPath("$[?(@.instanceId == '" + this.instanceId + "')].body").isEqualTo("{ \"foo\" : \"bar\" }")
@@ -199,7 +198,7 @@ public abstract class AbstractInstancesProxyControllerIntegrationTest {
 							" } }";
 		//@formatter:on
 		this.wireMock.stubFor(get(urlEqualTo(managementPath + "/health"))
-				.willReturn(ok("{ \"status\" : \"UP\" }").withHeader(CONTENT_TYPE, ActuatorMediaType.V2_JSON)));
+				.willReturn(ok("{ \"status\" : \"UP\" }").withHeader(CONTENT_TYPE, ApiVersion.LATEST.getProducedMimeType().toString())));
 		this.wireMock.stubFor(get(urlEqualTo(managementPath + "/info"))
 				.willReturn(ok("{ }").withHeader(CONTENT_TYPE, ACTUATOR_CONTENT_TYPE)));
 		this.wireMock.stubFor(options(urlEqualTo(managementPath + "/env")).willReturn(

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/web/client/InstanceExchangeFilterFunctionsTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/web/client/InstanceExchangeFilterFunctionsTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import org.springframework.boot.actuate.endpoint.http.ActuatorMediaType;
+import org.springframework.boot.actuate.endpoint.ApiVersion;
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.core.io.buffer.DefaultDataBufferFactory;
 import org.springframework.http.HttpHeaders;
@@ -51,8 +51,6 @@ import de.codecentric.boot.admin.server.domain.values.Registration;
 import de.codecentric.boot.admin.server.web.client.cookies.PerInstanceCookieStore;
 import de.codecentric.boot.admin.server.web.client.exception.ResolveEndpointException;
 
-import static de.codecentric.boot.admin.server.utils.MediaType.ACTUATOR_V1_MEDIATYPE;
-import static de.codecentric.boot.admin.server.utils.MediaType.ACTUATOR_V2_MEDIATYPE;
 import static de.codecentric.boot.admin.server.web.client.InstanceExchangeFilterFunctions.ATTRIBUTE_ENDPOINT;
 import static de.codecentric.boot.admin.server.web.client.InstanceWebClient.ATTRIBUTE_INSTANCE;
 import static java.util.Collections.emptyMap;
@@ -91,16 +89,15 @@ class InstanceExchangeFilterFunctionsTest {
 		void should_convert_v1_actuator() {
 			ClientRequest request = ClientRequest.create(HttpMethod.GET, URI.create("/test"))
 					.attribute(ATTRIBUTE_ENDPOINT, "test").build();
-			@SuppressWarnings("deprecation")
 			ClientResponse legacyResponse = ClientResponse.create(HttpStatus.OK)
-					.header(CONTENT_TYPE, ACTUATOR_V1_MEDIATYPE.toString())
+					.header(CONTENT_TYPE, InstanceExchangeFilterFunctions.V1_ACTUATOR_JSON.toString())
 					.header(CONTENT_LENGTH, Integer.toString(this.original.readableByteCount()))
 					.body(Flux.just(this.original)).build();
 
 			Mono<ClientResponse> response = this.filter.filter(INSTANCE, request, (r) -> Mono.just(legacyResponse));
 
 			StepVerifier.create(response).assertNext((r) -> {
-				assertThat(r.headers().contentType()).hasValue(MediaType.valueOf(ActuatorMediaType.V2_JSON));
+				assertThat(r.headers().contentType()).hasValue(new MediaType(ApiVersion.LATEST.getProducedMimeType()));
 				assertThat(r.headers().contentLength()).isEmpty();
 				StepVerifier.create(r.body(BodyExtractors.toDataBuffers())).expectNext(this.converted).verifyComplete();
 			}).verifyComplete();
@@ -118,7 +115,7 @@ class InstanceExchangeFilterFunctionsTest {
 			Mono<ClientResponse> response = this.filter.filter(INSTANCE, request, (r) -> Mono.just(legacyResponse));
 
 			StepVerifier.create(response).assertNext((r) -> {
-				assertThat(r.headers().contentType()).hasValue(MediaType.valueOf(ActuatorMediaType.V2_JSON));
+				assertThat(r.headers().contentType()).hasValue(new MediaType(ApiVersion.LATEST.getProducedMimeType()));
 				assertThat(r.headers().contentLength()).isEmpty();
 				StepVerifier.create(r.body(BodyExtractors.toDataBuffers())).expectNext(this.converted).verifyComplete();
 			}).verifyComplete();
@@ -133,14 +130,14 @@ class InstanceExchangeFilterFunctionsTest {
 			ClientRequest request = ClientRequest.create(HttpMethod.GET, URI.create("/test"))
 					.attribute(ATTRIBUTE_ENDPOINT, "test").build();
 			ClientResponse response = ClientResponse.create(HttpStatus.OK)
-					.header(CONTENT_TYPE, ActuatorMediaType.V2_JSON)
+					.header(CONTENT_TYPE, ApiVersion.LATEST.getProducedMimeType().toString())
 					.header(CONTENT_LENGTH, Integer.toString(this.original.readableByteCount()))
 					.body(Flux.just(this.original)).build();
 
 			Mono<ClientResponse> convertedResponse = filter.filter(INSTANCE, request, (r) -> Mono.just(response));
 
 			StepVerifier.create(convertedResponse).assertNext((r) -> {
-				assertThat(r.headers().contentType()).hasValue(MediaType.valueOf(ActuatorMediaType.V2_JSON));
+				assertThat(r.headers().contentType()).hasValue(new MediaType(ApiVersion.LATEST.getProducedMimeType()));
 				assertThat(r.headers().contentLength()).hasValue(this.original.readableByteCount());
 				StepVerifier.create(r.body(BodyExtractors.toDataBuffers())).expectNext(this.original).verifyComplete();
 			}).verifyComplete();
@@ -300,7 +297,10 @@ class InstanceExchangeFilterFunctionsTest {
 			ClientRequest request = ClientRequest.create(HttpMethod.GET, URI.create("/test")).build();
 
 			Mono<ClientResponse> response = this.filter.filter(INSTANCE, request, (req) -> {
-				assertThat(req.headers().getAccept()).containsExactly(ACTUATOR_V2_MEDIATYPE, ACTUATOR_V1_MEDIATYPE,
+				assertThat(req.headers().getAccept()).containsExactly(
+						new MediaType(ApiVersion.V3.getProducedMimeType()),
+						new MediaType(ApiVersion.V2.getProducedMimeType()),
+						InstanceExchangeFilterFunctions.V1_ACTUATOR_JSON,
 						MediaType.APPLICATION_JSON);
 				return Mono.just(ClientResponse.create(HttpStatus.OK).build());
 			});

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/web/client/InstanceExchangeFilterFunctionsTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/web/client/InstanceExchangeFilterFunctionsTest.java
@@ -300,8 +300,7 @@ class InstanceExchangeFilterFunctionsTest {
 				assertThat(req.headers().getAccept()).containsExactly(
 						new MediaType(ApiVersion.V3.getProducedMimeType()),
 						new MediaType(ApiVersion.V2.getProducedMimeType()),
-						InstanceExchangeFilterFunctions.V1_ACTUATOR_JSON,
-						MediaType.APPLICATION_JSON);
+						InstanceExchangeFilterFunctions.V1_ACTUATOR_JSON, MediaType.APPLICATION_JSON);
 				return Mono.just(ClientResponse.create(HttpStatus.OK).build());
 			});
 


### PR DESCRIPTION
See spring boot 2.7 [release notes](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.7-Release-Notes) and spring cloud 2021.0.3 [release note](https://github.com/spring-cloud/spring-cloud-release/wiki/Spring-Cloud-2021.0-Release-Notes)

The main points of contributions are the following

* adding `AutoConfiguration` annotation on auto configuration classes. Inner classes keeps their `Configuration`classes as specified in the [documlentation](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.7-Release-Notes#new-autoconfiguration-annotation)
* Removing references to deprecated actuator classe and migrate to `ApiVersion` as specified in former [classe](https://github.com/spring-projects/spring-boot/blob/2.6.x/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/http/ActuatorMediaType.java)
* Upgrade hazelcast test to the new hazelcast version