### PR TITLE
Bugfix/add identifiertype to opsGenienotifier buildurl

### DIFF
--- a/.github/workflows/build-feature.yml
+++ b/.github/workflows/build-feature.yml
@@ -6,6 +6,7 @@ on:
       - master
       - 1.*
       - 2.*
+  pull_request:
 
 jobs:
   build:

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/notify/OpsGenieNotifier.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/notify/OpsGenieNotifier.java
@@ -118,7 +118,7 @@ public class OpsGenieNotifier extends AbstractStatusChangeNotifier {
 	protected String buildUrl(InstanceEvent event, Instance instance) {
 		if ((event instanceof InstanceStatusChangedEvent statusChangedEvent)
 				&& (StatusInfo.STATUS_UP.equals(statusChangedEvent.getStatusInfo().getStatus()))) {
-			return String.format("%s/%s/close", url, generateAlias(instance));
+			return String.format("%s/%s/close?identifierType=alias", url, generateAlias(instance));
 		}
 		return url.toString();
 	}

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/notify/OpsGenieNotifierTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/notify/OpsGenieNotifierTest.java
@@ -81,7 +81,7 @@ class OpsGenieNotifierTest {
 				.notify(new InstanceStatusChangedEvent(INSTANCE.getId(), INSTANCE.getVersion() + 2, StatusInfo.ofUp())))
 			.verifyComplete();
 
-		verify(restTemplate).exchange("https://api.opsgenie.com/v2/alerts/App_-id-/close", HttpMethod.POST,
+		verify(restTemplate).exchange("https://api.opsgenie.com/v2/alerts/App_-id-/close?identifierType=alias", HttpMethod.POST,
 				expectedRequest("DOWN", "UP"), Void.class);
 	}
 


### PR DESCRIPTION
This is a second try at adding the "identifierType=alias" to the OpsGenieNotifier.buildUrl() method.  This time with passing unit tests. 