### PR TITLE
feat: allow to opt-in toast notifications

### DIFF
--- a/spring-boot-admin-server-ui/src/main/frontend/utils/axios.js
+++ b/spring-boot-admin-server-ui/src/main/frontend/utils/axios.js
@@ -13,32 +13,39 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import sbaConfig from '@/sba-config'
+import sbaConfig from '@/sba-config';
 import axios from 'axios';
 import Vue from 'vue';
 
 axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
 axios.defaults.xsrfHeaderName = sbaConfig.csrf.headerName;
 
-export const redirectOn401 = (predicate = () => true) => error => {
+export const redirectOn401 = (predicate = () => true) => (error) => {
   if (error.response && error.response.status === 401 && predicate(error)) {
-    window.location.assign(`login?redirectTo=${encodeURIComponent(window.location.href)}`);
+    window.location.assign(
+      `login?redirectTo=${encodeURIComponent(window.location.href)}`
+    );
   }
   return Promise.reject(error);
 };
 
-const instance = axios.create({withCredentials: true, headers: {'Accept': 'application/json'}});
-instance.interceptors.response.use(response => response, redirectOn401());
+const instance = axios.create({
+  withCredentials: true,
+  headers: { Accept: 'application/json' },
+});
+instance.interceptors.response.use((response) => response, redirectOn401());
 instance.create = axios.create;
 
 export default instance;
 
 export const registerErrorToastInterceptor = (axios) => {
-  axios.interceptors.response.use(
-    response => response,
-    error => {
-      let data = error.request;
-      Vue.$toast.error(`Request failed: ${data.status} - ${data.statusText}`);
-    }
-  )
-}
+  if (sbaConfig.uiSettings.enableToasts === true) {
+    axios.interceptors.response.use(
+      (response) => response,
+      (error) => {
+        let data = error.request;
+        Vue.$toast.error(`Request failed: ${data.status} - ${data.statusText}`);
+      }
+    );
+  }
+};

--- a/spring-boot-admin-server-ui/src/main/java/de/codecentric/boot/admin/server/ui/config/AdminServerUiAutoConfiguration.java
+++ b/spring-boot-admin-server-ui/src/main/java/de/codecentric/boot/admin/server/ui/config/AdminServerUiAutoConfiguration.java
@@ -90,7 +90,7 @@ public class AdminServerUiAutoConfiguration {
 
 		Settings uiSettings = Settings.builder().brand(this.adminUi.getBrand()).title(this.adminUi.getTitle())
 				.loginIcon(this.adminUi.getLoginIcon()).favicon(this.adminUi.getFavicon())
-				.faviconDanger(this.adminUi.getFaviconDanger())
+				.faviconDanger(this.adminUi.getFaviconDanger()).enableToasts(this.adminUi.getEnableToasts())
 				.notificationFilterEnabled(
 						!this.applicationContext.getBeansOfType(NotificationFilterController.class).isEmpty())
 				.routes(routes).rememberMeEnabled(this.adminUi.isRememberMeEnabled())

--- a/spring-boot-admin-server-ui/src/main/java/de/codecentric/boot/admin/server/ui/config/AdminServerUiProperties.java
+++ b/spring-boot-admin-server-ui/src/main/java/de/codecentric/boot/admin/server/ui/config/AdminServerUiProperties.java
@@ -126,6 +126,11 @@ public class AdminServerUiProperties {
 	 */
 	private List<String> additionalRouteExcludes = new ArrayList<>();
 
+	/**
+	 * Allows to enable toast notifications in SBA.
+	 */
+	private Boolean enableToasts = false;
+
 	@lombok.Data
 	public static class PollTimer {
 

--- a/spring-boot-admin-server-ui/src/main/java/de/codecentric/boot/admin/server/ui/web/UiController.java
+++ b/spring-boot-admin-server-ui/src/main/java/de/codecentric/boot/admin/server/ui/web/UiController.java
@@ -139,6 +139,8 @@ public class UiController {
 
 		private final List<ViewSettings> viewSettings;
 
+		private final Boolean enableToasts;
+
 	}
 
 	@lombok.Data


### PR DESCRIPTION
closes #2174, #2165.

After merging this PR, users will have to explicitly enable toasts by setting `spring.boot.admin.ui.enable-toasts` to `true`.