### PR TITLE
chore: fix lack of test resources when npm build is skip

### DIFF
--- a/spring-boot-admin-server-ui/pom.xml
+++ b/spring-boot-admin-server-ui/pom.xml
@@ -31,6 +31,10 @@
         <relativePath>../spring-boot-admin-build</relativePath>
     </parent>
 
+    <properties>
+        <ui-resources.relative-path>META-INF/spring-boot-admin-server-ui</ui-resources.relative-path>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>de.codecentric</groupId>
@@ -73,7 +77,63 @@
         </dependency>
     </dependencies>
 
+    <profiles>
+        <!--
+        Profile: noNpm
+        Set this profile to skip any frontend related build step in this project.
+        Skipping frontend tests can be achieved by using default flag -D skipTests.
+        -->
+        <profile>
+            <id>noNpm</id>
+            <build>
+                <plugins>
+                    <!--
+                    Run this only when this profile is active since, when it's not, the missing resources are
+                    already generated and provided under the right path from the NPM+Maven build.
+                    -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <executions>
+                            <!--
+                            Copy some predefined resources, which are usually generated during the frontend build,
+                            otherwise some of the tests in
+                            the de.codecentric.boot.admin.server.ui.AdminUiServletApplicationTest will fail because
+                            Thymeleaf can't find the resources like, for example, sba-settings.js.
+                            -->
+                            <execution>
+                                <id>copy-dummy-test-resources</id>
+                                <phase>generate-resources</phase>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${project.build.outputDirectory}/${ui-resources.relative-path}</outputDirectory>
+                                    <resources>
+                                        <resource>
+                                            <directory>${project.basedir}/src/test/resources/${ui-resources.relative-path}</directory>
+                                            <filtering>false</filtering>
+                                        </resource>
+                                    </resources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <build>
+        <testResources>
+            <testResource>
+                <directory>${project.basedir}/src/test/resources</directory>
+                <excludes>
+                    <!-- These resources are needed only when running with the noNpm profile active -->
+                    <exclude>${ui-resources.relative-path}/*</exclude>
+                </excludes>
+            </testResource>
+        </testResources>
         <plugins>
             <plugin>
                 <groupId>com.github.eirslett</groupId>
@@ -156,7 +216,7 @@
                         </goals>
                         <configuration>
                             <outputDirectory>
-                                ${project.build.outputDirectory}/META-INF/spring-boot-admin-server-ui
+                                ${project.build.outputDirectory}/${ui-resources.relative-path}
                             </outputDirectory>
                             <resources>
                                 <resource>

--- a/spring-boot-admin-server-ui/src/test/java/de/codecentric/boot/admin/server/ui/AdminUiServletApplicationTest.java
+++ b/spring-boot-admin-server-ui/src/test/java/de/codecentric/boot/admin/server/ui/AdminUiServletApplicationTest.java
@@ -66,7 +66,7 @@ class AdminUiServletApplicationTest extends AbstractAdminUiApplicationTest {
 		public static class SecurityConfiguration {
 
 			@Bean
-			protected SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+			protected SecurityFilterChain filterChain(HttpSecurity http) {
 				return http.csrf(AbstractHttpConfigurer::disable)
 					.authorizeHttpRequests((authz) -> authz.anyRequest().permitAll())
 					.anonymous((config) -> config.principal("anonymousUser"))

--- a/spring-boot-admin-server-ui/src/test/resources/META-INF/spring-boot-admin-server-ui/index.html
+++ b/spring-boot-admin-server-ui/src/test/resources/META-INF/spring-boot-admin-server-ui/index.html
@@ -1,0 +1,61 @@
+<!--
+  ~ Copyright 2014-2020 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!doctype html>
+<html class="h-full">
+  <head>
+    <base href="/" th:href="${baseUrl}" />
+    <meta charset="utf-8" />
+    <title th:text="${uiSettings.title}">Spring Boot Admin</title>
+    <link
+      rel="shortcut icon"
+      th:href="${uiSettings.favicon}"
+      type="image/png"
+    />
+    <meta content="width=device-width, initial-scale=1" name="viewport" />
+    <meta content="IE=edge,chrome=1" http-equiv="X-UA-Compatible" />
+    <meta content="telephone=no,email=no" name="format-detection" />
+    <meta
+      content="#42d3a5"
+      name="theme-color"
+      th:content="${uiSettings.theme.color}"
+    />
+
+    <link href="./variables.css" rel="stylesheet" />
+
+    <link
+      as="style"
+      rel="preload"
+      th:each="cssExtension : ${cssExtensions}"
+      th:href="'extensions/' + ${cssExtension.resourcePath}"
+    />
+    <script lang="javascript" src="sba-settings.js"></script>
+    <link
+      as="script"
+      rel="preload"
+      th:each="jsExtension : ${jsExtensions}"
+      th:href="'extensions/' + ${jsExtension.resourcePath}"
+    />
+    <script type="module" crossorigin src="./assets/sba-DqWTbRYH.js"></script>
+    <link rel="modulepreload" crossorigin href="./assets/index-DIiXKTRC.js">
+    <link rel="stylesheet" crossorigin href="./assets/index-ZFGUj1iQ.css">
+    <link rel="stylesheet" crossorigin href="./assets/sba-BZCrJZH3.css">
+  </head>
+  <body class="h-full">
+    <div id="app"></div>
+
+  </body>
+</html>

--- a/spring-boot-admin-server-ui/src/test/resources/META-INF/spring-boot-admin-server-ui/login.html
+++ b/spring-boot-admin-server-ui/src/test/resources/META-INF/spring-boot-admin-server-ui/login.html
@@ -1,0 +1,53 @@
+<!--
+  ~ Copyright 2014-2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!doctype html>
+<html class="h-full">
+  <head>
+    <base href="/" th:href="${baseUrl}" />
+    <meta charset="utf-8" />
+    <meta content="width=device-width, initial-scale=1" name="viewport" />
+    <meta content="IE=edge,chrome=1" http-equiv="X-UA-Compatible" />
+    <meta content="telephone=no,email=no" name="format-detection" />
+    <meta content="#42d3a5" name="theme-color" />
+
+    <link
+      rel="shortcut icon"
+      th:href="${uiSettings.favicon}"
+      type="image/png"
+    />
+    <title th:text="${uiSettings.title}">Spring Boot Admin - Login</title>
+    <script th:inline="javascript">
+      var csrf = /*[[${_csrf}]]*/ {};
+      var uiSettings = /*[[${uiSettings}]]*/ {};
+      var param = /*[[${param}]]*/ {};
+    </script>
+    <script type="module" crossorigin src="./assets/login-B2h9tIKB.js"></script>
+    <link rel="modulepreload" crossorigin href="./assets/index-DIiXKTRC.js">
+    <link rel="stylesheet" crossorigin href="./assets/index-ZFGUj1iQ.css">
+    <link rel="stylesheet" crossorigin href="./assets/login-ohsYTZfl.css">
+  </head>
+  <body class="flex flex-col min-h-full h-full">
+    <div
+      class="absolute w-full h-full t-0 l-0 bg-white/40 backdrop-blur-sm z-0"
+    ></div>
+    <section
+      id="login"
+      class="relative z-10 flex items-center justify-center h-full"
+    ></section>
+
+  </body>
+</html>

