### PR TITLE
Samples use @SpringBootApplication

### DIFF
--- a/spring-boot-admin-docs/src/site/asciidoc/_server-clustering.adoc
+++ b/spring-boot-admin-docs/src/site/asciidoc/_server-clustering.adoc
@@ -16,7 +16,7 @@ include::{samples-dir}/spring-boot-admin-sample-hazelcast/pom.xml[tags=dependenc
 +
 [source,java,indent=0]
 ----
-include::{samples-dir}/spring-boot-admin-sample-hazelcast/src/main/java/de/codecentric/boot/admin/SpringBootAdminHazelcastApplication.java[tags=application-hazelcast]
+include::{samples-dir}/spring-boot-admin-sample-hazelcast/src/main/java/de/codecentric/boot/admin/sample/SpringBootAdminHazelcastApplication.java[tags=application-hazelcast]
 ----
 
 .Hazelcast configuration options

--- a/spring-boot-admin-docs/src/site/asciidoc/customize_http-headers.adoc
+++ b/spring-boot-admin-docs/src/site/asciidoc/customize_http-headers.adoc
@@ -5,5 +5,5 @@ In case you need to inject custom HTTP headers into the requests made to the mon
 
 [source,java,indent=0]
 ----
-include::{samples-dir}/spring-boot-admin-sample-servlet/src/main/java/de/codecentric/boot/admin/SpringBootAdminServletApplication.java[tags=customization-http-headers-providers]
+include::{samples-dir}/spring-boot-admin-sample-servlet/src/main/java/de/codecentric/boot/admin/sample/SpringBootAdminServletApplication.java[tags=customization-http-headers-providers]
 ----

--- a/spring-boot-admin-docs/src/site/asciidoc/customize_interceptors.adoc
+++ b/spring-boot-admin-docs/src/site/asciidoc/customize_interceptors.adoc
@@ -6,5 +6,5 @@ This can be useful for auditing or adding some extra security checks.
 
 [source,java,indent=0]
 ----
-include::{samples-dir}/spring-boot-admin-sample-servlet/src/main/java/de/codecentric/boot/admin/SpringBootAdminServletApplication.java[tags=customization-instance-exchange-filter-function]
+include::{samples-dir}/spring-boot-admin-sample-servlet/src/main/java/de/codecentric/boot/admin/sample/SpringBootAdminServletApplication.java[tags=customization-instance-exchange-filter-function]
 ----

--- a/spring-boot-admin-docs/src/site/asciidoc/customize_notifiers.adoc
+++ b/spring-boot-admin-docs/src/site/asciidoc/customize_notifiers.adoc
@@ -6,5 +6,5 @@ You can add your own Notifiers by adding Spring Beans which implement the `Notif
 
 [source,java,indent=0]
 ----
-include::{samples-dir}/spring-boot-admin-sample-servlet/src/main/java/de/codecentric/boot/admin/CustomNotifier.java[tags=customization-notifiers]
+include::{samples-dir}/spring-boot-admin-sample-servlet/src/main/java/de/codecentric/boot/admin/sample/CustomNotifier.java[tags=customization-notifiers]
 ----

--- a/spring-boot-admin-docs/src/site/asciidoc/getting-started.adoc
+++ b/spring-boot-admin-docs/src/site/asciidoc/getting-started.adoc
@@ -32,8 +32,7 @@ Since Spring Boot Admin relies on Spring Boot, you have to set up a Spring Boot 
 +
 [source,java]
 ----
-@Configuration
-@EnableAutoConfiguration
+@SpringBootApplication
 @EnableAdminServer
 public class SpringBootAdminApplication {
     public static void main(String[] args) {

--- a/spring-boot-admin-docs/src/site/asciidoc/security.adoc
+++ b/spring-boot-admin-docs/src/site/asciidoc/security.adoc
@@ -9,7 +9,7 @@ By default `spring-boot-admin-server-ui` provides a login page and a logout butt
 A Spring Security configuration for your server could look like this:
 [source,java,indent=0]
 ----
-include::{samples-dir}/spring-boot-admin-sample-servlet/src/main/java/de/codecentric/boot/admin/SecuritySecureConfig.java[tags=configuration-spring-security]
+include::{samples-dir}/spring-boot-admin-sample-servlet/src/main/java/de/codecentric/boot/admin/sample/SecuritySecureConfig.java[tags=configuration-spring-security]
 ----
 <1> Grants public access to all static assets and the login page.
 <2> Every other request must be authenticated.

--- a/spring-boot-admin-docs/src/site/asciidoc/server-notifications.adoc
+++ b/spring-boot-admin-docs/src/site/asciidoc/server-notifications.adoc
@@ -500,7 +500,7 @@ A `FilteringNotifier` might be useful, for instance, if you don't want to receiv
 .How to configure filtering
 [source,java,indent=0]
 ----
-include::{samples-dir}/spring-boot-admin-sample-servlet/src/main/java/de/codecentric/boot/admin/NotifierConfig.java[tags=configuration-filtering-notifier]
+include::{samples-dir}/spring-boot-admin-sample-servlet/src/main/java/de/codecentric/boot/admin/sample/NotifierConfig.java[tags=configuration-filtering-notifier]
 ----
 <1> Add the `FilteringNotifier` bean using a delegate (e.g. `MailNotifier` when configured)
 <2> Add the `RemindingNotifier` as primary bean using the `FilteringNotifier` as delegate.

--- a/spring-boot-admin-samples/spring-boot-admin-sample-consul/docker-compose.yml
+++ b/spring-boot-admin-samples/spring-boot-admin-sample-consul/docker-compose.yml
@@ -1,5 +1,5 @@
 services:
   consul:
-    image: library/consul
+    image: hashicorp/consul
     ports:
       - "8500:8500"

--- a/spring-boot-admin-samples/spring-boot-admin-sample-consul/pom.xml
+++ b/spring-boot-admin-samples/spring-boot-admin-sample-consul/pom.xml
@@ -65,7 +65,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <mainClass>de.codecentric.boot.admin.SpringBootAdminConsulApplication</mainClass>
+                    <mainClass>de.codecentric.boot.admin.sample.SpringBootAdminConsulApplication</mainClass>
                     <addResources>false</addResources>
                 </configuration>
             </plugin>

--- a/spring-boot-admin-samples/spring-boot-admin-sample-consul/src/test/java/de/codecentric/boot/admin/sample/SpringBootAdminConsulApplicationTest.java
+++ b/spring-boot-admin-samples/spring-boot-admin-sample-consul/src/test/java/de/codecentric/boot/admin/sample/SpringBootAdminConsulApplicationTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package de.codecentric.boot.admin;
+package de.codecentric.boot.admin.sample;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/spring-boot-admin-samples/spring-boot-admin-sample-hazelcast/pom.xml
+++ b/spring-boot-admin-samples/spring-boot-admin-sample-hazelcast/pom.xml
@@ -72,7 +72,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <mainClass>de.codecentric.boot.admin.SpringBootAdminHazelcastApplication</mainClass>
+                    <mainClass>de.codecentric.boot.admin.sample.SpringBootAdminHazelcastApplication</mainClass>
                     <addResources>false</addResources>
                 </configuration>
             </plugin>

--- a/spring-boot-admin-samples/spring-boot-admin-sample-hazelcast/src/main/java/de/codecentric/boot/admin/sample/SpringBootAdminHazelcastApplication.java
+++ b/spring-boot-admin-samples/spring-boot-admin-sample-hazelcast/src/main/java/de/codecentric/boot/admin/sample/SpringBootAdminHazelcastApplication.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package de.codecentric.boot.admin;
+package de.codecentric.boot.admin.sample;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.config.EvictionConfig;
@@ -28,7 +28,7 @@ import com.hazelcast.spi.merge.PutIfAbsentMergePolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -49,8 +49,7 @@ import static de.codecentric.boot.admin.server.config.AdminServerHazelcastAutoCo
 import static de.codecentric.boot.admin.server.config.AdminServerHazelcastAutoConfiguration.DEFAULT_NAME_SENT_NOTIFICATIONS_MAP;
 import static java.util.Collections.singletonList;
 
-@Configuration(proxyBeanMethods = false)
-@EnableAutoConfiguration
+@SpringBootApplication
 @EnableAdminServer
 public class SpringBootAdminHazelcastApplication {
 

--- a/spring-boot-admin-samples/spring-boot-admin-sample-hazelcast/src/test/java/de/codecentric/boot/admin/sample/SpringBootAdminHazelcastApplicationTest.java
+++ b/spring-boot-admin-samples/spring-boot-admin-sample-hazelcast/src/test/java/de/codecentric/boot/admin/sample/SpringBootAdminHazelcastApplicationTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package de.codecentric.boot.admin;
+package de.codecentric.boot.admin.sample;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -22,8 +22,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)
-@SpringBootTest(classes = { SpringBootAdminReactiveApplication.class })
-public class SpringBootAdminReactiveApplicationTest {
+@SpringBootTest(classes = { SpringBootAdminHazelcastApplication.class })
+public class SpringBootAdminHazelcastApplicationTest {
 
 	@Test
 	public void contextLoads() {

--- a/spring-boot-admin-samples/spring-boot-admin-sample-reactive/pom.xml
+++ b/spring-boot-admin-samples/spring-boot-admin-sample-reactive/pom.xml
@@ -67,7 +67,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <mainClass>de.codecentric.boot.admin.SpringBootAdminReactiveApplication</mainClass>
+                    <mainClass>de.codecentric.boot.admin.sample.SpringBootAdminReactiveApplication</mainClass>
                     <addResources>false</addResources>
                 </configuration>
             </plugin>

--- a/spring-boot-admin-samples/spring-boot-admin-sample-reactive/src/main/java/de/codecentric/boot/admin/sample/SpringBootAdminReactiveApplication.java
+++ b/spring-boot-admin-samples/spring-boot-admin-sample-reactive/src/main/java/de/codecentric/boot/admin/sample/SpringBootAdminReactiveApplication.java
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
-package de.codecentric.boot.admin;
+package de.codecentric.boot.admin.sample;
 
 import java.net.URI;
 
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
@@ -36,8 +35,7 @@ import de.codecentric.boot.admin.server.config.AdminServerProperties;
 import de.codecentric.boot.admin.server.config.EnableAdminServer;
 import de.codecentric.boot.admin.server.notify.Notifier;
 
-@Configuration(proxyBeanMethods = false)
-@EnableAutoConfiguration
+@SpringBootApplication
 @EnableAdminServer
 public class SpringBootAdminReactiveApplication {
 

--- a/spring-boot-admin-samples/spring-boot-admin-sample-reactive/src/test/java/de/codecentric/boot/admin/sample/SpringBootAdminReactiveApplicationTest.java
+++ b/spring-boot-admin-samples/spring-boot-admin-sample-reactive/src/test/java/de/codecentric/boot/admin/sample/SpringBootAdminReactiveApplicationTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package de.codecentric.boot.admin;
+package de.codecentric.boot.admin.sample;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -22,8 +22,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)
-@SpringBootTest(classes = { SpringBootAdminHazelcastApplication.class })
-public class SpringBootAdminHazelcastApplicationTest {
+@SpringBootTest(classes = { SpringBootAdminReactiveApplication.class })
+public class SpringBootAdminReactiveApplicationTest {
 
 	@Test
 	public void contextLoads() {

--- a/spring-boot-admin-samples/spring-boot-admin-sample-servlet-graalvm/src/main/java/de/codecentric/boot/admin/sample/SpringBootAdminServletApplication.java
+++ b/spring-boot-admin-samples/spring-boot-admin-sample-servlet-graalvm/src/main/java/de/codecentric/boot/admin/sample/SpringBootAdminServletApplication.java
@@ -14,16 +14,14 @@
  * limitations under the License.
  */
 
-package de.codecentric.boot.admin;
+package de.codecentric.boot.admin.sample;
 
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 import de.codecentric.boot.admin.server.config.EnableAdminServer;
 
-@Configuration(proxyBeanMethods = false)
-@EnableAutoConfiguration
+@SpringBootApplication
 @EnableAdminServer
 public class SpringBootAdminServletApplication {
 

--- a/spring-boot-admin-samples/spring-boot-admin-sample-servlet/pom.xml
+++ b/spring-boot-admin-samples/spring-boot-admin-sample-servlet/pom.xml
@@ -101,7 +101,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <mainClass>de.codecentric.boot.admin.SpringBootAdminServletApplication</mainClass>
+                    <mainClass>de.codecentric.boot.admin.sample.SpringBootAdminServletApplication</mainClass>
                     <addResources>false</addResources>
                     <executable>true</executable>
                 </configuration>

--- a/spring-boot-admin-samples/spring-boot-admin-sample-servlet/src/main/java/de/codecentric/boot/admin/sample/CustomCsrfFilter.java
+++ b/spring-boot-admin-samples/spring-boot-admin-sample-servlet/src/main/java/de/codecentric/boot/admin/sample/CustomCsrfFilter.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package de.codecentric.boot.admin;
+package de.codecentric.boot.admin.sample;
 
 import java.io.IOException;
 

--- a/spring-boot-admin-samples/spring-boot-admin-sample-servlet/src/main/java/de/codecentric/boot/admin/sample/CustomEndpoint.java
+++ b/spring-boot-admin-samples/spring-boot-admin-sample-servlet/src/main/java/de/codecentric/boot/admin/sample/CustomEndpoint.java
@@ -14,19 +14,17 @@
  * limitations under the License.
  */
 
-package de.codecentric.boot.admin;
+package de.codecentric.boot.admin.sample;
 
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
 
-@ExtendWith(SpringExtension.class)
-@SpringBootTest(classes = { SpringBootAdminServletApplication.class })
-public class SpringBootAdminServletApplicationTest {
+@Endpoint(id = "custom")
+public class CustomEndpoint {
 
-	@Test
-	public void contextLoads() {
+	@ReadOperation
+	public String invoke() {
+		return "Hello World!";
 	}
 
 }

--- a/spring-boot-admin-samples/spring-boot-admin-sample-servlet/src/main/java/de/codecentric/boot/admin/sample/CustomNotifier.java
+++ b/spring-boot-admin-samples/spring-boot-admin-sample-servlet/src/main/java/de/codecentric/boot/admin/sample/CustomNotifier.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package de.codecentric.boot.admin;
+package de.codecentric.boot.admin.sample;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/spring-boot-admin-samples/spring-boot-admin-sample-servlet/src/main/java/de/codecentric/boot/admin/sample/NotifierConfig.java
+++ b/spring-boot-admin-samples/spring-boot-admin-sample-servlet/src/main/java/de/codecentric/boot/admin/sample/NotifierConfig.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package de.codecentric.boot.admin;
+package de.codecentric.boot.admin.sample;
 
 import java.time.Duration;
 import java.util.Collections;

--- a/spring-boot-admin-samples/spring-boot-admin-sample-servlet/src/main/java/de/codecentric/boot/admin/sample/SecurityPermitAllConfig.java
+++ b/spring-boot-admin-samples/spring-boot-admin-sample-servlet/src/main/java/de/codecentric/boot/admin/sample/SecurityPermitAllConfig.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package de.codecentric.boot.admin;
+package de.codecentric.boot.admin.sample;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/spring-boot-admin-samples/spring-boot-admin-sample-servlet/src/main/java/de/codecentric/boot/admin/sample/SecuritySecureConfig.java
+++ b/spring-boot-admin-samples/spring-boot-admin-sample-servlet/src/main/java/de/codecentric/boot/admin/sample/SecuritySecureConfig.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package de.codecentric.boot.admin;
+package de.codecentric.boot.admin.sample;
 
 import java.util.UUID;
 

--- a/spring-boot-admin-samples/spring-boot-admin-sample-servlet/src/main/java/de/codecentric/boot/admin/sample/SpringBootAdminServletApplication.java
+++ b/spring-boot-admin-samples/spring-boot-admin-sample-servlet/src/main/java/de/codecentric/boot/admin/sample/SpringBootAdminServletApplication.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package de.codecentric.boot.admin;
+package de.codecentric.boot.admin.sample;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,14 +23,12 @@ import org.springframework.boot.actuate.audit.AuditEventRepository;
 import org.springframework.boot.actuate.audit.InMemoryAuditEventRepository;
 import org.springframework.boot.actuate.web.exchanges.HttpExchangeRepository;
 import org.springframework.boot.actuate.web.exchanges.InMemoryHttpExchangeRepository;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.metrics.buffering.BufferingApplicationStartup;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -43,10 +41,8 @@ import de.codecentric.boot.admin.server.domain.entities.InstanceRepository;
 import de.codecentric.boot.admin.server.web.client.HttpHeadersProvider;
 import de.codecentric.boot.admin.server.web.client.InstanceExchangeFilterFunction;
 
-@Configuration(proxyBeanMethods = false)
-@EnableAutoConfiguration
+@SpringBootApplication
 @EnableAdminServer
-@Import({ SecurityPermitAllConfig.class, SecuritySecureConfig.class, NotifierConfig.class })
 @Lazy(false)
 @EnableCaching
 public class SpringBootAdminServletApplication {

--- a/spring-boot-admin-samples/spring-boot-admin-sample-servlet/src/test/java/de/codecentric/boot/admin/sample/SpringBootAdminServletApplicationTest.java
+++ b/spring-boot-admin-samples/spring-boot-admin-sample-servlet/src/test/java/de/codecentric/boot/admin/sample/SpringBootAdminServletApplicationTest.java
@@ -14,17 +14,19 @@
  * limitations under the License.
  */
 
-package de.codecentric.boot.admin;
+package de.codecentric.boot.admin.sample;
 
-import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
-import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@Endpoint(id = "custom")
-public class CustomEndpoint {
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = { SpringBootAdminServletApplication.class })
+public class SpringBootAdminServletApplicationTest {
 
-	@ReadOperation
-	public String invoke() {
-		return "Hello World!";
+	@Test
+	public void contextLoads() {
 	}
 
 }

--- a/spring-boot-admin-samples/spring-boot-admin-sample-war/src/main/java/de/codecentric/boot/admin/sample/SpringBootAdminWarApplication.java
+++ b/spring-boot-admin-samples/spring-boot-admin-sample-war/src/main/java/de/codecentric/boot/admin/sample/SpringBootAdminWarApplication.java
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package de.codecentric.boot.admin;
+package de.codecentric.boot.admin.sample;
 
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
 import org.springframework.context.annotation.Bean;
@@ -34,8 +34,7 @@ import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import de.codecentric.boot.admin.server.config.AdminServerProperties;
 import de.codecentric.boot.admin.server.config.EnableAdminServer;
 
-@Configuration(proxyBeanMethods = false)
-@EnableAutoConfiguration
+@SpringBootApplication
 @EnableAdminServer
 public class SpringBootAdminWarApplication extends SpringBootServletInitializer {
 

--- a/spring-boot-admin-samples/spring-boot-admin-sample-zookeeper/docker-compose.yml
+++ b/spring-boot-admin-samples/spring-boot-admin-sample-zookeeper/docker-compose.yml
@@ -1,0 +1,5 @@
+services:
+  zookeeper:
+    image: zookeeper
+    ports:
+      - 2181:2181

--- a/spring-boot-admin-samples/spring-boot-admin-sample-zookeeper/pom.xml
+++ b/spring-boot-admin-samples/spring-boot-admin-sample-zookeeper/pom.xml
@@ -68,7 +68,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <mainClass>de.codecentric.boot.admin.SpringBootAdminZookeeperApplication</mainClass>
+                    <mainClass>de.codecentric.boot.admin.sample.SpringBootAdminZookeeperApplication</mainClass>
                     <addResources>false</addResources>
                 </configuration>
             </plugin>

--- a/spring-boot-admin-samples/spring-boot-admin-sample-zookeeper/src/test/java/de/codecentric/boot/admin/sample/SpringBootAdminZookeeperApplicationTest.java
+++ b/spring-boot-admin-samples/spring-boot-admin-sample-zookeeper/src/test/java/de/codecentric/boot/admin/sample/SpringBootAdminZookeeperApplicationTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package de.codecentric.boot.admin;
+package de.codecentric.boot.admin.sample;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;


### PR DESCRIPTION
@SpringBootApplication enables component scanning (which was not enabled before). To prevent component scanning from picking up Spring Boot Admin's auto-configuration classes, the package of the samples had to be changed.