### PR TITLE
#3865: restore previous behaviour, tags is object, not array

### DIFF
--- a/spring-boot-admin-server-ui/src/main/frontend/views/applications/InstancesList.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/applications/InstancesList.vue
@@ -62,7 +62,6 @@
         </template>
       </div>
       <div
-        v-if="Array.isArray(instance.tags)"
         class="hidden xl:block w-1/4"
         :class="{
           'overflow-x-scroll': Object.keys(instance.tags ?? {}).length > 0,


### PR DESCRIPTION
was changed recently here: https://github.com/codecentric/spring-boot-admin/commit/eff73bb621144d1bb5b93fa765f2a189a38df0fc#diff-c57e24625bd2e812f7fa841a2a7e14463b831582fb2a88a9dc038380147b3520R65 but I don't know why. @SteKoe can you please have a look?