### PR TITLE
Feature/issue 1323 inetutils support

### DIFF
--- a/spring-boot-admin-client/src/main/java/de/codecentric/boot/admin/client/config/SpringBootAdminClientAutoConfiguration.java
+++ b/spring-boot-admin-client/src/main/java/de/codecentric/boot/admin/client/config/SpringBootAdminClientAutoConfiguration.java
@@ -18,6 +18,7 @@ package de.codecentric.boot.admin.client.config;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import jakarta.servlet.ServletContext;
 import org.springframework.beans.factory.ObjectProvider;
@@ -112,11 +113,11 @@ public class SpringBootAdminClientAutoConfiguration {
 		public ApplicationFactory applicationFactory(InstanceProperties instance, ManagementServerProperties management,
 				ServerProperties server, ServletContext servletContext, PathMappedEndpoints pathMappedEndpoints,
 				WebEndpointProperties webEndpoint, ObjectProvider<List<MetadataContributor>> metadataContributors,
-				DispatcherServletPath dispatcherServletPath) {
+				DispatcherServletPath dispatcherServletPath, ObjectProvider<?> inetUtilsProvider) {
 			return new ServletApplicationFactory(instance, management, server, servletContext, pathMappedEndpoints,
 					webEndpoint,
 					new CompositeMetadataContributor(metadataContributors.getIfAvailable(Collections::emptyList)),
-					dispatcherServletPath);
+					dispatcherServletPath, Optional.ofNullable(inetUtilsProvider.getIfAvailable()));
 		}
 
 	}
@@ -130,10 +131,11 @@ public class SpringBootAdminClientAutoConfiguration {
 		@ConditionalOnMissingBean
 		public ApplicationFactory applicationFactory(InstanceProperties instance, ManagementServerProperties management,
 				ServerProperties server, PathMappedEndpoints pathMappedEndpoints, WebEndpointProperties webEndpoint,
-				ObjectProvider<List<MetadataContributor>> metadataContributors, WebFluxProperties webFluxProperties) {
+				ObjectProvider<List<MetadataContributor>> metadataContributors, WebFluxProperties webFluxProperties,
+				ObjectProvider<?> inetUtilsProvider) {
 			return new ReactiveApplicationFactory(instance, management, server, pathMappedEndpoints, webEndpoint,
 					new CompositeMetadataContributor(metadataContributors.getIfAvailable(Collections::emptyList)),
-					webFluxProperties);
+					webFluxProperties, Optional.ofNullable(inetUtilsProvider.getIfAvailable()));
 		}
 
 	}

--- a/spring-boot-admin-client/src/main/java/de/codecentric/boot/admin/client/registration/ReactiveApplicationFactory.java
+++ b/spring-boot-admin-client/src/main/java/de/codecentric/boot/admin/client/registration/ReactiveApplicationFactory.java
@@ -16,6 +16,8 @@
 
 package de.codecentric.boot.admin.client.registration;
 
+import java.util.Optional;
+
 import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
 import org.springframework.boot.actuate.autoconfigure.web.server.ManagementServerProperties;
 import org.springframework.boot.actuate.endpoint.web.PathMappedEndpoints;
