### PR TITLE
Added identifierType=alias to the OpsGenie close URL

### DIFF
--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/notify/OpsGenieNotifier.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/notify/OpsGenieNotifier.java
@@ -118,7 +118,7 @@ public class OpsGenieNotifier extends AbstractStatusChangeNotifier {
 	protected String buildUrl(InstanceEvent event, Instance instance) {
 		if ((event instanceof InstanceStatusChangedEvent statusChangedEvent)
 				&& (StatusInfo.STATUS_UP.equals(statusChangedEvent.getStatusInfo().getStatus()))) {
-			return String.format("%s/%s/close", url, generateAlias(instance));
+			return String.format("%s/%s/close?identifierType=alias", url, generateAlias(instance));
 		}
 		return url.toString();
 	}


### PR DESCRIPTION
… OpsGenieNotifier.buildUrl.  This identifierType is required to successfully close an open alert when using an alias as the identifier.