### PR TITLE
chore: specify npm version explicitly to avoid 'npm MODULE_NOT_FOUND' error

### DIFF
--- a/.github/workflows/build-feature.yml
+++ b/.github/workflows/build-feature.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
-          node-version: 'lts/*'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
 

--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
-          node-version: 'lts/*'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
 
@@ -71,7 +71,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
-          node-version: 'lts/*'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
 

--- a/.github/workflows/deploy-documentation.yml
+++ b/.github/workflows/deploy-documentation.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
-          node-version: 'lts/*'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
 

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,8 @@
         <revision>4.1.0-SNAPSHOT</revision>
 
         <java.version>17</java.version>
-        <node.version>v22.12.0</node.version>
+        <npm.version>11.12.1</npm.version>
+        <node.version>v24.15.0</node.version>
 
         <require.maven.version>3.9</require.maven.version>
 

--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,18 @@
   ],
   "minimumReleaseAge": "5 days",
   "internalChecksFilter": "strict",
+  "customManagers": [
+    {
+      "description": "Track Node.js version in frontend-maven-plugin <node.version> property",
+      "customType": "regex",
+      "managerFilePatterns": ["/(^|/)pom\\.xml$/"],
+      "matchStrings": ["<node\\.version>v(?<currentValue>[^<]+)</node\\.version>"],
+      "depNameTemplate": "node",
+      "datasourceTemplate": "node-version",
+      "versioningTemplate": "node",
+      "extractVersionTemplate": "^v?(?<version>.+)$"
+    }
+  ],
   "packageRules": [
     {
       "description": "Automatically merge minor and patch-level updates when checks pass, creates a PR otherwise",
@@ -33,6 +45,13 @@
         "com.puppycrawl.tools:checkstyle"
       ],
       "allowedVersions": "<13"
+    },
+    {
+      "description": "Group all Node.js version updates (pom.xml, .nvmrc, package.json engines, GitHub Actions) into one PR",
+      "matchDepNames": ["node"],
+      "matchDatasources": ["node-version"],
+      "groupName": "Node.js version",
+      "groupSlug": "nodejs-version"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -47,9 +47,10 @@
       "allowedVersions": "<13"
     },
     {
-      "description": "Group all Node.js version updates (pom.xml, .nvmrc, package.json engines, GitHub Actions) into one PR",
-      "matchDepNames": ["node"],
-      "matchDatasources": ["node-version"],
+      "description": "Group all Node.js and npm version updates (pom.xml, .nvmrc, package.json engines, GitHub Actions) into one PR",
+      "matchDepNames": ["node", "npm"],
+      "matchDatasources": ["node-version", "npm"],
+      "matchDepTypes": ["engines", "node"],
       "groupName": "Node.js version",
       "groupSlug": "nodejs-version"
     }

--- a/spring-boot-admin-docs/pom.xml
+++ b/spring-boot-admin-docs/pom.xml
@@ -53,6 +53,7 @@
                         </goals>
                         <phase>pre-site</phase>
                         <configuration>
+                            <npmVersion>${npm.version}</npmVersion>
                             <nodeVersion>${node.version}</nodeVersion>
                         </configuration>
                     </execution>

--- a/spring-boot-admin-samples/spring-boot-admin-sample-custom-ui/pom.xml
+++ b/spring-boot-admin-samples/spring-boot-admin-sample-custom-ui/pom.xml
@@ -46,6 +46,7 @@
                             <goal>install-node-and-npm</goal>
                         </goals>
                         <configuration>
+                            <npmVersion>${npm.version}</npmVersion>
                             <nodeVersion>${node.version}</nodeVersion>
                         </configuration>
                     </execution>

--- a/spring-boot-admin-server-ui/package.json
+++ b/spring-boot-admin-server-ui/package.json
@@ -119,6 +119,7 @@
     "> .5%, last 2 versions"
   ],
   "engines": {
+    "npm": "11.12.0",
     "node": "24.15.0"
   },
   "msw": {

--- a/spring-boot-admin-server-ui/pom.xml
+++ b/spring-boot-admin-server-ui/pom.xml
@@ -85,6 +85,7 @@
                             <goal>install-node-and-npm</goal>
                         </goals>
                         <configuration>
+                            <npmVersion>${npm.version}</npmVersion>
                             <nodeVersion>${node.version}</nodeVersion>
                         </configuration>
                     </execution>


### PR DESCRIPTION
See https://github.com/eirslett/frontend-maven-plugin/issues/1178

@SteKoe can't `renovate` be configured to keep in sync those `node.version` (and now `npm.version`) properties every time it updates the `engines` section under the `package.json`?

The Node version specified in the `pom.xml` was way older than the one specified under `engines` in the `package.json`.