@@ -40,12 +42,20 @@ public class ReactiveApplicationFactory extends DefaultApplicationFactory {
 
 	public ReactiveApplicationFactory(InstanceProperties instance, ManagementServerProperties management,
 			ServerProperties server, PathMappedEndpoints pathMappedEndpoints, WebEndpointProperties webEndpoint,
-			MetadataContributor metadataContributor, WebFluxProperties webFluxProperties) {
-		super(instance, management, server, pathMappedEndpoints, webEndpoint, metadataContributor);
+			MetadataContributor metadataContributor, WebFluxProperties webFluxProperties, Optional<?> inetUtils) {
+		super(instance, management, server, pathMappedEndpoints, webEndpoint, metadataContributor, inetUtils);
 		this.management = management;
 		this.server = server;
 		this.webflux = webFluxProperties;
 		this.instance = instance;
+	}
+
+	// Backward-compatible constructor for tests and callers that don't provide InetUtils
+	public ReactiveApplicationFactory(InstanceProperties instance, ManagementServerProperties management,
+			ServerProperties server, PathMappedEndpoints pathMappedEndpoints, WebEndpointProperties webEndpoint,
+			MetadataContributor metadataContributor, WebFluxProperties webFluxProperties) {
+		this(instance, management, server, pathMappedEndpoints, webEndpoint, metadataContributor, webFluxProperties,
+				Optional.empty());
 	}
 
 	@Override

--- a/spring-boot-admin-client/src/main/java/de/codecentric/boot/admin/client/registration/ServletApplicationFactory.java
+++ b/spring-boot-admin-client/src/main/java/de/codecentric/boot/admin/client/registration/ServletApplicationFactory.java
@@ -16,6 +16,8 @@
 
 package de.codecentric.boot.admin.client.registration;
 
+import java.util.Optional;
+
 import jakarta.servlet.ServletContext;
 import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
 import org.springframework.boot.actuate.autoconfigure.web.server.ManagementServerProperties;
@@ -44,13 +46,22 @@ public class ServletApplicationFactory extends DefaultApplicationFactory {
 	public ServletApplicationFactory(InstanceProperties instance, ManagementServerProperties management,
 			ServerProperties server, ServletContext servletContext, PathMappedEndpoints pathMappedEndpoints,
 			WebEndpointProperties webEndpoint, MetadataContributor metadataContributor,
-			DispatcherServletPath dispatcherServletPath) {
-		super(instance, management, server, pathMappedEndpoints, webEndpoint, metadataContributor);
+			DispatcherServletPath dispatcherServletPath, Optional<?> inetUtils) {
+		super(instance, management, server, pathMappedEndpoints, webEndpoint, metadataContributor, inetUtils);
 		this.servletContext = servletContext;
 		this.server = server;
 		this.management = management;
 		this.instance = instance;
 		this.dispatcherServletPath = dispatcherServletPath;
+	}
+
+	// Backward-compatible constructor for callers that don't provide InetUtils
+	public ServletApplicationFactory(InstanceProperties instance, ManagementServerProperties management,
+			ServerProperties server, ServletContext servletContext, PathMappedEndpoints pathMappedEndpoints,
+			WebEndpointProperties webEndpoint, MetadataContributor metadataContributor,
+			DispatcherServletPath dispatcherServletPath) {
+		this(instance, management, server, servletContext, pathMappedEndpoints, webEndpoint, metadataContributor,
+				dispatcherServletPath, Optional.empty());
 	}
 
 	@Override

--- a/spring-boot-admin-samples/pom.xml
+++ b/spring-boot-admin-samples/pom.xml
@@ -35,10 +35,11 @@
 
     <modules>
         <module>spring-boot-admin-sample-custom-ui</module>
-        <module>spring-boot-admin-sample-servlet</module>
         <module>spring-boot-admin-sample-reactive</module>
         <module>spring-boot-admin-sample-war</module>
         <module>spring-boot-admin-sample-hazelcast</module>
+        <module>spring-boot-admin-sample-oauth2</module>
+        <module>spring-boot-admin-sample-oauth2-client</module>
     </modules>
 
     <dependencyManagement>

--- a/spring-boot-admin-samples/spring-boot-admin-sample-oauth2-client/pom.xml
+++ b/spring-boot-admin-samples/spring-boot-admin-sample-oauth2-client/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" 
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 
+                             http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>de.codecentric</groupId>
+    <artifactId>spring-boot-admin-samples</artifactId>
+    <version>${revision}</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>spring-boot-admin-sample-oauth2-client</artifactId>
+  <name>Spring Boot Admin OAuth2 Client Sample</name>
+  <description>Sample monitored app configured as OAuth2 Resource Server</description>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>de.codecentric</groupId>
+      <artifactId>spring-boot-admin-starter-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <configuration>
+          <mainClass>de.codecentric.boot.admin.sample.client.OAuth2ClientApplication</mainClass>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/spring-boot-admin-samples/spring-boot-admin-sample-oauth2-client/src/main/java/de/codecentric/boot/admin/sample/client/OAuth2ClientApplication.java
+++ b/spring-boot-admin-samples/spring-boot-admin-sample-oauth2-client/src/main/java/de/codecentric/boot/admin/sample/client/OAuth2ClientApplication.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2014-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.codecentric.boot.admin.sample.client;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.metrics.buffering.BufferingApplicationStartup;
+
+@SpringBootApplication
+public class OAuth2ClientApplication {
+
+	public static void main(String[] args) {
+		SpringApplication app = new SpringApplication(OAuth2ClientApplication.class);
+		app.setApplicationStartup(new BufferingApplicationStartup(1500));
+		app.run(args);
+	}
+
+}

--- a/spring-boot-admin-samples/spring-boot-admin-sample-oauth2-client/src/main/java/de/codecentric/boot/admin/sample/client/OAuth2ResourceServerConfig.java
+++ b/spring-boot-admin-samples/spring-boot-admin-sample-oauth2-client/src/main/java/de/codecentric/boot/admin/sample/client/OAuth2ResourceServerConfig.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2014-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.codecentric.boot.admin.sample.client;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class OAuth2ResourceServerConfig {
+
+	@Bean
+	SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+		http.authorizeHttpRequests(
+				(auth) -> auth.requestMatchers("/actuator/**").authenticated().anyRequest().permitAll())
+			.oauth2ResourceServer((oauth2) -> oauth2.jwt((jwt) -> {
+			}));
+		return http.build();
+	}
+
+}

--- a/spring-boot-admin-samples/spring-boot-admin-sample-oauth2-client/src/main/resources/application.yml
+++ b/spring-boot-admin-samples/spring-boot-admin-sample-oauth2-client/src/main/resources/application.yml
@@ -1,0 +1,21 @@
+spring:
+  application:
+    name: spring-boot-admin-sample-oauth2-client
+
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: https://YOUR_ISSUER_URL
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+
+spring:
+  boot:
+    admin:
+      client:
+        url: http://localhost:8080

--- a/spring-boot-admin-samples/spring-boot-admin-sample-oauth2/pom.xml
+++ b/spring-boot-admin-samples/spring-boot-admin-sample-oauth2/pom.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2014-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>spring-boot-admin-sample-servlet</artifactId>
+
+    <name>Spring Boot Admin Sample Servlet</name>
+    <description>Spring Boot Admin Sample Servlet</description>
+
+    <parent>
+        <groupId>de.codecentric</groupId>
+        <artifactId>spring-boot-admin-samples</artifactId>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <dependencies>
+        <dependency>
+            <groupId>de.codecentric</groupId>
+            <artifactId>spring-boot-admin-sample-custom-ui</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>de.codecentric</groupId>
+            <artifactId>spring-boot-admin-starter-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>de.codecentric</groupId>
+            <artifactId>spring-boot-admin-starter-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.session</groupId>
+            <artifactId>spring-session-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.session</groupId>
+            <artifactId>spring-session-jdbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hsqldb</groupId>
+            <artifactId>hsqldb</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jolokia</groupId>
+            <artifactId>jolokia-support-spring</artifactId>
+        </dependency>
+        <!-- Test -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.cyclonedx</groupId>
+                <artifactId>cyclonedx-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>makeAggregateBom</goal>
+                        </goals>
+                        <configuration>
+                            <projectType>application</projectType>
+                            <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+                            <outputName>bom</outputName>
+                            <outputFormat>json</outputFormat>
+                            <skipAttach>true</skipAttach>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                            <goal>build-info</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <mainClass>de.codecentric.boot.admin.sample.SpringBootAdminServletApplication</mainClass>
+                    <addResources>false</addResources>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/spring-boot-admin-samples/spring-boot-admin-sample-oauth2/src/main/java/de/codecentric/boot/admin/sample/OAuth2RestTemplateConfig.java
+++ b/spring-boot-admin-samples/spring-boot-admin-sample-oauth2/src/main/java/de/codecentric/boot/admin/sample/OAuth2RestTemplateConfig.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2014-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.codecentric.boot.admin.sample;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration(proxyBeanMethods = false)
+public class OAuth2RestTemplateConfig {
+
+	@Bean
+	public RestTemplate restTemplate(ClientHttpRequestFactory factory) {
+		return new RestTemplate(factory);
+	}
+
+}

--- a/spring-boot-admin-samples/spring-boot-admin-sample-oauth2/src/main/java/de/codecentric/boot/admin/sample/OAuth2SecurityConfig.java
+++ b/spring-boot-admin-samples/spring-boot-admin-sample-oauth2/src/main/java/de/codecentric/boot/admin/sample/OAuth2SecurityConfig.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2014-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.codecentric.boot.admin.sample;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+import static org.springframework.security.config.Customizer.withDefaults;
+
+@Configuration(proxyBeanMethods = false)
+public class OAuth2SecurityConfig {
+
+	@Bean
+	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+		http.authorizeHttpRequests((authorizeRequests) -> authorizeRequests.anyRequest().authenticated())
+			.oauth2Login(withDefaults());
+		return http.build();
+	}
+
+}

