### PR TITLE
fix(#4030): health information show up properly, when actuator header is v3

### DIFF
--- a/spring-boot-admin-server-ui/src/main/frontend/components/sba-status-badge.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/components/sba-status-badge.vue
@@ -1,5 +1,9 @@
 <template>
-  <span :class="classNames('status-badge', healthStatus)" v-text="status" />
+  <span
+    role="status"
+    :class="classNames('status-badge', healthStatus)"
+    v-text="status"
+  />
 </template>
 
 <script>

--- a/spring-boot-admin-server-ui/src/main/frontend/views/instances/details/health-details.spec.ts
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/instances/details/health-details.spec.ts
@@ -1,0 +1,134 @@
+import { screen, within } from '@testing-library/vue';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { render } from '@/test-utils';
+import HealthDetails from '@/views/instances/details/health-details.vue';
+
+describe('HealthDetails', () => {
+  describe('Health .details', () => {
+    beforeEach(() => {
+      const healthMock = {
+        status: 'UP',
+        details: {
+          clientConfigServer: {
+            status: 'UNKNOWN',
+            details: { error: 'no property sources located' },
+          },
+          db: {
+            status: 'UP',
+            details: {
+              database: 'HSQL Database Engine',
+              validationQuery: 'isValid()',
+            },
+          },
+          discoveryComposite: {
+            description: 'Discovery Client not initialized',
+            status: 'UNKNOWN',
+            details: {
+              discoveryClient: {
+                description: 'Discovery Client not initialized',
+                status: 'DOWN',
+              },
+            },
+          },
+          diskSpace: {
+            status: 'UP',
+            details: {
+              total: 994662584320,
+              free: 300063879168,
+              threshold: 10485760,
+              exists: true,
+            },
+          },
+        },
+      };
+
+      render(HealthDetails, {
+        props: {
+          health: healthMock,
+        },
+      });
+    });
+
+    it.each`
+      componentId             | status
+      ${'clientConfigServer'} | ${'UNKNOWN'}
+      ${'discoveryComposite'} | ${'UNKNOWN'}
+      ${'discoveryClient'}    | ${'DOWN'}
+      ${'diskSpace'}          | ${'UP'}
+    `(
+      'should display health components status',
+      async ({ componentId, status }) => {
+        const clientConfigServer = await screen.findByRole('definition', {
+          name: componentId,
+        });
+        expect(
+          await within(clientConfigServer).findByRole('status'),
+        ).toHaveTextContent(status);
+      },
+    );
+  });
+
+  describe('Health .components', () => {
+    beforeEach(() => {
+      const healthMock = {
+        status: 'UP',
+        components: {
+          clientConfigServer: {
+            status: 'UNKNOWN',
+            details: { error: 'no property sources located' },
+          },
+          discoveryComposite: {
+            description: 'Discovery Client not initialized',
+            status: 'UNKNOWN',
+            components: {
+              discoveryClient: {
+                description: 'Discovery Client not initialized',
+                status: 'DOWN',
+              },
+            },
+          },
+          diskSpace: {
+            status: 'UP',
+            details: {
+              total: 994662584320,
+              free: 116363821056,
+              threshold: 10485760,
+              exists: true,
+            },
+          },
+        },
+      };
+
+      render(HealthDetails, {
+        props: {
+          health: healthMock,
+        },
+      });
+    });
+
+    it('should display health status', async () => {
+      expect(
+        screen.getByRole('definition', { name: 'clientConfigServer' }),
+      ).toBeInTheDocument();
+    });
+
+    it.each`
+      componentId             | status
+      ${'clientConfigServer'} | ${'UNKNOWN'}
+      ${'discoveryComposite'} | ${'UNKNOWN'}
+      ${'discoveryClient'}    | ${'DOWN'}
+      ${'diskSpace'}          | ${'UP'}
+    `(
+      'should display health components status',
+      async ({ componentId, status }) => {
+        const clientConfigServer = await screen.findByRole('definition', {
+          name: componentId,
+        });
+        expect(
+          await within(clientConfigServer).findByRole('status'),
+        ).toHaveTextContent(status);
+      },
+    );
+  });
+});

--- a/spring-boot-admin-server-ui/src/main/frontend/views/instances/details/health-details.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/instances/details/health-details.vue
@@ -29,7 +29,7 @@
       class="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2"
       :aria-labelledby="'health-detail__' + name"
     >
-      <sba-status-badge :status="health.status" />
+      <sba-status-badge v-if="health.status" :status="health.status" />
 
       <dl v-if="details && details.length > 0" class="grid grid-cols-2 mt-2">
         <template v-for="detail in details" :key="detail.name">
@@ -92,16 +92,16 @@ export default {
   },
   computed: {
     details() {
-      if (this.health.details) {
-        return Object.entries(this.health.details)
+      if (this.health.details || this.health.components) {
+        return Object.entries(this.health.details || this.health.components)
           .filter(([, value]) => !isChildHealth(value))
           .map(([name, value]) => ({ name, value }));
       }
       return [];
     },
     childHealth() {
-      if (this.health.details) {
-        return Object.entries(this.health.details)
+      if (this.health.details || this.health.components) {
+        return Object.entries(this.health.details || this.health.components)
           .filter(([, value]) => isChildHealth(value))
           .map(([name, value]) => ({ name, value }));
       }


### PR DESCRIPTION
closes #4030 

This PR fixes an issue, when health information are not shown entirely in UI because caused as side effect of fix for bug #3999.
