### PR TITLE
Fix discovery of tests under Windows

### DIFF
--- a/spring-boot-admin-server-ui/vite.config.mts
+++ b/spring-boot-admin-server-ui/vite.config.mts
@@ -50,21 +50,15 @@ export default defineConfig(({ mode }) => {
       },
     },
     test: {
-      root: __dirname,
       globals: true,
       environment: 'jsdom',
-      setupFiles: [resolve(frontendDir, 'tests/setup.ts')],
+      setupFiles: ['tests/setup.ts'],
       env: {
         LANG: 'de_DE.UTF-8',
         LC_ALL: 'de_DE.UTF-8',
         TZ: 'Europe/Berlin',
       },
-      include: [
-        resolve(
-          frontendDir,
-          '**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
-        ),
-      ],
+      include: ['**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     },
     root: frontendDir,
     build: {


### PR DESCRIPTION
Fixes the error reported in https://github.com/codecentric/spring-boot-admin/pull/5241#issue-4240057893

Please be aware that some tests fail on Windows due to mismatches like
```diff
-   data-v-4727d85f=""
+   data-v-ee5aaf5b=""
```
~~(I've no clue what's that about)~~

and others fail due to localization issues
```console
FAIL  utils/formatWithDataTypes.spec.ts > formatWithDataTypes > formats date from ISO string
AssertionError: expected 'Jun 1, 2024, 2:34:56 PM' to match /01\.06\.2024, 14:34:56/

- Expected:
/01\.06\.2024, 14:34:56/

+ Received:
"Jun 1, 2024, 2:34:56 PM"
```