### PR TITLE
Wrap long thread names

### DIFF
--- a/spring-boot-admin-server-ui/src/main/frontend/views/instances/threaddump/threads-list.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/instances/threaddump/threads-list.vue
@@ -205,9 +205,16 @@ export default {
 }
 .threads__thread-name {
   width: 250px;
+  max-width: 750px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.threads__thread-name:hover {
+  height: auto;
+  overflow: visible;
+  white-space: normal;
 }
 
 .threads__timeline {


### PR DESCRIPTION
Set a maximum width for thread names. Show The full name on hover. Fixes #4154.