### PR TITLE
chore: fix discovery of tests under Windows

### DIFF
--- a/spring-boot-admin-server-ui/src/main/frontend/utils/formatWithDataTypes.spec.ts
+++ b/spring-boot-admin-server-ui/src/main/frontend/utils/formatWithDataTypes.spec.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { formatWithDataTypes } from './formatWithDataTypes';
 
@@ -64,16 +64,35 @@ describe('formatWithDataTypes', () => {
     expect(output).toEqual({ a: 1 });
   });
 
-  it('formats date from timestamp', () => {
-    const input = { timestamp: 1717243496000 };
-    const output = formatWithDataTypes(input, { timestamp: 'date' });
-    expect(output.timestamp).toMatch(/01\.06\.2024, 14:04:56/);
-  });
+  describe('date format', () => {
+    const OriginalDateTimeFormat = Intl.DateTimeFormat;
 
-  it('formats date from ISO string', () => {
-    const input = { created: '2024-06-01T12:34:56Z' };
-    const output = formatWithDataTypes(input, { created: 'date' });
-    expect(output.created).toMatch(/01\.06\.2024, 14:34:56/);
+    beforeAll(() => {
+      Intl.DateTimeFormat = class extends OriginalDateTimeFormat {
+        constructor(
+          _?: string | string[],
+          options?: Intl.DateTimeFormatOptions,
+        ) {
+          super('de-DE', options);
+        }
+      } as Intl.DateTimeFormatConstructor;
+    });
+
+    afterAll(() => {
+      Intl.DateTimeFormat = OriginalDateTimeFormat;
+    });
+
+    it('formats date from timestamp', () => {
+      const input = { timestamp: 1717243496000 };
+      const output = formatWithDataTypes(input, { timestamp: 'date' });
+      expect(output.timestamp).toMatch(/01\.06\.2024, 14:04:56/);
+    });
+
+    it('formats date from ISO string', () => {
+      const input = { created: '2024-06-01T12:34:56Z' };
+      const output = formatWithDataTypes(input, { created: 'date' });
+      expect(output.created).toMatch(/01\.06\.2024, 14:34:56/);
+    });
   });
 
   it('handles formatting errors gracefully', () => {

--- a/spring-boot-admin-server-ui/vite.config.mts
+++ b/spring-boot-admin-server-ui/vite.config.mts
@@ -59,12 +59,7 @@ export default defineConfig(({ mode }) => {
         LC_ALL: 'de_DE.UTF-8',
         TZ: 'Europe/Berlin',
       },
-      include: [
-        resolve(
-          frontendDir,
-          '**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
-        ),
-      ],
+      include: ['**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     },
     root: frontendDir,
     build: {


### PR DESCRIPTION
Recreating this PR since I'm not allowed to reopen https://github.com/codecentric/spring-boot-admin/pull/5273.

It seems like that removing the `test.root` property to make `vitest` default to the parent `root` property was the cause of the CSS hashes changing.
This has now been reverted.

Also, the `formatWithDataTypes` tests have been fixed to not rely on the fact that the running Node instance has the `de-DE` locale set.
Moreover, depending on how the Node binary was built, locales/languages apart English may not be available. 
See https://github.com/nodejs/node/blob/main/BUILDING.md#intl-ecma-402-support which may explains why the `LANG` env variable set in the `vite` config may be potentially ignored.