### PR TITLE
change deprecated rawStatusCode() method, already removed from spring

### DIFF
--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/endpoints/ProbeEndpointsStrategy.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/endpoints/ProbeEndpointsStrategy.java
@@ -97,7 +97,7 @@ public class ProbeEndpointsStrategy implements EndpointDetectionStrategy {
 			}
 			else {
 				log.debug("Endpoint probe for instance {} on endpoint '{}' failed with status {}.", instanceId, uri,
-						response.rawStatusCode());
+						response.statusCode().value());
 			}
 			return response.releaseBody().then(endpoint);
 		};


### PR DESCRIPTION
Seeing this error with Spring 6.1.

```     
java.lang.NoSuchMethodError: 'int org.springframework.web.reactive.function.client.ClientResponse.rawStatusCode()'
        at de.codecentric.boot.admin.server.services.endpoints.ProbeEndpointsStrategy.lambda$convert$2(ProbeEndpointsStrategy.java:100) ~[spring-boot-admin-server-3.1.7.jar!/:3.1.7]
        at org.springframework.web.reactive.function.client.DefaultWebClient$DefaultRequestBodyUriSpec.lambda$exchangeToMono$3(DefaultWebClient.java:410) ~[spring-webflux-6.1.0-M5.jar!/:6.1.0-M5]
```