### PR TITLE
Ignore the ui coverage folder that is generated during the build

### DIFF
--- a/spring-boot-admin-server-ui/.gitignore
+++ b/spring-boot-admin-server-ui/.gitignore
@@ -1,0 +1,1 @@
+/coverage/


### PR DESCRIPTION
If I run a `mvn clean install` locally the UI build creates a coverage folder that appears in git as unmerged changes. This PR just ignores this folder to remove the noise on the git merge.