### PR TITLE
chore: use Temurin jdk

### DIFF
--- a/.github/workflows/build-feature.yml
+++ b/.github/workflows/build-feature.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '17'
           cache: 'maven'
 

--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '17'
           cache: 'maven'
 
@@ -55,7 +55,7 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '17'
           cache: 'maven'
 

--- a/.github/workflows/build-pullrequest.yml
+++ b/.github/workflows/build-pullrequest.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '17'
           cache: 'maven'
 

--- a/.github/workflows/release-to-maven-central.yml
+++ b/.github/workflows/release-to-maven-central.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up settings.xml for Maven Central Repository
         uses: actions/setup-java@v4
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '17'
           server-id: oss.sonatype.org
           server-username: MAVEN_USERNAME


### PR DESCRIPTION
replace 'adopt' with 'temurin'

Note: AdoptOpenJdk is obsolete