### PR TITLE
fix: prevent audit log view from shaking on periodic refresh

### DIFF
--- a/spring-boot-admin-server-ui/src/main/frontend/views/instances/auditevents/index.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/instances/auditevents/index.vue
@@ -148,7 +148,7 @@ export default {
       return moment(value, moment.HTML5_FMT.DATETIME_LOCAL, true).toDate();
     },
     async fetchAuditevents() {
-      this.isLoading = true;
+      this.isLoading = this.events.length === 0;
       const response = await this.instance.fetchAuditevents(this.filter);
       const converted = response.data.events.map(
         (event) => new Auditevent(event),

--- a/spring-boot-admin-server-ui/src/main/frontend/views/instances/auditevents/index.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/instances/auditevents/index.vue
@@ -124,6 +124,7 @@ export default {
   },
   data: () => ({
     isLoading: false,
+    hasLoadedInitially: false,
     error: null,
     events: [],
     filter: {
@@ -148,14 +149,19 @@ export default {
       return moment(value, moment.HTML5_FMT.DATETIME_LOCAL, true).toDate();
     },
     async fetchAuditevents() {
-      this.isLoading = this.events.length === 0;
-      const response = await this.instance.fetchAuditevents(this.filter);
-      const converted = response.data.events.map(
-        (event) => new Auditevent(event),
-      );
-      converted.reverse();
-      this.isLoading = false;
-      return converted;
+      this.isLoading = !this.hasLoadedInitially;
+
+      try {
+        const response = await this.instance.fetchAuditevents(this.filter);
+        const converted = response.data.events.map(
+          (event) => new Auditevent(event),
+        );
+        converted.reverse();
+        return converted;
+      } finally {
+        this.isLoading = false;
+        this.hasLoadedInitially = true;
+      }
     },
     createSubscription() {
       this.filterChanged = new Subject();


### PR DESCRIPTION
## Summary

Fixes #5134

### Problem

The Audit Log view visually "shakes" on the right side every 5 seconds when the periodic refresh triggers.

### Root Cause

`fetchAuditevents()` unconditionally sets `isLoading = true` on every poll cycle, even when audit events are already displayed. This causes the loading spinner overlay — an absolutely positioned element with `h-screen` height inside `sba-instance-section` — to be inserted into and removed from the DOM every 5 seconds. This DOM churn triggers a brief scrollbar appearance/disappearance, resulting in a horizontal layout shift perceived as shaking.

### Fix

Only set `isLoading = true` when there are no events loaded yet (initial load or after a filter change clears the list):

```js
// Before:
this.isLoading = true;

// After:
this.isLoading = this.events.length === 0;
```

Subsequent periodic refreshes with existing data skip the loading state entirely, eliminating the DOM churn that causes the layout shift. This is consistent with `InfoUpdateTrigger`'s approach and the general UX expectation: a loading indicator is useful when there is no data to show, but unnecessary when silently polling for updates behind already-visible content.

### Scope

Single line change in `spring-boot-admin-server-ui/src/main/frontend/views/instances/auditevents/index.vue`.

## Test Plan

- [x] All 4 existing audit events unit tests pass
- [x] Manual verification: ran the servlet sample app with fake audit events generating every 3 seconds, confirmed the audit log table updates smoothly without any horizontal shaking