### PR TITLE
Use cross-env dev package to make the build:dev and build:watch commands work on Windows

### DIFF
--- a/spring-boot-admin-server-ui/package-lock.json
+++ b/spring-boot-admin-server-ui/package-lock.json
@@ -80,6 +80,7 @@
         "@vue/test-utils": "2.4.6",
         "axios-mock-adapter": "^2.1.0",
         "babel-loader": "10.1.1",
+        "cross-env": "^10.1.0",
         "eslint": "^10.0.0",
         "eslint-config-prettier": "^10.0.0",
         "eslint-plugin-prettier": "^5.0.0",
@@ -461,6 +462,13 @@
       "engines": {
         "node": ">=20.19.0"
       }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.28.0",
@@ -5428,6 +5436,24 @@
       "license": "MIT",
       "bin": {
         "cronstrue": "bin/cli.js"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/cross-spawn": {

--- a/spring-boot-admin-server-ui/package.json
+++ b/spring-boot-admin-server-ui/package.json
@@ -4,8 +4,8 @@
   "description": "Spring Boot Admin UI",
   "scripts": {
     "build": "vite build --emptyOutDir --sourcemap",
-    "build:dev": "NODE_ENV=development vite build --emptyOutDir --sourcemap --mode development",
-    "build:watch": "NODE_ENV=development vite build --emptyOutDir --sourcemap --watch --mode development",
+    "build:dev": "cross-env NODE_ENV=development vite build --emptyOutDir --sourcemap --mode development",
+    "build:watch": "cross-env NODE_ENV=development vite build --emptyOutDir --sourcemap --watch --mode development",
     "dev": "vite",
     "test": "vitest run --silent",
     "test:watch": "vitest",
@@ -91,6 +91,7 @@
     "@vue/test-utils": "2.4.6",
     "axios-mock-adapter": "^2.1.0",
     "babel-loader": "10.1.1",
+    "cross-env": "^10.1.0",
     "eslint": "^10.0.0",
     "eslint-config-prettier": "^10.0.0",
     "eslint-plugin-prettier": "^5.0.0",


### PR DESCRIPTION
Allows to run `build:dev` and `build:watch` on Windows as well which would otherwise fail with
> 'NODE_ENV' is not recognized as an internal or external command, operable program or batch file.