### PR TITLE
fix(#2045): send credential cookies (i.e. session cookies) on ajax requests

### DIFF
--- a/spring-boot-admin-server-ui/src/main/frontend/utils/axios.js
+++ b/spring-boot-admin-server-ui/src/main/frontend/utils/axios.js
@@ -27,7 +27,7 @@ export const redirectOn401 = (predicate = () => true) => error => {
 
 };
 
-const instance = axios.create({headers: {'Accept': 'application/json'}});
+const instance = axios.create({withCredentials: true, headers: {'Accept': 'application/json'}});
 instance.interceptors.response.use(response => response, redirectOn401());
 instance.create = axios.create;
 


### PR DESCRIPTION
closes #2045 