### PR TITLE
docs(#2189): update JMX-bean management instructions for Spring Boot 2 and 3

### DIFF
--- a/spring-boot-admin-docs/src/site/docs/client/client-features.md
+++ b/spring-boot-admin-docs/src/site/docs/client/client-features.md
@@ -39,9 +39,28 @@ springBoot {
 
 ## JMX-Bean Management
 
-ATTENTION: Spring Boot 3 does currently not support Jolokia, so this will not work with Spring Boot 3 based applications. You can still monitor Spring Boot 2 applications with Jolokia endpoint using a Spring Boot Admin 3 server.
+To interact with JMX-beans in the admin UI you have to include [Jolokia](https://jolokia.org/) in your application and
+expose it via the actuator endpoint. As Jolokia is servlet based there is no support for reactive applications.
 
-To interact with JMX-beans in the admin UI you have to include [Jolokia](https://jolokia.org/) in your application. As Jolokia is servlet based there is no support for reactive applications. In case you are using the `spring-boot-admin-starter-client` it will be pulled in for you, if not add Jolokia to your dependencies. With Spring Boot 2.2.0 you might want to set `spring.jmx.enabled=true` if you want to expose Spring beans via JMX.
+You might want to set spring.jmx.enabled=true if you want to expose Spring beans via JMX.
+
+### Spring Boot 3 App
+
+Spring Boot 3 does not support Jolokia directly, you need a separate dependency for Spring Boot 3-based applications.
+See https://jolokia.org/reference/html/manual/spring.html for more details.
+
+```xml title="pom.xml"
+<dependency>
+    <groupId>org.jolokia</groupId>
+    <artifactId>jolokia-support-spring</artifactId>
+    <version>2.1.0</version>
+</dependency>
+```
+
+### Spring Boot 2 App
+
+You can still monitor Spring Boot 2 applications with Jolokia endpoint using a Spring Boot Admin 3 server. Spring Boot 2
+provided the actuator itself, so you only need the plain jolokia dependency.
 
 ```xml title="pom.xml"
 <dependency>


### PR DESCRIPTION
closes #2189 