--- a/spring-boot-admin-server-ui/src/test/resources/META-INF/spring-boot-admin-server-ui/sba-settings.js
+++ b/spring-boot-admin-server-ui/src/test/resources/META-INF/spring-boot-admin-server-ui/sba-settings.js
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2014-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//This is a Thymleaf template whill will be rendered by the backend
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+var SBA = {
+  uiSettings: /*[[${uiSettings}]]*/ {},
+  user: /*[[${user}]]*/ null,
+  extensions: {
+    js: /*[[${jsExtensions}]]*/ [],
+    css: /*[[${cssExtensions}]]*/ [],
+  },
+  csrf: {
+    parameterName: /*[[${_csrf} ? ${_csrf.parameterName} : 'null']]*/ null,
+    headerName: /*[[${_csrf} ? ${_csrf.headerName} : 'null']]*/ null,
+  },
+};

--- a/spring-boot-admin-server-ui/src/test/resources/META-INF/spring-boot-admin-server-ui/variables.css
+++ b/spring-boot-admin-server-ui/src/test/resources/META-INF/spring-boot-admin-server-ui/variables.css
@@ -1,0 +1,25 @@
+:root {
+  --main-50: /*[(${palette.rgbColor50})]*/ #e8fbef;
+  --main-100: /*[(${palette.rgbColor100})]*/ #d0f7df;
+  --main-200: /*[(${palette.rgbColor200})]*/ #a1efbd;
+  --main-300: /*[(${palette.rgbColor300})]*/ #71e69c;
+  --main-400: /*[(${palette.rgbColor400})]*/ #41de7b;
+  --main-500: /*[(${palette.rgbColor500})]*/ #22c55e;
+  --main-600: /*[(${palette.rgbColor600})]*/ #1a9547;
+  --main-700: /*[(${palette.rgbColor700})]*/ #116530;
+  --main-800: /*[(${palette.rgbColor800})]*/ #09351a;
+  --main-900: /*[(${palette.rgbColor900})]*/ #010603;
+
+  --bg-color-start: /*[(${uiSettings.theme.palette.shade300})]*/ #71e69c;
+  --bg-color-stop: /*[(${uiSettings.theme.palette.shade700})]*/ #09351a;
+}
+
+.bg-color-start {
+  transition: 0.4s ease;
+  stop-color: var(--bg-color-start);
+}
+
+.bg-color-stop {
+  transition: 0.4s ease;
+  stop-color: var(--bg-color-stop);
+}


### PR DESCRIPTION
Fixes the lack of resources (e.g.: `sba-settings.js`) when the tests are executed with `-PnoNpm`.
The issue with some tests failing was reported in https://github.com/codecentric/spring-boot-admin/pull/5285#issue-4295746872 and this PR fixes it.

The needed resources have been generated once and made them available under `target/classes`, as opposite of the default `target/testClasses`, to not change the existing tests which, by relying on the default configuration, they expect to load them from the class resources instead of from the test class ones.

~~By the way, the `frontend-maven-plugin` also fails with the same issue reported in https://github.com/eirslett/frontend-maven-plugin/issues/1178 😞 
**EDIT**: the point above about `npm` is solved with https://github.com/codecentric/spring-boot-admin/pull/5312~~