### PR TITLE
add pattern for management port that is used by spring-cloud-kubernetes-discoveryserver

### DIFF
--- a/spring-boot-admin-server-cloud/src/main/java/de/codecentric/boot/admin/server/cloud/discovery/DefaultServiceInstanceConverter.java
+++ b/spring-boot-admin-server-cloud/src/main/java/de/codecentric/boot/admin/server/cloud/discovery/DefaultServiceInstanceConverter.java
@@ -50,7 +50,7 @@ public class DefaultServiceInstanceConverter implements ServiceInstanceConverter
 
 	private static final String[] KEYS_MANAGEMENT_ADDRESS = { "management.address", "management-address" };
 
-	private static final String[] KEYS_MANAGEMENT_PORT = { "management.port", "management-port" };
+	private static final String[] KEYS_MANAGEMENT_PORT = { "management.port", "management-port", "port.management" };
 
 	private static final String[] KEYS_MANAGEMENT_PATH = { "management.context-path", "management-context-path" };
 


### PR DESCRIPTION
Response of discoveryserver looks like this:
<img width="569" alt="grafik" src="https://github.com/codecentric/spring-boot-admin/assets/16555444/35ae4ef6-fbda-4bb9-a300-c56b475f2512">
