### PR TITLE
fix(#5166): Render OUT_OF_SERVICE health status the same as DOWN

### DIFF
--- a/spring-boot-admin-server-ui/src/main/frontend/components/sba-status-badge.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/components/sba-status-badge.vue
@@ -36,7 +36,8 @@ export default {
 .up {
   @apply bg-green-200 text-green-700;
 }
-.down {
+.down,
+.out_of_service {
   @apply bg-red-200 text-red-700;
 }
 .restricted {


### PR DESCRIPTION
Fixes https://github.com/codecentric/spring-boot-admin/issues/5166.

If I saw correctly, the Wallboard is already defaulting `OUT_OF_SERVICE` to `DOWN` and SbaStatus is also already using the red color and a proper icon.
Therefore, unless I missed something, that one should be the only place where such a color setting was missing.