### PR TITLE
fix: Compatibility with Spring Boot Admin 1.5.x client status updates

### DIFF
--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/ApiMediaTypeHandler.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/ApiMediaTypeHandler.java
@@ -23,10 +23,13 @@ import org.springframework.http.MediaType;
 
 public class ApiMediaTypeHandler {
 
+	public static final org.springframework.http.MediaType ACTUATOR_V1_MEDIATYPE = org.springframework.http.MediaType
+		.parseMediaType("application/vnd.spring-boot.actuator.v1+json");
+
 	public boolean isApiMediaType(MediaType mediaType) {
 		return Stream.of(ApiVersion.values())
 			.map(ApiVersion::getProducedMimeType)
-			.anyMatch((mimeType) -> mimeType.isCompatibleWith(mediaType));
+			.anyMatch((mimeType) -> mimeType.isCompatibleWith(mediaType) || ACTUATOR_V1_MEDIATYPE.isCompatibleWith(mediaType));
 	}
 
 }


### PR DESCRIPTION
When using Spring Boot version 1.5.X as a client to connect to a Spring Boot Admin 2.7.X server, the logs continuously show 'Couldn't retrieve info for XXXX.' 
This is because the 'InfoUpdater#convertInfo()' method checks 'isApiMediaType' using 'org.springframework.boot.actuate.endpoint.ApiVersion' for version comparison. The 2.7.X server's actuator version only has V2 and V3, which results in the 1.X client registration and status update continuously logging 'Couldn't retrieve info for XX'.