### PR TITLE
fix: change transpilation target to support IE10+

### DIFF
--- a/spring-boot-admin-server-ui/package-lock.json
+++ b/spring-boot-admin-server-ui/package-lock.json
@@ -13309,14 +13309,20 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001258",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001258.tgz",
-      "integrity": "sha512-RBByOG6xWXUp0CR2/WU2amXz3stjKpSl5J1xU49F1n2OxD//uBZO4wCKUiG+QMGf7CHGfDDcqoKriomoGVxTeA==",
+      "version": "1.0.30001419",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001419.tgz",
+      "integrity": "sha512-aFO1r+g6R7TW+PNQxKzjITwLOyDhVRLjW0LcwS/HCZGUUKTGNp9+IwLC4xyDSZBygVL/mxaFR3HIV6wEKQuSzw==",
       "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/capture-exit": {
       "version": "2.0.0",
@@ -48929,9 +48935,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001258",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001258.tgz",
-      "integrity": "sha512-RBByOG6xWXUp0CR2/WU2amXz3stjKpSl5J1xU49F1n2OxD//uBZO4wCKUiG+QMGf7CHGfDDcqoKriomoGVxTeA==",
+      "version": "1.0.30001419",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001419.tgz",
+      "integrity": "sha512-aFO1r+g6R7TW+PNQxKzjITwLOyDhVRLjW0LcwS/HCZGUUKTGNp9+IwLC4xyDSZBygVL/mxaFR3HIV6wEKQuSzw==",
       "dev": true
     },
     "capture-exit": {

--- a/spring-boot-admin-server-ui/package.json
+++ b/spring-boot-admin-server-ui/package.json
@@ -138,7 +138,7 @@
   "browserslist": [
     "> 1%",
     "last 2 versions",
-    "not ie <= 8"
+    "ie >= 10"
   ],
   "jest": {
     "setupFiles": [

--- a/spring-boot-admin-server-ui/public/mockServiceWorker.js
+++ b/spring-boot-admin-server-ui/public/mockServiceWorker.js
@@ -2,7 +2,7 @@
 /* tslint:disable */
 
 /**
- * Mock Service Worker (0.47.0).
+ * Mock Service Worker (0.47.4).
  * @see https://github.com/mswjs/msw
  * - Please do NOT modify this file.
  * - Please do NOT serve this file on production.


### PR DESCRIPTION
`findIndex` is part of the source code but not supported in IE11. 

Possible low hanging fruit fix for #2138.