### PR TITLE
fix(#4468): update URL display to prevent overflow and improve readability

### DIFF
--- a/spring-boot-admin-server-ui/src/main/frontend/index.ts
+++ b/spring-boot-admin-server-ui/src/main/frontend/index.ts
@@ -18,6 +18,7 @@ import Aura from '@primeuix/themes/aura';
 import { usePrimeVue } from '@primevue/core';
 import NotificationcenterPlugin from '@stekoe/vue-toast-notificationcenter';
 import moment from 'moment';
+import { Tooltip } from 'primevue';
 import PrimeVue from 'primevue/config';
 import * as Vue from 'vue';
 import {
@@ -144,6 +145,7 @@ app.use(NotificationcenterPlugin, {
 });
 app.use(SbaModalPlugin, { i18n });
 app.use(viewRegistry.createRouter());
+app.directive('tooltip', Tooltip);
 app.use(PrimeVue, {
   theme: {
     preset: definePreset(Aura, {

--- a/spring-boot-admin-server-ui/src/main/frontend/views/applications/InstancesList.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/applications/InstancesList.vue
@@ -29,109 +29,36 @@
           :status="instance.statusInfo.status"
         />
       </div>
-      <div class="flex-1 overflow-hidden">
-        <section class="flex gap-2 items-center">
-          <div class="w-auto sm:w-[26rem]" data-name="">
-            <!-- Section when URL is visible -->
-            <template v-if="instance.showUrl()">
-              <div class="flex gap-1">
-                <div
-                  class="break-all"
-                  v-text="
-                    instance.registration.serviceUrl ||
-                    instance.registration.healthUrl
-                  "
-                />
-                <div class="ml-1 inline-flex gap-1 items-start">
-                  <template v-if="!instance.isUrlDisabled()">
-                    <sba-button
-                      as="a"
-                      :href="instance.registration.serviceUrl"
-                      size="2xs"
-                      referrerpolicy="no-referrer"
-                      target="_blank"
-                      :aria-label="t('term.homepage')"
-                    >
-                      <font-awesome-icon :icon="faHome" size="xs" />
-                    </sba-button>
-                  </template>
-                  <sba-button
-                    as="a"
-                    :href="instance.registration.managementUrl"
-                    size="2xs"
-                    referrerpolicy="no-referrer"
-                    target="_blank"
-                    :aria-label="t('term.actuator_endpoint')"
-                  >
-                    <font-awesome-icon :icon="faClipboardList" size="xs" />
-                  </sba-button>
-                  <sba-button
-                    as="a"
-                    :href="instance.registration.healthUrl"
-                    size="2xs"
-                    referrerpolicy="no-referrer"
-                    target="_blank"
-                    :aria-label="t('health.label')"
-                  >
-                    <font-awesome-icon :icon="faHeart" size="xs" />
-                  </sba-button>
-                </div>
-              </div>
-              <sba-tag
-                v-if="instance.registration.metadata?.['group']"
-                class="ml-2"
-                :value="instance.registration.metadata?.['group']"
-                small
-              />
-              <span class="text-sm italic" v-text="instance.id" />
-            </template>
-            <!-- URL are hidden -->
-            <template v-else>
-              <div v-text="instance.id"></div>
-              <sba-tag
-                v-if="instance.registration.metadata?.['group']"
-                class="ml-2"
-                :value="instance.registration.metadata?.['group']"
-                small
-              />
-            </template>
-          </div>
-          <div class="flex-1" v-text="instance.buildVersion" />
-          <div class="hidden lg:block text-right">
+      <div class="flex-1">
+        <div
+          class="flex gap-2 items-center instance-item"
+          :class="{ 'instance--show-url': instance.showUrl() }"
+        >
+          <ItemInformation
+            class="instance-item-information"
+            :instance="instance"
+          />
+          <div class="hidden lg:block">
             <slot :instance="instance" name="actions" />
           </div>
-        </section>
-        <section
-          v-if="Object.keys(instance.tags ?? {})?.length > 0"
-          class="mt-2 hidden lg:block overflow-x-auto"
-        >
-          <sba-tags :small="true" :tags="instance.tags" />
-        </section>
+        </div>
+        <ItemTags :instance="instance" />
       </div>
     </li>
   </ul>
 </template>
 
 <script lang="ts" setup>
-import {
-  faClipboardList,
-  faHeart,
-  faHome,
-} from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { PropType } from 'vue';
-import { useI18n } from 'vue-i18n';
 import { useRouter } from 'vue-router';
 
-import SbaButton from '@/components/sba-button.vue';
 import SbaStatus from '@/components/sba-status.vue';
-import SbaTag from '@/components/sba-tag.vue';
-import SbaTags from '@/components/sba-tags.vue';
 
 import Instance from '@/services/instance';
+import ItemInformation from '@/views/applications/listItem/ItemInformation.vue';
+import ItemTags from '@/views/applications/listItem/ItemTags.vue';
 
 const router = useRouter();
-const { t } = useI18n();
 
 defineProps({
   instances: {
@@ -156,8 +83,22 @@ const showDetails = (instance: Instance) => {
 };
 </script>
 
-<style lang="css">
-.instances-list td {
-  vertical-align: middle;
+<style scoped>
+.instance--show-url {
+  .instance-item-information {
+    @apply gap-1;
+    grid-area: 1 / 1 / 1 / 3;
+  }
+}
+</style>
+
+<style>
+.instance-item.instance--show-url {
+  .instance-id {
+    @apply text-xs font-light;
+  }
+  .instance-version {
+    @apply text-xs font-light;
+  }
 }
 </style>

--- a/spring-boot-admin-server-ui/src/main/frontend/views/applications/InstancesList.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/applications/InstancesList.vue
@@ -36,7 +36,7 @@
             <template v-if="instance.showUrl()">
               <div class="flex gap-1">
                 <div
-                  class="overflow-hidden text-ellipsis"
+                  class="break-all"
                   v-text="
                     instance.registration.serviceUrl ||
                     instance.registration.healthUrl

--- a/spring-boot-admin-server-ui/src/main/frontend/views/applications/listItem/ItemInformation.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/applications/listItem/ItemInformation.vue
@@ -1,0 +1,121 @@
+<!--
+  - Copyright 2014-2024 the original author or authors.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+  -->
+
+<template>
+  <section
+    class="grid grid-cols-2 md:grid-cols-[26.5rem_1fr] items-center w-full"
+  >
+    <div class="flex" style="grid-area: 1 / 1 / 1 / 3">
+      <template v-if="instance.showUrl()">
+        <div
+          v-tooltip.top="{
+            disabled: instanceUrlToShow.length <= 50,
+            value: instanceUrlToShow,
+            pt: {},
+          }"
+          class="text-ellipsis overflow-hidden whitespace-nowrap"
+          v-text="instanceUrlToShow"
+        />
+        <div class="ml-1 flex gap-1 items-start">
+          <sba-tag
+            v-if="instance.registration.metadata?.['group']"
+            class="ml-2"
+            :value="instance.registration.metadata?.['group']"
+            small
+          />
+
+          <template v-if="!instance.isUrlDisabled()">
+            <sba-button
+              as="a"
+              :href="instance.registration.serviceUrl"
+              size="2xs"
+              referrerpolicy="no-referrer"
+              target="_blank"
+              :aria-label="t('term.homepage')"
+            >
+              <font-awesome-icon :icon="faHome" size="xs" />
+            </sba-button>
+          </template>
+          <sba-button
+            as="a"
+            :href="instance.registration.managementUrl"
+            size="2xs"
+            referrerpolicy="no-referrer"
+            target="_blank"
+            :aria-label="t('term.actuator_endpoint')"
+          >
+            <font-awesome-icon :icon="faClipboardList" size="xs" />
+          </sba-button>
+          <sba-button
+            as="a"
+            :href="instance.registration.healthUrl"
+            size="2xs"
+            referrerpolicy="no-referrer"
+            target="_blank"
+            :aria-label="t('health.label')"
+          >
+            <font-awesome-icon :icon="faHeart" size="xs" />
+          </sba-button>
+        </div>
+      </template>
+
+      <template v-else>
+        <sba-tag
+          v-if="instance.registration.metadata?.['group']"
+          class="ml-2"
+          :value="instance.registration.metadata?.['group']"
+          small
+        />
+      </template>
+    </div>
+
+    <span class="instance-id" v-text="instance.id" />
+    <span
+      class="instance-version text-right lg:text-left"
+      v-text="instance.buildVersion"
+    />
+  </section>
+</template>
+
+<script setup lang="ts">
+import {
+  faClipboardList,
+  faHeart,
+  faHome,
+} from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import { useI18n } from 'vue-i18n';
+
+import SbaButton from '@/components/sba-button.vue';
+import SbaTag from '@/components/sba-tag.vue';
+
+import Instance from '@/services/instance';
+
+const { t } = useI18n();
+
+const { instance } = defineProps<{
+  instance: Instance;
+}>();
+
+const instanceUrlToShow =
+  instance.registration.serviceUrl || instance.registration.healthUrl;
+</script>
+
+<style>
+.p-tooltip {
+  max-width: fit-content !important;
+}
+</style>

--- a/spring-boot-admin-server-ui/src/main/frontend/views/applications/listItem/ItemTags.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/applications/listItem/ItemTags.vue
@@ -1,0 +1,34 @@
+<!--
+  - Copyright 2014-2024 the original author or authors.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+  -->
+
+<template>
+  <div
+    v-if="Object.keys(instance.tags ?? {}).length > 0"
+    class="mt-2 hidden lg:block overflow-x-auto"
+  >
+    <sba-tags :small="true" :tags="instance.tags" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import SbaTags from '@/components/sba-tags.vue';
+
+import Instance from '@/services/instance';
+
+defineProps<{
+  instance: Instance;
+}>();
+</script>


### PR DESCRIPTION
<img width="1552" height="549" alt="image" src="https://github.com/user-attachments/assets/4db9ce8f-2943-4100-955f-a9d356f7c2a7" />

addresses #4468 