### PR TITLE
feat(#5238): Disable by default the text wrapping in the logfile view and fix typo for the 'scrollSubcription' data variable

### DIFF
--- a/spring-boot-admin-server-ui/src/main/frontend/views/instances/logfile/index.spec.ts
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/instances/logfile/index.spec.ts
@@ -1,0 +1,29 @@
+import { screen, waitFor } from '@testing-library/vue';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { applications } from '@/mocks/applications/data';
+import Application from '@/services/application';
+import { render } from '@/test-utils';
+import LogFile from '@/views/instances/logfile/index.vue';
+
+describe('LogFile', () => {
+  beforeEach(async () => {
+    const application = new Application(applications[0]);
+    const instance = application.instances[0];
+
+    render(LogFile, {
+      props: {
+        instance,
+      },
+    });
+  });
+
+  it('disables the wrap lines by default', async () => {
+    const checkbox = await screen.findByRole('checkbox', {
+      name: 'instances.logfile.wrap_lines',
+    });
+    await waitFor(() => {
+      expect(checkbox).not.toBeChecked();
+    });
+  });
+});

--- a/spring-boot-admin-server-ui/src/main/frontend/views/instances/logfile/index.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/instances/logfile/index.vue
@@ -130,8 +130,8 @@ export default {
     atBottom: false,
     atTop: true,
     skippedBytes: null,
-    wrapLines: true,
-    scrollSubcription: null,
+    wrapLines: false,
+    scrollSubscription: null,
   }),
   computed: {
     skippedBytesString() {
@@ -143,7 +143,7 @@ export default {
   },
   created() {
     this.ansiUp = new AnsiUp();
-    this.scrollSubcription = fromEvent(window, 'scroll')
+    this.scrollSubscription = fromEvent(window, 'scroll')
       .pipe(
         debounceTime(25),
         map((event) => event.target.scrollingElement.scrollTop),
@@ -157,11 +157,11 @@ export default {
       });
   },
   beforeUnmount() {
-    if (this.scrollSubcription && !this.scrollSubcription.closed) {
+    if (this.scrollSubscription && !this.scrollSubscription.closed) {
       try {
-        this.scrollSubcription.unsubscribe();
+        this.scrollSubscription.unsubscribe();
       } finally {
-        this.scrollSubcription = null;
+        this.scrollSubscription = null;
       }
     }
   },


### PR DESCRIPTION
Fixes https://github.com/codecentric/spring-boot-admin/issues/5238.

I tried to write a test for it, but I didn't manage to run the tests locally at all (I tried also with PowerShell, but I get the same result):
```
Cosimo Damiano Prete@DESKTOP-R2R6SJS MINGW64 ~/Documents/spring-boot-admin/spring-boot-admin-server-ui (master)
$ npm run test

> test
> vitest run --silent


 RUN  v4.1.2 C:/Users/Cosimo Damiano Prete/Documents/spring-boot-admin/spring-boot-admin-server-ui

No test files found, exiting with code 1
                                                                                                                                                                                                                                    
include: C:\Users\Cosimo Damiano Prete\Documents\spring-boot-admin\spring-boot-admin-server-ui\src\main\frontend\**\*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}
exclude:  **/node_modules/**, **/.git/**
```

I can drop it, if necessary.
On the other end, on your pipeline it run just fine.