### PR TITLE
fix(#5079): Enable the KubernetesConverterConfiguration configuration only if also the KubernetesDiscoveryProperties bean is available in the context

### DIFF
--- a/spring-boot-admin-server-cloud/src/main/java/de/codecentric/boot/admin/server/cloud/config/AdminServerDiscoveryAutoConfiguration.java
+++ b/spring-boot-admin-server-cloud/src/main/java/de/codecentric/boot/admin/server/cloud/config/AdminServerDiscoveryAutoConfiguration.java
@@ -80,6 +80,7 @@ public class AdminServerDiscoveryAutoConfiguration {
 	}
 
 	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnBean(KubernetesDiscoveryProperties.class)
 	@ConditionalOnMissingBean({ ServiceInstanceConverter.class })
 	@ConditionalOnCloudPlatform(CloudPlatform.KUBERNETES)
 	public static class KubernetesConverterConfiguration {

--- a/spring-boot-admin-server-cloud/src/test/java/de/codecentric/boot/admin/server/cloud/config/AdminServerDiscoveryAutoConfigurationTest.java
+++ b/spring-boot-admin-server-cloud/src/test/java/de/codecentric/boot/admin/server/cloud/config/AdminServerDiscoveryAutoConfigurationTest.java
@@ -19,7 +19,6 @@ package de.codecentric.boot.admin.server.cloud.config;
 import com.netflix.discovery.EurekaClient;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.http.client.autoconfigure.reactive.ReactiveHttpClientAutoConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.boot.webclient.autoconfigure.WebClientAutoConfiguration;
@@ -65,8 +64,8 @@ class AdminServerDiscoveryAutoConfigurationTest {
 
 	@Test
 	void kubernetesServiceInstanceConverter() {
-		this.contextRunner.withUserConfiguration(KubernetesDiscoveryPropertiesConfiguration.class)
-			.withBean(DiscoveryClient.class, () -> mock(DiscoveryClient.class))
+		this.contextRunner.withBean(DiscoveryClient.class, () -> mock(DiscoveryClient.class))
+			.withBean(KubernetesDiscoveryProperties.class, () -> mock(KubernetesDiscoveryProperties.class))
 			.withPropertyValues("spring.main.cloud-platform=KUBERNETES")
 			.run((context) -> assertThat(context.getBean(ServiceInstanceConverter.class))
 				.isInstanceOf(KubernetesServiceInstanceConverter.class));
@@ -86,11 +85,6 @@ class AdminServerDiscoveryAutoConfigurationTest {
 		public Registration convert(ServiceInstance instance) {
 			return null;
 		}
-
-	}
-
-	@EnableConfigurationProperties(KubernetesDiscoveryProperties.class)
-	public static class KubernetesDiscoveryPropertiesConfiguration {
 
 	}
 


### PR DESCRIPTION
Fixes https://github.com/codecentric/spring-boot-admin/issues/5079

I cannot build the UI part in my corporate environment, therefore I couldn't test the full potentially released package.
Nevertheless, I've uploaded a snapshot in our repository and now the build of my monitoring application which uses SBA server as dependency is not failing anymore:
<img width="933" height="259" alt="image" src="https://github.com/user-attachments/assets/b1019d4e-6d2e-429b-b8c5-23c95ace4922" />