--- a/spring-boot-admin-samples/spring-boot-admin-sample-oauth2/src/main/java/de/codecentric/boot/admin/sample/SpringBootAdminOAuth2Application.java
+++ b/spring-boot-admin-samples/spring-boot-admin-sample-oauth2/src/main/java/de/codecentric/boot/admin/sample/SpringBootAdminOAuth2Application.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2014-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.codecentric.boot.admin.sample;
+
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+
+@SpringBootApplication
+public class SpringBootAdminOAuth2Application {
+
+	public static void main(String[] args) {
+		SpringApplication.run(SpringBootAdminOAuth2Application.class, args);
+	}
+
+	@Bean
+	public ApplicationRunner runner() {
+		return (args) -> System.out.println("Spring Boot Admin OAuth2 Sample started.");
+	}
+
+}

--- a/spring-boot-admin-samples/spring-boot-admin-sample-oauth2/src/main/resources/application-oauth2.yml
+++ b/spring-boot-admin-samples/spring-boot-admin-sample-oauth2/src/main/resources/application-oauth2.yml
@@ -1,0 +1,15 @@
+spring:
+  profiles: oauth2
+
+  security:
+    oauth2:
+      client:
+        registration:
+          admin:
+            client-id: ${OAUTH_CLIENT_ID}
+            client-secret: ${OAUTH_CLIENT_SECRET}
+            authorization-grant-type: client_credentials
+            scope: openid
+        provider:
+          auth0:
+            token-uri: ${OAUTH_TOKEN_URI}

