### PR TITLE
fix(#2849): drop replacement of characters in router name for external views

### DIFF
--- a/spring-boot-admin-server-ui/src/main/frontend/views/external/index.spec.ts
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/external/index.spec.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import ViewRegistry from '@/viewRegistry';
+import { addExternalLink } from '@/views/external/index';
+
+describe('External Link', () => {
+  let viewRegistry: ViewRegistry;
+
+  beforeEach(() => {
+    viewRegistry = new ViewRegistry();
+  });
+
+  it('will be added to view registry', () => {
+    addExternalLink(viewRegistry, {
+      label: 'External Link',
+      url: 'https://www.codecentric.de',
+    });
+
+    expect(viewRegistry.views).toHaveLength(1);
+    expect(viewRegistry.views.map((v) => v.label)).toContain('External Link');
+  });
+
+  it('will be added to view registry with children', () => {
+    addExternalLink(viewRegistry, {
+      label: 'External Link',
+      url: 'https://www.codecentric.de',
+      children: [
+        {
+          label: 'External Link Child',
+          url: 'https://www.codecentric.de',
+        },
+      ],
+    });
+
+    expect(viewRegistry.views).toHaveLength(2);
+    expect(viewRegistry.views.map((v) => v.label)).toContain('External Link');
+    expect(viewRegistry.views.map((v) => v.label)).toContain(
+      'External Link Child',
+    );
+  });
+
+  it('will add multiple external links', () => {
+    addExternalLink(viewRegistry, {
+      label: 'External Link 1',
+      url: 'https://www.codecentric.de',
+    });
+    addExternalLink(viewRegistry, {
+      label: 'External Link 2',
+      url: 'https://www.codecentric.de',
+    });
+
+    expect(viewRegistry.views).toHaveLength(2);
+    expect(viewRegistry.views.map((v) => v.label)).toContain('External Link 1');
+    expect(viewRegistry.views.map((v) => v.label)).toContain('External Link 2');
+  });
+});

--- a/spring-boot-admin-server-ui/src/main/frontend/views/external/index.spec.ts
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/external/index.spec.ts
@@ -1,56 +1,96 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import ViewRegistry from '@/viewRegistry';
-import { addExternalLink } from '@/views/external/index';
+import { addExternalLink, addIframeView } from '@/views/external/index';
 
-describe('External Link', () => {
+describe('External View', () => {
   let viewRegistry: ViewRegistry;
 
   beforeEach(() => {
     viewRegistry = new ViewRegistry();
   });
 
-  it('will be added to view registry', () => {
-    addExternalLink(viewRegistry, {
-      label: 'External Link',
-      url: 'https://www.codecentric.de',
+  describe('External Link', () => {
+    it('will be added to view registry', () => {
+      addExternalLink(viewRegistry, {
+        label: 'External Link',
+        url: 'https://www.codecentric.de',
+      });
+
+      expect(viewRegistry.views).toHaveLength(1);
+      expect(viewRegistry.views.map((v) => v.label)).toContain('External Link');
     });
 
-    expect(viewRegistry.views).toHaveLength(1);
-    expect(viewRegistry.views.map((v) => v.label)).toContain('External Link');
+    it('will be added to view registry with children', () => {
+      addExternalLink(viewRegistry, {
+        label: 'External Link',
+        url: 'https://www.codecentric.de',
+        children: [
+          {
+            label: 'External Link Child',
+            url: 'https://www.codecentric.de',
+          },
+        ],
+      });
+
+      expect(viewRegistry.views).toHaveLength(2);
+      expect(viewRegistry.views.map((v) => v.label)).toContain('External Link');
+      expect(viewRegistry.views.map((v) => v.label)).toContain(
+        'External Link Child',
+      );
+    });
+
+    it('will add multiple external links', () => {
+      addExternalLink(viewRegistry, {
+        label: 'External Link 1',
+        url: 'https://www.codecentric.de',
+      });
+      addExternalLink(viewRegistry, {
+        label: 'External Link 2',
+        url: 'https://www.codecentric.de',
+      });
+
+      expect(viewRegistry.views).toHaveLength(2);
+      expect(viewRegistry.views.map((v) => v.label)).toContain(
+        'External Link 1',
+      );
+      expect(viewRegistry.views.map((v) => v.label)).toContain(
+        'External Link 2',
+      );
+    });
   });
 
-  it('will be added to view registry with children', () => {
-    addExternalLink(viewRegistry, {
-      label: 'External Link',
-      url: 'https://www.codecentric.de',
-      children: [
-        {
-          label: 'External Link Child',
-          url: 'https://www.codecentric.de',
-        },
-      ],
+  describe('External Iframe', () => {
+    it('will be added to view registry', () => {
+      addIframeView(viewRegistry, {
+        label: 'External Iframe',
+        url: 'https://www.codecentric.de',
+        iframe: true,
+      });
+
+      expect(viewRegistry.views).toHaveLength(1);
+      expect(viewRegistry.views.map((v) => v.label)).toContain(
+        'External Iframe',
+      );
     });
 
-    expect(viewRegistry.views).toHaveLength(2);
-    expect(viewRegistry.views.map((v) => v.label)).toContain('External Link');
-    expect(viewRegistry.views.map((v) => v.label)).toContain(
-      'External Link Child',
-    );
-  });
+    it('will add multiple iframes', () => {
+      addIframeView(viewRegistry, {
+        label: 'External Link 1',
+        url: 'https://www.codecentric.de',
+      });
+      addIframeView(viewRegistry, {
+        label: 'External Link 2',
+        url: 'https://www.codecentric.de',
+      });
 
-  it('will add multiple external links', () => {
-    addExternalLink(viewRegistry, {
-      label: 'External Link 1',
-      url: 'https://www.codecentric.de',
+      expect(viewRegistry.views).toHaveLength(2);
+      expect(viewRegistry.views.map((v) => v.label)).toContain(
+        'External Link 1',
+      );
+      expect(viewRegistry.views.map((v) => v.label)).toContain(
+        'External Link 2',
+      );
     });
-    addExternalLink(viewRegistry, {
-      label: 'External Link 2',
-      url: 'https://www.codecentric.de',
-    });
-
-    expect(viewRegistry.views).toHaveLength(2);
-    expect(viewRegistry.views.map((v) => v.label)).toContain('External Link 1');
-    expect(viewRegistry.views.map((v) => v.label)).toContain('External Link 2');
   });
 });

--- a/spring-boot-admin-server-ui/src/main/frontend/views/external/index.ts
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/external/index.ts
@@ -18,14 +18,14 @@ import { h } from 'vue';
 import sbaConfig from '@/sba-config';
 import ViewRegistry from '@/viewRegistry';
 
-const addIframeView = (
+export const addIframeView = (
   viewRegistry: ViewRegistry,
   { url, label, order }: Omit<ExternalView, 'children'>,
 ) => {
   const urlWithoutScheme = url.replace(/^https?:[/][/]/, '');
   viewRegistry.addView({
-    name: `external/${urlWithoutScheme}`,
-    path: `/external/${urlWithoutScheme.replace(/[^a-zA-Z]+/g, '-')}`,
+    name: `external/${label}`,
+    path: `/external/${encodeURIComponent(urlWithoutScheme)}`,
     label,
     order,
     component: {

--- a/spring-boot-admin-server-ui/src/main/frontend/views/external/index.ts
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/external/index.ts
@@ -15,12 +15,13 @@
  */
 import { h } from 'vue';
 
-import './style.css';
-
 import sbaConfig from '@/sba-config';
 import ViewRegistry from '@/viewRegistry';
 
-const addIframeView = (viewRegistry: ViewRegistry, { url, label, order }) => {
+const addIframeView = (
+  viewRegistry: ViewRegistry,
+  { url, label, order }: Omit<ExternalView, 'children'>,
+) => {
   const urlWithoutScheme = url.replace(/^https?:[/][/]/, '');
   viewRegistry.addView({
     name: `external/${urlWithoutScheme}`,
@@ -38,12 +39,12 @@ const addIframeView = (viewRegistry: ViewRegistry, { url, label, order }) => {
   } as ComponentView);
 };
 
-const addExternalLink = (
+export const addExternalLink = (
   viewRegistry: ViewRegistry,
-  { url, label, order, children },
+  { url, label, order, children }: Omit<ExternalView, 'iframe'>,
   parent?: string,
 ) => {
-  const name = `external/${label.toLowerCase().replace(/[^a-zA-Z]+/g, '-')}`;
+  const name = `external/${label}`;
 
   viewRegistry.addView({
     href: url,

--- a/spring-boot-admin-server-ui/src/main/java/de/codecentric/boot/admin/server/ui/web/UiController.java
+++ b/spring-boot-admin-server-ui/src/main/java/de/codecentric/boot/admin/server/ui/web/UiController.java
@@ -182,6 +182,7 @@ public class UiController {
 
 		public ExternalView(String label, String url, Integer order, boolean iframe, List<ExternalView> children) {
 			Assert.hasText(label, "'label' must not be empty");
+			Assert.hasText(url, "'url' must not be empty");
 			this.label = label;
 			this.url = url;
 			this.order = order;


### PR DESCRIPTION
closes #2849 