### PR TITLE
feat(#4689): format object details in health component for better readability

### DIFF
--- a/spring-boot-admin-server-ui/src/main/frontend/views/instances/details/health-details.spec.ts
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/instances/details/health-details.spec.ts
@@ -49,6 +49,14 @@ describe('HealthDetails', () => {
               exists: false,
             },
           },
+          ssl: {
+            status: 'UP',
+            details: {
+              validChains: JSON.parse(
+                '[{"status": "VALID", "chain": [{"subject": "CN=example.com, OU=IT, O=Example Corp, L=San Francisco, ST=CA, C=US", "issuer": "CN=R3, O=Let\'s Encrypt, C=US"}]}]',
+              ),
+            },
+          },
         },
       };
 
@@ -104,6 +112,26 @@ describe('HealthDetails', () => {
       expect(
         await dsi.findByRole('definition', { name: 'exists' }),
       ).toHaveTextContent('false');
+    });
+
+    it('should format object details correctly', async () => {
+      const sslInfo = await screen.findByRole('definition', {
+        name: 'validChains',
+      });
+      expect(sslInfo).toHaveTextContent(
+        `[
+  {
+    "status": "VALID",
+    "chain": [
+      {
+        "subject": "CN=example.com, OU=IT, O=Example Corp, L=San Francisco, ST=CA, C=US",
+        "issuer": "CN=R3, O=Let's Encrypt, C=US"
+      }
+    ]
+  }
+]`,
+        { normalizeWhitespace: false },
+      );
     });
   });
 

--- a/spring-boot-admin-server-ui/src/main/frontend/views/instances/details/health-details.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/instances/details/health-details.vue
@@ -31,8 +31,8 @@
       <dl v-if="details && details.length > 0" class="grid grid-cols-2 mt-2">
         <template v-for="detail in details" :key="detail.name">
           <dt
-            class="font-medium"
             :id="`health-detail-${id}__${detail.name}`"
+            class="font-medium"
             v-text="detail.name"
           />
           <dd
@@ -48,8 +48,8 @@
             :aria-labelledby="`health-detail-${id}__${detail.name}`"
           >
             <pre
-              class="break-words whitespace-pre-wrap"
-              v-text="JSON.stringify(detail.value)"
+              class="overflow-auto"
+              v-text="JSON.stringify(detail.value, null, 2)"
             />
           </dd>
           <dd


### PR DESCRIPTION
Contents of type "object" are now formatted in a nicer way than just having a JSON one-liner.

closes #4689

<img width="1097" height="903" alt="image" src="https://github.com/user-attachments/assets/2de36390-8faf-42f9-b9d9-d7ddb0d58c15" />
