### PR TITLE
test: add missing getter and toString tests for ApplicationNameNotificationFilter

### DIFF
--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/notify/filter/InstanceNameNotificationFilterTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/notify/filter/InstanceNameNotificationFilterTest.java
@@ -65,4 +65,17 @@ class InstanceNameNotificationFilterTest {
 			.untilAsserted(() -> assertThat(filterLong.isExpired()).isTrue());
 	}
 
+	@Test
+	void test_getApplicationName() {
+		ApplicationNameNotificationFilter filter = new ApplicationNameNotificationFilter("my-app", null);
+		assertThat(filter.getApplicationName()).isEqualTo("my-app");
+	}
+
+	@Test
+	void test_toString() {
+		Instant expiry = Instant.parse("2099-01-01T00:00:00Z");
+		ApplicationNameNotificationFilter filter = new ApplicationNameNotificationFilter("my-app", expiry);
+		assertThat(filter.toString()).contains("my-app").contains(expiry.toString());
+	}
+
 }


### PR DESCRIPTION
Add two missing test cases to `InstanceNameNotificationFilterTest`:

- `test_getApplicationName()`: verifies that `getApplicationName()` returns the configured name
- `test_toString()`: verifies that `toString()` output contains the application name and expiry time