### PR TITLE
Add runtime hints for @EventListener methods

### DIFF
--- a/spring-boot-admin-client/src/main/java/de/codecentric/boot/admin/client/config/ClientRuntimeHints.java
+++ b/spring-boot-admin-client/src/main/java/de/codecentric/boot/admin/client/config/ClientRuntimeHints.java
@@ -21,9 +21,11 @@ import org.springframework.aot.hint.ExecutableMode;
 import org.springframework.aot.hint.MemberCategory;
 import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.RuntimeHintsRegistrar;
+import org.springframework.boot.web.context.WebServerInitializedEvent;
 import org.springframework.context.annotation.Configuration;
 
 import de.codecentric.boot.admin.client.registration.Application;
+import de.codecentric.boot.admin.client.registration.DefaultApplicationFactory;
 
 @Configuration
 public class ClientRuntimeHints implements RuntimeHintsRegistrar {
@@ -42,7 +44,9 @@ public class ClientRuntimeHints implements RuntimeHintsRegistrar {
 					MemberCategory.INVOKE_PUBLIC_CONSTRUCTORS)
 			.registerConstructor(Application.Builder.class.getDeclaredConstructor(), ExecutableMode.INVOKE)
 			.registerMethod(Application.Builder.class.getMethod("build"), ExecutableMode.INVOKE)
-			.registerMethod(Application.class.getMethod("builder"), ExecutableMode.INVOKE);
+			.registerMethod(Application.class.getMethod("builder"), ExecutableMode.INVOKE)
+			.registerMethod(DefaultApplicationFactory.class.getMethod("onWebServerInitialized",
+					WebServerInitializedEvent.class), ExecutableMode.INVOKE);
 	}
 
 }

--- a/spring-boot-admin-samples/spring-boot-admin-sample-servlet-graalvm/src/main/resources/application.yml
+++ b/spring-boot-admin-samples/spring-boot-admin-sample-servlet-graalvm/src/main/resources/application.yml
@@ -33,10 +33,7 @@ spring:
     admin:
       client:
         url: http://localhost:8080
-        instance:
-          service-base-url: http://localhost:8080
       ui:
         external-views:
           - label: 'Is it Christmas yet?'
             url: https://isitchristmas.com/
-


### PR DESCRIPTION
I worked on support of native image compilation for my applications and found this error:
```
2023-11-16T11:23:42.765+01:00 ERROR 99225 --- [gistrationTask1] o.s.s.s.TaskUtils$LoggingErrorHandler    : Unexpected error occurred in scheduled task

java.lang.IllegalStateException: couldn't determine local port. Please set spring.boot.admin.client.instance.service-base-url.
	at de.codecentric.boot.admin.client.registration.DefaultApplicationFactory.getLocalServerPort(DefaultApplicationFactory.java:205)
	at de.codecentric.boot.admin.client.registration.DefaultApplicationFactory.getServiceBaseUrl(DefaultApplicationFactory.java:109)
	at de.codecentric.boot.admin.client.registration.ServletApplicationFactory.getServiceUrl(ServletApplicationFactory.java:62)
	at de.codecentric.boot.admin.client.registration.ServletApplicationFactory.getManagementBaseUrl(ServletApplicationFactory.java:77)
	at de.codecentric.boot.admin.client.registration.DefaultApplicationFactory.getHealthUrl(DefaultApplicationFactory.java:165)
	at de.codecentric.boot.admin.client.registration.DefaultApplicationFactory.createApplication(DefaultApplicationFactory.java:80)
	at de.codecentric.boot.admin.client.registration.DefaultApplicationRegistrator.register(DefaultApplicationRegistrator.java:56)
	at org.springframework.scheduling.support.DelegatingErrorHandlingRunnable.run(DelegatingErrorHandlingRunnable.java:54)
	at java.base@21.0.1/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at java.base@21.0.1/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:358)
	at java.base@21.0.1/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
	at java.base@21.0.1/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base@21.0.1/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base@21.0.1/java.lang.Thread.runWith(Thread.java:1596)
	at java.base@21.0.1/java.lang.Thread.run(Thread.java:1583)
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:832)
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.posix.thread.PosixPlatformThreads.pthreadStartRoutine(PosixPlatformThreads.java:211)
```
The workaround is setting `spring.boot.admin.client.instance.service-base-url` property, but it's actually not required. Setting `spring.boot.admin.client.url` is sufficient in JVM setup

After some debugging I found that `DefaultApplicationFactory#onWebServerInitialized` is not invoked when running as native image. To illustrate it compare logs from native image and JVM.
On JVM it's invoked:
```
2023-11-16T11:22:59.859+01:00 DEBUG 99159 --- [           main] o.s.c.e.EventListenerMethodProcessor     : 1 @EventListener methods processed on bean 'applicationFactory': {public void de.codecentric.boot.admin.client.registration.DefaultApplicationFactory.onWebServerInitialized(org.springframework.boot.web.context.WebServerInitializedEvent)=@org.springframework.context.event.EventListener(classes={}, condition="", id="", value={})}
2023-11-16T11:22:59.860+01:00 DEBUG 99159 --- [           main] o.s.c.e.EventListenerMethodProcessor     : 2 @EventListener methods processed on bean 'registrationListener': {public void de.codecentric.boot.admin.client.registration.RegistrationApplicationListener.onApplicationReady(org.springframework.boot.context.event.ApplicationReadyEvent)=@org.springframework.context.event.EventListener(classes={}, condition="", id="", value={}), public void de.codecentric.boot.admin.client.registration.RegistrationApplicationListener.onClosedContext(org.springframework.context.event.ContextClosedEvent)=@org.springframework.context.event.EventListener(classes={}, condition="", id="", value={})}
```
And on native image it's not:
```
2023-11-16T11:23:32.752+01:00 DEBUG 99225 --- [           main] o.s.c.e.EventListenerMethodProcessor     : 2 @EventListener methods processed on bean 'registrationListener': {public void de.codecentric.boot.admin.client.registration.RegistrationApplicationListener.onApplicationReady(org.springframework.boot.context.event.ApplicationReadyEvent)=@org.springframework.context.event.EventListener(classes={}, condition="", id="", value={}), public void de.codecentric.boot.admin.client.registration.RegistrationApplicationListener.onClosedContext(org.springframework.context.event.ContextClosedEvent)=@org.springframework.context.event.EventListener(classes={}, condition="", id="", value={})}
```

I'm not a big expert in graalvm and don't quite undestand why `onWebServerInitialized` isn't getting registered for invocation, but adding a runtime hint does the trick.
I suppose it may be due to the fact that this method is in parent class of actual bean class created and that's why not found by spring boot, so I might file an issue there. In the meantime please check out my PR if you're interested