### PR TITLE
all requests to /instances/*/actuator/** should be proxied

### DIFF
--- a/spring-boot-admin-server-ui/src/main/java/de/codecentric/boot/admin/server/ui/config/AdminServerUiAutoConfiguration.java
+++ b/spring-boot-admin-server-ui/src/main/java/de/codecentric/boot/admin/server/ui/config/AdminServerUiAutoConfiguration.java
@@ -65,7 +65,7 @@ public class AdminServerUiAutoConfiguration {
 			"/journal/**", "/wallboard/**", "/external/**");
 
 	private static final List<String> DEFAULT_UI_ROUTE_EXCLUDES = asList("/extensions/**",
-			"/instances/*/actuator/heapdump", "/instances/*/actuator/logfile");
+			"/instances/*/actuator/**");
 
 	private final AdminServerUiProperties adminUi;
 


### PR DESCRIPTION
It allow custom actuator endpoint return files and other staff with different content-type).

Before this fix: if you add custom endpoint that returns files, you will not be able to download these files via boot admin.

It can be workarounded but from my point of view it will be good to have ability to access proxied actuator from browser.