### PR TITLE
fix: adjust table layout for thread dump chart to prevent width overflow

### DIFF
--- a/spring-boot-admin-server-ui/src/main/frontend/views/instances/threaddump/threads-list.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/instances/threaddump/threads-list.vue
@@ -15,7 +15,7 @@
   -->
 
 <template>
-  <table class="table-auto w-full">
+  <table class="threads">
     <thead>
       <tr>
         <th class="threads__thread-name" v-text="$t('term.name')" />
@@ -202,6 +202,7 @@ export default {
 <style lang="css">
 .threads {
   table-layout: fixed;
+  width: 100%;
 }
 .threads__thread-name {
   width: 250px;


### PR DESCRIPTION
closes #4341 