--- a/spring-boot-admin-samples/spring-boot-admin-sample-oauth2/src/main/resources/application.yml
+++ b/spring-boot-admin-samples/spring-boot-admin-sample-oauth2/src/main/resources/application.yml
@@ -1,0 +1,21 @@
+spring:
+  application:
+    name: spring-boot-admin-sample-oauth2
+  security:
+    oauth2:
+      client:
+        registration:
+          admin:
+            client-id: your-client-id
+            client-secret: your-client-secret
+            authorization-grant-type: client_credentials
+            scope: openid
+        provider:
+          auth0:
+            token-uri: https://YOUR_ISSUER/oauth/token
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "*"

--- a/spring-boot-admin-samples/spring-boot-admin-sample-servlet/src/main/java/de/codecentric/boot/admin/sample/OAuth2RestTemplateConfig.java
+++ b/spring-boot-admin-samples/spring-boot-admin-sample-servlet/src/main/java/de/codecentric/boot/admin/sample/OAuth2RestTemplateConfig.java
@@ -1,0 +1,38 @@
+
+/*
+ * Copyright 2014-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.codecentric.boot.admin.sample;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.web.reactive.function.client.ServletOAuth2AuthorizedClientExchangeFilterFunction;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration(proxyBeanMethods = false)
+public class OAuth2RestTemplateConfig {
+
+	@Bean
+	public RestTemplate restTemplate(OAuth2AuthorizedClientManager authorizedClientManager) {
+		return new RestTemplateBuilder()
+			.additionalRequestCustomizers(new ServletOAuth2AuthorizedClientExchangeFilterFunction(authorizedClientManager)
+				.getRequestCustomizer())
+			.build();
+	}
+
+}

--- a/spring-boot-admin-samples/spring-boot-admin-sample-servlet/src/main/java/de/codecentric/boot/admin/sample/OAuth2SecurityConfig.java
+++ b/spring-boot-admin-samples/spring-boot-admin-sample-servlet/src/main/java/de/codecentric/boot/admin/sample/OAuth2SecurityConfig.java
@@ -1,0 +1,35 @@
+
+/*
+ * Copyright 2014-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.codecentric.boot.admin.sample;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration(proxyBeanMethods = false)
+public class OAuth2SecurityConfig {
+
+	@Bean
+	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+		http.authorizeHttpRequests(authorize -> authorize.anyRequest().authenticated())
+		    .oauth2Login(oauth2Login -> oauth2Login.defaultSuccessUrl("/", true));
+		return http.build();
+	}
+
+}

--- a/spring-boot-admin-samples/spring-boot-admin-sample-servlet/src/main/java/de/codecentric/boot/admin/sample/SpringBootAdminOAuth2Application.java
+++ b/spring-boot-admin-samples/spring-boot-admin-sample-servlet/src/main/java/de/codecentric/boot/admin/sample/SpringBootAdminOAuth2Application.java
@@ -1,0 +1,35 @@
+
+/*
+ * Copyright 2014-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.codecentric.boot.admin.sample;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.Configuration;
+
+import de.codecentric.boot.admin.server.config.EnableAdminServer;
+
+@Configuration(proxyBeanMethods = false)
+@EnableAutoConfiguration
+@EnableAdminServer
+public class SpringBootAdminOAuth2Application {
+
+	public static void main(String[] args) {
+		SpringApplication.run(SpringBootAdminOAuth2Application.class, args);
+	}
+
+}


### PR DESCRIPTION
This PR implements support for Spring Cloud's InetUtils in DefaultApplicationFactory.getLocalHost().

- Injects Optional<InetUtils> into DefaultApplicationFactory
- Resolves preferred non-loopback address if configured via spring.cloud.inetutils.*
- Falls back to InetAddress.getLocalHost() if InetUtils is absent or fails
- Adds conditional bean definition for Optional<InetUtils> in auto-configuration

Closes #1323.