### PR TITLE
fix(#3059): scrollbar for tags in InstanceList is shown, even when there are none

### DIFF
--- a/spring-boot-admin-server-ui/src/main/frontend/views/applications/InstancesList.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/applications/InstancesList.vue
@@ -48,7 +48,12 @@
         <br />
         <span class="text-sm italic" v-text="instance.id" />
       </div>
-      <div class="hidden xl:block w-1/4 overflow-x-scroll">
+      <div
+        class="hidden xl:block w-1/4"
+        :class="{
+          'overflow-x-scroll': Object.keys(instance.tags ?? {}).length > 0,
+        }"
+      >
         <sba-tags :small="true" :tags="instance.tags" :wrap="false" />
       </div>
       <div


### PR DESCRIPTION
closes #3059