### PR TITLE
refactoring: useRouterState

### DIFF
--- a/spring-boot-admin-server-ui/.storybook/preview.js
+++ b/spring-boot-admin-server-ui/.storybook/preview.js
@@ -1,20 +1,28 @@
 import { setup } from '@storybook/vue3';
 import { initialize, mswDecorator } from 'msw-storybook-addon';
+import { createRouter, createWebHistory } from 'vue-router';
 
 import './storybook.css';
 import '@/index.css';
 
 import components from '@/components';
-
+import { createApplicationStore } from '@/composables/useApplicationStore';
 import i18n from '@/i18n';
 import applicationsEndpoint from '@/mocks/applications';
 import mappingsEndpoint from '@/mocks/instance/mappings';
 
 initialize();
+const router = createRouter({
+  history: createWebHistory(),
+  routes: [],
+});
 
+const applicationStore = createApplicationStore();
 setup((app) => {
   app.use(components);
   app.use(i18n);
+  app.use(router);
+  app.use(applicationStore);
 });
 
 export const parameters = {

--- a/spring-boot-admin-server-ui/src/main/frontend/components/sba-input.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/components/sba-input.vue
@@ -53,6 +53,7 @@
           :readonly="readonly"
           :type="type"
           :value="modelValue"
+          :aria-label="label || placeholder"
           class="focus:z-10 p-2 relative flex-1 block w-full rounded-none bg-opacity-40 backdrop-blur-sm"
           @input="handleInput"
         />

--- a/spring-boot-admin-server-ui/src/main/frontend/components/sba-panel.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/components/sba-panel.vue
@@ -15,7 +15,11 @@
   -->
 
 <template>
-  <div class="shadow-sm border rounded break-inside-avoid mb-6">
+  <div
+    class="shadow-sm border rounded break-inside-avoid mb-6"
+    v-bind:aria-expanded="$attrs.ariaExpanded"
+    v-bind:id="$attrs.id"
+  >
     <header
       v-if="hasTitle"
       ref="header"

--- a/spring-boot-admin-server-ui/src/main/frontend/components/sba-panel.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/components/sba-panel.vue
@@ -16,9 +16,9 @@
 
 <template>
   <div
+    :id="$attrs.id"
     class="shadow-sm border rounded break-inside-avoid mb-6"
-    v-bind:aria-expanded="$attrs.ariaExpanded"
-    v-bind:id="$attrs.id"
+    :aria-expanded="$attrs.ariaExpanded"
   >
     <header
       v-if="hasTitle"

--- a/spring-boot-admin-server-ui/src/main/frontend/composables/useApplicationStore.ts
+++ b/spring-boot-admin-server-ui/src/main/frontend/composables/useApplicationStore.ts
@@ -5,7 +5,7 @@ import ApplicationStore from '../store.js';
 import Application from '@/services/application';
 
 let applicationStore: ApplicationStore | null = null;
-let applications: Ref<Application[]> = ref([]);
+const applications: Ref<Application[]> = ref([]);
 const applicationsInitialized = ref(false);
 const error = ref(null);
 

--- a/spring-boot-admin-server-ui/src/main/frontend/composables/useApplicationStore.ts
+++ b/spring-boot-admin-server-ui/src/main/frontend/composables/useApplicationStore.ts
@@ -1,11 +1,11 @@
-import { Ref, UnwrapRef, ref } from 'vue';
+import { Ref, ref } from 'vue';
 
 import ApplicationStore from '../store.js';
 
 import Application from '@/services/application';
 
 let applicationStore: ApplicationStore | null = null;
-const applications = ref([] as Application[]);
+let applications: Ref<Application[]> = ref([]);
 const applicationsInitialized = ref(false);
 const error = ref(null);
 
@@ -17,7 +17,7 @@ export function createApplicationStore() {
 }
 
 type ApplicationStoreValue = {
-  applications: Ref<UnwrapRef<Application[]>>;
+  applications: Ref<Application[]>;
   applicationsInitialized: Ref<boolean>;
   error: Ref<any>;
   applicationStore: ApplicationStore;

--- a/spring-boot-admin-server-ui/src/main/frontend/notificationcenter.d.ts
+++ b/spring-boot-admin-server-ui/src/main/frontend/notificationcenter.d.ts
@@ -1,0 +1,1 @@
+declare module '@stekoe/vue-toast-notificationcenter';

--- a/spring-boot-admin-server-ui/src/main/frontend/services/instance.ts
+++ b/spring-boot-admin-server-ui/src/main/frontend/services/instance.ts
@@ -428,7 +428,7 @@ class Instance {
 
 export default Instance;
 
-type Registration = {
+export type Registration = {
   name: string;
   managementUrl?: string;
   healthUrl: string;

--- a/spring-boot-admin-server-ui/src/main/frontend/services/instance.ts
+++ b/spring-boot-admin-server-ui/src/main/frontend/services/instance.ts
@@ -37,7 +37,7 @@ const isInstanceActuatorRequest = (url: string) =>
 class Instance {
   public readonly id: string;
   public registration: Registration;
-  public endpoints: any[];
+  public endpoints: any[] = [];
   public tags: { [key: string]: string }[];
   public statusTimestamp: string;
   public buildVersion: string;

--- a/spring-boot-admin-server-ui/src/main/frontend/test-utils.ts
+++ b/spring-boot-admin-server-ui/src/main/frontend/test-utils.ts
@@ -1,5 +1,5 @@
 import NotificationcenterPlugin from '@stekoe/vue-toast-notificationcenter';
-import { render as tlRender } from '@testing-library/vue';
+import { RenderResult, render as tlRender } from '@testing-library/vue';
 import { RouterLinkStub } from '@vue/test-utils';
 import { merge } from 'lodash-es';
 import { createI18n } from 'vue-i18n';
@@ -21,7 +21,7 @@ for (const modulesKey in modules) {
 export let router;
 createViewRegistry();
 
-export const render = (testComponent, options?) => {
+export const render = (testComponent, options?): RenderResult => {
   const routes = [{ path: '/', component: testComponent }];
   if (testComponent.install) {
     const viewRegistry = new ViewRegistry();
@@ -62,6 +62,5 @@ export const render = (testComponent, options?) => {
     },
     options,
   );
-  const utils = tlRender(testComponent, renderOptions);
-  return { ...utils };
+  return tlRender(testComponent, renderOptions);
 };

--- a/spring-boot-admin-server-ui/src/main/frontend/utils/useRouterState.spec.ts
+++ b/spring-boot-admin-server-ui/src/main/frontend/utils/useRouterState.spec.ts
@@ -5,7 +5,7 @@ import { reactive } from 'vue';
 import { useRouterState } from '@/utils/useRouterState';
 
 const routerReplace = vi.fn();
-let mockedQuery = vi.fn().mockReturnValue({});
+const mockedQuery = vi.fn().mockReturnValue({});
 
 vi.mock('vue-router', () => {
   return {
@@ -65,7 +65,7 @@ describe('useRouterState', () => {
       foo: 'bar',
     });
 
-    let routerState = useRouterState({
+    const routerState = useRouterState({
       bar: 'baz',
     });
 
@@ -88,7 +88,7 @@ describe('useRouterState', () => {
       foo: 'bar',
     });
 
-    let routerState = useRouterState({
+    const routerState = useRouterState({
       foo: 'baz',
     });
 

--- a/spring-boot-admin-server-ui/src/main/frontend/utils/useRouterState.spec.ts
+++ b/spring-boot-admin-server-ui/src/main/frontend/utils/useRouterState.spec.ts
@@ -1,0 +1,106 @@
+import { waitFor } from '@testing-library/vue';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { reactive } from 'vue';
+
+import { useRouterState } from '@/utils/useRouterState';
+
+const routerReplace = vi.fn();
+let mockedQuery = vi.fn().mockReturnValue({});
+
+vi.mock('vue-router', () => {
+  return {
+    useRouter: () => ({
+      replace: routerReplace,
+    }),
+    useRoute: () =>
+      reactive({
+        get query() {
+          return mockedQuery();
+        },
+      }),
+  };
+});
+
+describe('useRouterState', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('should initialize routerState with the initial query parameters', async () => {
+    mockedQuery.mockReturnValue({
+      string: 'foo',
+      boolean: 'true',
+      number: '0',
+      float: '0.123',
+    });
+
+    const routerState = useRouterState();
+
+    await waitFor(() => {
+      expect(routerState).toEqual({
+        string: 'foo',
+        boolean: true,
+        number: 0,
+        float: 0.123,
+      });
+    });
+  });
+
+  it('should call router with initial state', () => {
+    useRouterState({
+      foo: 'bar',
+    });
+
+    waitFor(() => {
+      expect(routerReplace).toHaveBeenCalledWith({
+        query: {
+          foo: 'bar',
+        },
+      });
+    });
+  });
+
+  it('should extend existing query params', () => {
+    mockedQuery.mockReturnValue({
+      foo: 'bar',
+    });
+
+    let routerState = useRouterState({
+      bar: 'baz',
+    });
+
+    waitFor(() => {
+      expect(routerReplace).toHaveBeenCalledWith({
+        query: {
+          foo: 'bar',
+          bar: 'baz',
+        },
+      });
+      expect(routerState).toEqual({
+        foo: 'bar',
+        bar: 'baz',
+      });
+    });
+  });
+
+  it('should override existing query params', () => {
+    mockedQuery.mockReturnValue({
+      foo: 'bar',
+    });
+
+    let routerState = useRouterState({
+      foo: 'baz',
+    });
+
+    waitFor(() => {
+      expect(routerReplace).toHaveBeenCalledWith({
+        query: {
+          foo: 'baz',
+        },
+      });
+      expect(routerState).toEqual({
+        foo: 'baz',
+      });
+    });
+  });
+});

--- a/spring-boot-admin-server-ui/src/main/frontend/utils/useRouterState.ts
+++ b/spring-boot-admin-server-ui/src/main/frontend/utils/useRouterState.ts
@@ -1,0 +1,74 @@
+import { UnwrapNestedRefs } from '@vue/reactivity';
+import qs from 'qs';
+import { reactive, watch } from 'vue';
+import { LocationQuery, useRoute, useRouter } from 'vue-router';
+
+/**
+ * Hook to synchronize the query parameters of the current route with a reactive object.
+ *
+ * @param initialState The initial state of the reactive object.
+ * @returns The reactive object.
+ */
+export function useRouterState<T extends object>(
+  initialState: T = {} as T,
+): UnwrapNestedRefs<T> {
+  const route = useRoute();
+  const router = useRouter();
+
+  let routerState = reactive({
+    ...initialState,
+    ...correctTypesInRouterQuery(route.query),
+  });
+
+  watch(route, (_route) => {
+    const queryParams = JSON.stringify(_route.query);
+    routerState = parseQueryParams(queryParams);
+  });
+
+  watch(routerState, (newValue: any) => {
+    const to = {
+      name: route.name,
+      query: {
+        ...route.query,
+        ...newValue,
+      },
+    };
+    router.replace(to);
+  });
+
+  return routerState;
+}
+
+function parseQueryParams(queryParams: string) {
+  return qs.parse(queryParams, {
+    decoder: (str, defaultDecoder, charset, type) => {
+      let bools = {
+        true: true,
+        false: false,
+      };
+      if (type === 'value' && typeof bools[str] === 'boolean') {
+        return bools[str];
+      } else {
+        return defaultDecoder(str);
+      }
+    },
+  });
+}
+
+function correctTypesInRouterQuery(query: LocationQuery) {
+  return (
+    query !== undefined &&
+    JSON.parse(JSON.stringify(query), (_, value) => {
+      if (value === 'false') return false;
+      if (value === 'true') return true;
+
+      const float = Number.parseFloat(value);
+      if (!isNaN(float)) return float;
+
+      const number = Number.parseInt(value);
+      if (!isNaN(number)) return number;
+
+      return value;
+    })
+  );
+}

--- a/spring-boot-admin-server-ui/src/main/frontend/utils/useRouterState.ts
+++ b/spring-boot-admin-server-ui/src/main/frontend/utils/useRouterState.ts
@@ -1,5 +1,5 @@
-import { UnwrapNestedRefs } from '@vue/reactivity';
 import qs from 'qs';
+import { UnwrapNestedRefs } from 'vue';
 import { reactive, watch } from 'vue';
 import { LocationQuery, useRoute, useRouter } from 'vue-router';
 
@@ -42,7 +42,7 @@ export function useRouterState<T extends object>(
 function parseQueryParams(queryParams: string) {
   return qs.parse(queryParams, {
     decoder: (str, defaultDecoder, charset, type) => {
-      let bools = {
+      const bools = {
         true: true,
         false: false,
       };

--- a/spring-boot-admin-server-ui/src/main/frontend/utils/useSubscription.ts
+++ b/spring-boot-admin-server-ui/src/main/frontend/utils/useSubscription.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Subscription } from 'rxjs';
+import { onBeforeUnmount } from 'vue';
+
+/**
+ * When a subscription is passed, it will be unsubscribed on unmount.
+ *
+ * @param subscription Subscription
+ */
+export const useSubscription = (subscription: Subscription) => {
+  onBeforeUnmount(() => {
+    if (subscription) {
+      try {
+        !subscription.closed && subscription.unsubscribe();
+      } finally {
+        subscription = null;
+      }
+    }
+  });
+};

--- a/spring-boot-admin-server-ui/src/main/frontend/views/applications/applications.spec.ts
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/applications/applications.spec.ts
@@ -1,12 +1,12 @@
 import userEvent from '@testing-library/user-event';
-import { RenderResult, screen, waitFor } from '@testing-library/vue';
+import { screen, waitFor } from '@testing-library/vue';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Ref, ref } from 'vue';
 
 import { useApplicationStore } from '@/composables/useApplicationStore';
 import Application from '@/services/application';
 import Instance, { Registration } from '@/services/instance';
-import { render, router } from '@/test-utils';
+import { render } from '@/test-utils';
 import Applications from '@/views/applications/index.vue';
 
 vi.mock('@/composables/useApplicationStore', () => ({

--- a/spring-boot-admin-server-ui/src/main/frontend/views/applications/applications.spec.ts
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/applications/applications.spec.ts
@@ -1,0 +1,123 @@
+import userEvent from '@testing-library/user-event';
+import { RenderResult, screen, waitFor } from '@testing-library/vue';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Ref, ref } from 'vue';
+
+import { useApplicationStore } from '@/composables/useApplicationStore';
+import Application from '@/services/application';
+import Instance, { Registration } from '@/services/instance';
+import { render, router } from '@/test-utils';
+import Applications from '@/views/applications/index.vue';
+
+vi.mock('@/composables/useApplicationStore', () => ({
+  useApplicationStore: vi.fn(),
+}));
+
+describe('Applications', () => {
+  let applicationsInitialized: Ref<boolean>;
+  let applications: Ref<Application[]>;
+  let error: Ref<any>;
+
+  beforeEach(async () => {
+    applicationsInitialized = ref(false);
+    applications = ref([]);
+    error = ref(null);
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    useApplicationStore.mockReturnValue({
+      applicationStore: {
+        findApplicationByInstanceId: (id: string) => {
+          return applications.value.find((a) => {
+            return a.instances.some((i) => i.id === id);
+          });
+        },
+      },
+      applicationsInitialized,
+      applications,
+      error,
+    });
+
+    render(Applications);
+  });
+
+  it('when applications are loading, a hint should be shown', async () => {
+    expect(await screen.findByText('Loading applications...')).toBeVisible();
+  });
+
+  it('when there are no applications, a corresponding text is shown', async () => {
+    applicationsInitialized.value = true;
+
+    await waitFor(() => {
+      expect(screen.getByText('No applications registered.')).toBeVisible();
+    });
+  });
+
+  describe('when there are applications', () => {
+    beforeEach(async () => {
+      const instance = new Instance({
+        id: 'id',
+        statusInfo: {
+          status: 'UP',
+        },
+        registration: {
+          name: 'spring-boot-admin-sample-servlet',
+          serviceUrl: 'serviceUrl',
+          metadata: {},
+        } as Registration,
+      });
+
+      applicationsInitialized.value = true;
+      applications.value = [
+        new Application({
+          id: 'app-id',
+          name: 'spring-boot-admin-sample-servlet',
+          instances: [instance],
+          status: 'UP',
+        }),
+      ];
+    });
+
+    it('name of applications are shown', async () => {
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', {
+            name: /spring-boot-admin-sample-servlet/i,
+          }),
+        ).toBeVisible();
+      });
+    });
+
+    it('when the search does not match, a corresponding text is shown', async () => {
+      const filterInput = screen.getByLabelText('Filter');
+      await userEvent.type(filterInput, 'does-not-match');
+
+      expect(
+        await screen.findByText('No results matching your filter.'),
+      ).toBeVisible();
+    });
+
+    it('when the search matches, the application is shown', async () => {
+      const filterInput = screen.getByLabelText('Filter');
+      await userEvent.type(filterInput, 'sample');
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', {
+            name: /spring-boot-admin-sample-servlet/i,
+          }),
+        ).toBeVisible();
+      });
+    });
+
+    it('clicking on the name opens list of instances', async () => {
+      const applicationElement = await screen.findByRole('button', {
+        name: /spring-boot-admin-sample-servlet/i,
+      });
+
+      await userEvent.click(applicationElement);
+
+      expect(await screen.findByText('serviceUrl')).toBeVisible();
+    });
+  });
+});

--- a/spring-boot-admin-server-ui/src/main/frontend/views/applications/index.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/applications/index.vue
@@ -28,7 +28,7 @@
           />
           <div class="flex-1">
             <sba-input
-              v-model="filter"
+              v-model="routerState.q"
               :placeholder="t('term.filter')"
               name="filter"
               type="search"
@@ -80,6 +80,7 @@
 
             <sba-panel
               v-for="group in grouped"
+              :id="group.name"
               :key="group.name"
               :seamless="true"
               :title="t(group.name)"
@@ -87,7 +88,14 @@
                 t('term.instances_tc', { count: group.instances?.length ?? 0 })
               "
               class="application-group"
-              @title-click="() => toggleGroup(group.name)"
+              :aria-expanded="isExpanded(group.name)"
+              v-on-clickaway="(event: Event) => deselect(event, group.name)"
+              @title-click="
+                () => {
+                  select(group.name);
+                  toggleGroup(group.name);
+                }
+              "
             >
               <template #prefix>
                 <font-awesome-icon
@@ -101,7 +109,9 @@
                   v-if="isGroupedByApplication"
                   class="mr-2"
                   :status="
-                    findApplicationByInstanceId(group.instances[0].id)?.status
+                    applicationStore.findApplicationByInstanceId(
+                      group.instances[0].id,
+                    )?.status
                   "
                 />
               </template>
@@ -111,7 +121,11 @@
                   :has-notification-filters-support="
                     hasNotificationFiltersSupport
                   "
-                  :item="findApplicationByInstanceId(group.instances[0].id)"
+                  :item="
+                    applicationStore.findApplicationByInstanceId(
+                      group.instances[0].id,
+                    )
+                  "
                   @filter-settings="toggleNotificationFilterSettings"
                 />
               </template>
@@ -153,36 +167,47 @@
   </div>
 </template>
 
-<script lang="ts">
+<script lang="ts" setup>
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { useNotificationCenter } from '@stekoe/vue-toast-notificationcenter';
 import { groupBy, sortBy, transform } from 'lodash-es';
-import { computed, defineComponent, ref, watch } from 'vue';
-import { directive as onClickaway } from 'vue3-click-away';
+import { computed, nextTick, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { RouteLocationNamedRaw, useRoute, useRouter } from 'vue-router';
+import { useRouter } from 'vue-router';
 
 import SbaStickySubnav from '@/components/sba-sticky-subnav.vue';
 import SbaWave from '@/components/sba-wave.vue';
 
 import { useApplicationStore } from '@/composables/useApplicationStore';
-import Popper from '@/directives/popper';
-import subscribing from '@/mixins/subscribing';
 import Application from '@/services/application';
 import Instance from '@/services/instance';
 import NotificationFilter from '@/services/notification-filter';
 import { anyValueMatches } from '@/utils/collections';
-import { Subject, concatMap, mergeWith, timer } from '@/utils/rxjs';
+import { concatMap, mergeWith, Subject, timer } from '@/utils/rxjs';
+import { useRouterState } from '@/utils/useRouterState';
+import { useSubscription } from '@/utils/useSubscription';
 import ApplicationListItemAction from '@/views/applications/ApplicationListItemAction.vue';
 import ApplicationNotificationCenter from '@/views/applications/ApplicationNotificationCenter.vue';
 import ApplicationStats from '@/views/applications/ApplicationStats.vue';
 import ApplicationStatusHero from '@/views/applications/ApplicationStatusHero.vue';
 import InstancesList from '@/views/applications/InstancesList.vue';
 import NotificationFilterSettings from '@/views/applications/NotificationFilterSettings.vue';
-import handle from '@/views/applications/handle.vue';
 
-const instanceMatchesFilter = (term, instance) => {
-  const predicate = (value) => String(value).toLowerCase().includes(term);
+const props = defineProps({
+  error: {
+    type: Error,
+    default: null,
+  },
+  selected: {
+    type: String,
+    default: null,
+  },
+});
+
+const instanceMatchesFilter = (term: string, instance: Instance) => {
+  const predicate = (value: string | number) =>
+    String(value).toLowerCase().includes(term);
+
   return (
     anyValueMatches(instance.registration, predicate) ||
     anyValueMatches(instance.buildVersion, predicate) ||
@@ -207,252 +232,206 @@ const groupingFunctions = {
     instance.registration.metadata?.['group'] ?? 'term.no_group',
 };
 
-export default defineComponent({
-  directives: { Popper, onClickaway },
-  components: {
-    FontAwesomeIcon,
-    InstancesList,
-    ApplicationListItemAction,
-    ApplicationNotificationCenter,
-    SbaWave,
-    ApplicationStatusHero,
-    SbaStickySubnav,
-    ApplicationStats,
-    NotificationFilterSettings,
-  },
-  mixins: [subscribing],
-  props: {
-    error: {
-      type: Error,
-      default: null,
-    },
-    selected: {
-      type: String,
-      default: null,
-    },
-  },
-  setup: function (props) {
-    const { t } = useI18n();
-    const router = useRouter();
-    const route = useRoute();
-    const { applications, applicationsInitialized, applicationStore } =
-      useApplicationStore();
-    const notificationCenter = useNotificationCenter({});
-    const filter = ref(route.query.q?.toString());
-    const expandedGroups = ref([]);
-    const groupingFunction = ref(groupingFunctions.application);
+const { t } = useI18n();
+const router = useRouter();
+const { applications, applicationsInitialized, applicationStore } =
+  useApplicationStore();
+const notificationCenter = useNotificationCenter({});
+const expandedGroups = ref([props.selected]);
+const groupingFunction = ref(groupingFunctions.application);
 
-    watch(filter, (q) => {
-      let to = {
-        name: 'applications',
-        params: { selected: props.selected },
-      } as RouteLocationNamedRaw;
+const routerState = useRouterState({
+  q: '',
+});
+const hasActiveFilter = computed(() => {
+  return routerState.q?.length > 0;
+});
+const notificationFilterSubject = new Subject();
+const hasNotificationFiltersSupport = NotificationFilter.isSupported();
+const notificationFilters = ref([]);
 
-      if (q?.length > 0) {
-        to = {
-          ...to,
-          query: {
-            q,
-          },
-        } as RouteLocationNamedRaw;
-      }
-
-      router.replace(to);
-    });
-
-    const hasActiveFilter = computed(() => {
-      return filter.value?.length > 0;
-    });
-
-    return {
-      applications,
-      applicationsInitialized,
-      setGroupingFunction: (key: keyof typeof groupingFunctions) => {
-        groupingFunction.value = groupingFunctions[key];
-        expandedGroups.value = [];
+useSubscription(
+  timer(0, 60000)
+    .pipe(
+      mergeWith(notificationFilterSubject),
+      concatMap(fetchNotificationFilters),
+    )
+    .subscribe({
+      next: (data) => {
+        notificationFilters.value = data;
       },
-      findApplicationByInstanceId: applicationStore.findApplicationByInstanceId,
-      errors: ref([]),
-      filter,
-      hasActiveFilter,
-      hasNotificationFiltersSupport: ref(false),
-      notificationCenter,
-      notificationFilterSubject: new Subject(),
-      notificationFilters: ref([]),
-      palette: ref({}),
-      router,
-      expandedGroups,
-      isExpanded: (name: string) => expandedGroups.value.includes(name),
-      groupingFunction,
-      toggleGroup: (name: string) => {
-        if (expandedGroups.value.includes(name)) {
-          expandedGroups.value = expandedGroups.value.filter((n) => n !== name);
-        } else {
-          expandedGroups.value = [...expandedGroups.value, name];
-        }
+      error: (error) => {
+        console.warn('Fetching notification filters failed with error:', error);
+        notificationCenter.error(
+          t('applications.fetching_notification_filters_failed'),
+        );
       },
-      showNotificationFilterSettingsObject: ref(
-        null as unknown as NotificationFilterSettingsObject,
-      ),
-      t,
-    };
-  },
-  computed: {
-    groupNames() {
-      return [
-        ...new Set(
-          this.applications
-            .flatMap((application) => application.instances)
-            .map(
-              (instance) =>
-                instance.registration.metadata?.['group'] ?? 'Ungrouped',
-            ),
+    }),
+);
+
+async function fetchNotificationFilters() {
+  if (hasNotificationFiltersSupport) {
+    const response = await NotificationFilter.getFilters();
+    return response.data;
+  }
+  return [];
+}
+
+const groupNames = computed(() => {
+  return [
+    ...new Set(
+      applications.value
+        .flatMap((application: Application) => application.instances)
+        .map(
+          (instance: Instance) =>
+            instance.registration.metadata?.['group'] ?? 'Ungrouped',
         ),
-      ];
-    },
-    grouped() {
-      const filteredApplications = this.filterInstances(this.applications);
+    ),
+  ];
+});
 
-      const instances = filteredApplications.flatMap(
-        (application) => application.instances,
-      );
+const grouped = computed(() => {
+  const filteredApplications = filterInstances(applications.value);
 
-      const grouped = groupBy<Instance>(instances, this.groupingFunction);
+  const instances = filteredApplications.flatMap(
+    (application: Application) => application.instances,
+  );
 
-      const list = transform<Instance[], InstancesListType[]>(
-        grouped,
-        (result, instances, name) => {
-          result.push({
-            name,
-            instances: sortBy(instances, [
-              (instance) => instance.registration.name,
-            ]),
-          });
-        },
-        [],
-      );
+  const grouped = groupBy<Instance>(instances, groupingFunction.value);
 
-      return sortBy(list, [(item) => item.status]);
-    },
-    isGroupedByApplication() {
-      return this.groupingFunction === groupingFunctions.application;
-    },
-  },
-  watch: {
-    selected: {
-      immediate: true,
-      handler: 'scrollIntoView',
-    },
-  },
-  mounted() {
-    this.hasNotificationFiltersSupport = NotificationFilter.isSupported();
-  },
-  methods: {
-    select(name) {
-      this.router.replace({
-        name: 'applications',
-        params: { selected: name },
+  const list = transform<Instance[], InstancesListType[]>(
+    grouped,
+    (result, instances, name) => {
+      result.push({
+        name,
+        instances: sortBy(instances, [
+          (instance) => instance.registration.name,
+        ]),
       });
     },
-    deselect(event, expectedSelected) {
-      if (event && event.target instanceof HTMLAnchorElement) {
-        return;
-      }
-      this.toggleNotificationFilterSettings(null);
-      if (this.selected === expectedSelected || !expectedSelected) {
-        this.router.replace({ name: 'applications' });
-      }
-    },
-    async scrollIntoView(id, behavior) {
-      if (id) {
-        await this.$nextTick();
-        const el = document.getElementById(id);
-        if (el) {
-          const top = el.getBoundingClientRect().top + window.scrollY - 100;
-          window.scroll({
-            top,
-            left: window.scrollX,
-            behavior: behavior || 'smooth',
-          });
-        }
-      }
-    },
-    createSubscription() {
-      return timer(0, 60000)
-        .pipe(
-          mergeWith(this.notificationFilterSubject),
-          concatMap(this.fetchNotificationFilters),
-        )
-        .subscribe({
-          next: (data) => {
-            this.notificationFilters = data;
-          },
-          error: (error) => {
-            console.warn(
-              'Fetching notification filters failed with error:',
-              error,
-            );
-            this.notificationCenter.error(
-              this.t('applications.fetching_notification_filters_failed'),
-            );
-          },
-        });
-    },
-    async fetchNotificationFilters() {
-      if (this.hasNotificationFiltersSupport) {
-        const response = await NotificationFilter.getFilters();
-        return response.data;
-      }
-      return [];
-    },
-    async addFilter({ object, ttl }) {
-      try {
-        const response = await NotificationFilter.addFilter(object, ttl);
-        let notificationFilter = response.data;
-        this.notificationFilterSubject.next(notificationFilter);
-        this.notificationCenter.success(
-          `${this.t('applications.notifications_suppressed_for', {
-            name:
-              notificationFilter.applicationName ||
-              notificationFilter.instanceId,
-          })} <strong>${notificationFilter.expiry.fromNow(true)}</strong>.`,
-        );
-      } catch (error) {
-        console.warn('Adding notification filter failed:', error);
-      } finally {
-        this.toggleNotificationFilterSettings(null);
-      }
-    },
-    async removeFilter(activeFilter) {
-      try {
-        await activeFilter.delete();
-        this.notificationFilterSubject.next(activeFilter.id);
-        this.notificationCenter.success(
-          this.t('applications.notification_filter.removed'),
-        );
-      } catch (error) {
-        console.warn('Deleting notification filter failed:', error);
-      } finally {
-        this.toggleNotificationFilterSettings(null);
-      }
-    },
-    toggleNotificationFilterSettings(obj) {
-      this.showNotificationFilterSettingsObject = obj ? obj : null;
-    },
-    filterInstances(applications: Application[]) {
-      if (!this.filter) {
-        return applications;
-      }
+    [],
+  );
 
-      return applications
-        .map((application) =>
-          application.filterInstances((i) =>
-            instanceMatchesFilter(this.filter.toLowerCase(), i),
-          ),
-        )
-        .filter((application) => application.instances.length > 0);
-    },
-  },
+  return sortBy(list, [(item) => item.status]);
+});
+
+function filterInstances(applications: Application[]) {
+  if (!routerState.q) {
+    return applications;
+  }
+
+  return applications
+    .map((application) =>
+      application.filterInstances((i) =>
+        instanceMatchesFilter(routerState.q.toLowerCase(), i),
+      ),
+    )
+    .filter((application) => application.instances.length > 0);
+}
+
+const isGroupedByApplication = computed(() => {
+  return groupingFunction.value === groupingFunctions.application;
+});
+
+if (props.selected) {
+  scrollIntoView(props.selected);
+}
+
+async function scrollIntoView(id) {
+  if (id) {
+    await nextTick();
+    const el = document.getElementById(id);
+    if (el) {
+      el.scrollIntoView({
+        behavior: 'smooth',
+        block: 'end',
+        inline: 'nearest',
+      });
+    }
+  }
+}
+
+const showNotificationFilterSettingsObject = ref(
+  null as unknown as NotificationFilterSettingsObject,
+);
+const setGroupingFunction = (key: keyof typeof groupingFunctions) => {
+  groupingFunction.value = groupingFunctions[key];
+  expandedGroups.value = [];
+};
+
+function isExpanded(name: string) {
+  return expandedGroups.value.includes(name);
+}
+
+function toggleGroup(name: string) {
+  if (expandedGroups.value.includes(name)) {
+    expandedGroups.value = expandedGroups.value.filter((n) => n !== name);
+  } else {
+    expandedGroups.value = [...expandedGroups.value, name];
+  }
+}
+
+function select(name: string) {
+  router.replace({
+    name: 'applications',
+    params: { selected: name },
+  });
+}
+
+function deselect(event: Event, expectedSelected: string) {
+  if (event && event.target instanceof HTMLAnchorElement) {
+    return;
+  }
+  toggleNotificationFilterSettings(null);
+  if (!expectedSelected || props.selected === expectedSelected) {
+    router.replace({ name: 'applications' });
+  }
+}
+
+async function addFilter({ object, ttl }) {
+  try {
+    const response = await NotificationFilter.addFilter(object, ttl);
+    let notificationFilter = response.data;
+    notificationFilterSubject.next(notificationFilter);
+    notificationCenter.success(
+      `${t('applications.notifications_suppressed_for', {
+        name:
+          notificationFilter.applicationName || notificationFilter.instanceId,
+      })} <strong>${notificationFilter.expiry.fromNow(true)}</strong>.`,
+    );
+  } catch (error) {
+    console.warn('Adding notification filter failed:', error);
+  } finally {
+    toggleNotificationFilterSettings(null);
+  }
+}
+
+async function removeFilter(activeFilter) {
+  try {
+    await activeFilter.delete();
+    notificationFilterSubject.next(activeFilter.id);
+    notificationCenter.success(t('applications.notification_filter.removed'));
+  } catch (error) {
+    console.warn('Deleting notification filter failed:', error);
+  } finally {
+    toggleNotificationFilterSettings(null);
+  }
+}
+
+function toggleNotificationFilterSettings(obj) {
+  showNotificationFilterSettingsObject.value = obj ? obj : null;
+}
+</script>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { directive as onClickaway } from 'vue3-click-away';
+
+import Popper from '@/directives/popper';
+import handle from '@/views/applications/handle.vue';
+
+export default defineComponent({
+  directives: { Popper, onClickaway },
   install({ viewRegistry }) {
     viewRegistry.addView({
       path: '/applications/:selected?',

--- a/spring-boot-admin-server-ui/src/main/frontend/views/applications/index.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/applications/index.vue
@@ -82,6 +82,7 @@
               v-for="group in grouped"
               :id="group.name"
               :key="group.name"
+              v-on-clickaway="(event: Event) => deselect(event, group.name)"
               :seamless="true"
               :title="t(group.name)"
               :subtitle="
@@ -89,7 +90,6 @@
               "
               class="application-group"
               :aria-expanded="isExpanded(group.name)"
-              v-on-clickaway="(event: Event) => deselect(event, group.name)"
               @title-click="
                 () => {
                   select(group.name);

--- a/spring-boot-admin-server-ui/src/main/frontend/views/wallboard/index.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/wallboard/index.vue
@@ -20,7 +20,7 @@
       class="flex gap-2 justify-end absolute w-full md:w-[28rem] top-14 right-0 bg-black/20 py-3 px-4 rounded-bl"
     >
       <sba-input
-        v-model="termFilter"
+        v-model="routerState.termFilter"
         class="flex-1"
         :placeholder="$t('term.filter')"
         name="filter"
@@ -33,7 +33,7 @@
 
       <select
         v-if="healthStatus.size > 1"
-        v-model="statusFilter"
+        v-model="routerState.statusFilter"
         aria-label="status-filter"
         class="relative focus:z-10 focus:ring-indigo-500 focus:border-indigo-500 block sm:text-sm border-gray-300 rounded"
       >
@@ -61,11 +61,11 @@
 
     <template v-if="applicationsInitialized">
       <div
-        v-if="termFilter.length > 0 && applications.length === 0"
+        v-if="routerState.termFilter.length > 0 && applications.length === 0"
         class="flex w-full h-full items-center text-center text-white text-xl"
         v-text="
           t('term.no_results_for_term', {
-            term: termFilter,
+            term: routerState.termFilter,
           })
         "
       />
@@ -102,27 +102,34 @@
 </template>
 
 <script lang="ts">
+import classNames from 'classnames';
 import Fuse from 'fuse.js';
-import { computed, ref } from 'vue';
+import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 import { HealthStatus } from '@/HealthStatus';
 import { useApplicationStore } from '@/composables/useApplicationStore';
-import hexMesh from '@/views/wallboard/hex-mesh';
+import Application from '@/services/application';
+import { useRouterState } from '@/utils/useRouterState';
+import hexMesh from '@/views/wallboard/hex-mesh.vue';
 
 export default {
   components: { hexMesh },
   setup() {
     const { t } = useI18n();
-    const termFilter = ref('');
-    const statusFilter = ref('none');
+
+    const routerState = useRouterState({
+      termFilter: '',
+      wordWrap: true,
+      statusFilter: 'none',
+    });
 
     const { applications, applicationsInitialized, error } =
       useApplicationStore();
 
     const fuse = computed(
       () =>
-        new Fuse(applications.value, {
+        new Fuse<Application>(applications.value, {
           includeScore: true,
           useExtendedSearch: true,
           threshold: 0.25,
@@ -131,18 +138,19 @@ export default {
     );
 
     const filteredApplications = computed(() => {
-      function filterByTerm() {
-        if (termFilter.value.length > 0) {
-          return fuse.value.search(termFilter.value).map((sr) => sr.item);
+      function filterByTerm(): Application[] {
+        if (routerState.termFilter.length > 0) {
+          return fuse.value.search(routerState.termFilter).map((sr) => sr.item);
         } else {
           return applications.value;
         }
       }
 
-      function filterByStatus(result) {
-        if (statusFilter.value !== 'none') {
+      function filterByStatus(result: Application[]) {
+        if (routerState.statusFilter !== 'none') {
           return result.filter(
-            (application) => application.status === statusFilter.value,
+            (application: Application) =>
+              application.status === routerState.statusFilter,
           );
         }
 
@@ -166,13 +174,13 @@ export default {
       applicationsInitialized,
       error,
       t,
-      termFilter,
-      statusFilter,
       healthStatus,
+      routerState,
     };
   },
   methods: {
-    classForApplication(application) {
+    classNames,
+    classForApplication(application: Application) {
       if (!application) {
         return null;
       }
@@ -196,7 +204,7 @@ export default {
       }
       return '';
     },
-    select(application) {
+    select(application: Application) {
       if (application.instances.length === 1) {
         this.$router.push({
           name: 'instances/details',
@@ -244,7 +252,6 @@ export default {
   width: 100%;
   padding: 2.5%;
   color: #fff;
-  word-break: break-word;
   font-size: 2em;
   font-weight: 600;
   line-height: 1.125;

--- a/spring-boot-admin-server-ui/src/main/frontend/views/wallboard/wallboard.spec.ts
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/wallboard/wallboard.spec.ts
@@ -1,6 +1,6 @@
 import { screen, waitFor, within } from '@testing-library/vue';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { ref } from 'vue';
+import { Ref, ref } from 'vue';
 
 import { useApplicationStore } from '@/composables/useApplicationStore';
 import Application from '@/services/application';
@@ -13,9 +13,9 @@ vi.mock('@/composables/useApplicationStore', () => ({
 }));
 
 describe('Wallboard', () => {
-  let applicationsInitialized;
-  let applications;
-  let error;
+  let applicationsInitialized: Ref<boolean>;
+  let applications: Ref<Application[]>;
+  let error: Ref<any>;
 
   beforeEach(async () => {
     applicationsInitialized = ref(false);

--- a/spring-boot-admin-server-ui/src/main/frontend/views/wallboard/wallboard.stories.ts
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/wallboard/wallboard.stories.ts
@@ -1,9 +1,11 @@
+import { vueRouter } from 'storybook-vue3-router';
+
 import Application from '../../services/application.js';
 import Wallboard from './index.vue';
 
 import { HealthStatus } from '@/HealthStatus';
 import { useApplicationStore } from '@/composables/useApplicationStore';
-import { applications } from '@/mocks/applications/data';
+import Instance from '@/services/instance';
 
 export default {
   component: Wallboard,
@@ -16,42 +18,34 @@ const Template = (args) => ({
     const { applicationStore } = useApplicationStore();
     applicationStore._dispatchEvent(
       'changed',
-      shuffle([...healthStatus, ...healthStatus]).map((healthStatus) => {
-        const application = new Application(applications[0]);
-        application.statusTimestamp = Date.now();
-        application.name = healthStatus;
-        application.status = healthStatus;
-        return application;
+      Object.keys(HealthStatus).map((status) => {
+        return new Application({
+          status: status,
+          statusTimestamp: '2023-05-02',
+          name: `controller${status}`,
+          group: 'group-' + Math.floor(Math.random() * 10),
+          buildVersion: '1.2.3',
+          instances: [new Instance({ id: '123' })],
+        });
       }),
     );
     return { args };
   },
-  template: '<Wallboard v-bind="args" />',
+  template: '<Wallboard />',
 });
 
 export const Default = {
   render: Template,
-
-  args: {
-    applications: shuffle([...healthStatus, ...healthStatus]).map(
-      (healthStatus) => {
-        const application = new Application(applications[0]);
-        application.statusTimestamp = Date.now();
-        application.name = healthStatus;
-        application.status = healthStatus;
-        return application;
-      },
+  decorators: [
+    vueRouter(
+      [
+        {
+          name: 'wallboard',
+          path: '/',
+          component: Template,
+        },
+      ],
+      { initialRoute: '/' },
     ),
-    applicationsInitialized: true,
-  },
+  ],
 };
-
-const healthStatus = Object.keys(HealthStatus);
-
-function shuffle(a) {
-  for (let i = a.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [a[i], a[j]] = [a[j], a[i]];
-  }
-  return a;
-}


### PR DESCRIPTION
Well, there is a lot going on in this PR. Main goal was to "just" simplify the common behavior of Wallboard and Applications view where both are using the URL as state management: Whenever a search term is typed into the search box, the URL query params update accordingly in order to have shareable URLs like `/applications?q=spring-boot`. As both views implemented this behavior but differently, I decided to extract this and write tests.

Since Vue 3 common behavior can be extracted using "[composables](https://vuejs.org/guide/reusability/composables.html)". For our case there is a new (and now tested!) composable (i.e. behavior) called `useRouterState` that takes care of syncing an internal state with the state of the URL.

Implementing this for the Wallboard was pretty easy, but Applications view uses mixins which are not compatible to Vue 3’s composition API that is required when one wants to use composables. Hence, I was forced to restructure the Applications view and decided to add tests here, too.

So please, don’t kill me for restructuring a lot of code (again). I strive to make the frontend better testable and easier to maintain.