### PR TITLE
fix(#5307): make the LineChart component have a proper parent width

### DIFF
--- a/spring-boot-admin-server-ui/src/main/frontend/views/instances/details/LineChart.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/instances/details/LineChart.vue
@@ -15,7 +15,9 @@
   -->
 
 <template>
-  <canvas id="chart" ref="chart" />
+  <div class="flex w-full">
+    <canvas id="chart" ref="chart" />
+  </div>
 </template>
 
 <script>

--- a/spring-boot-admin-server-ui/src/main/frontend/views/instances/details/LineChart.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/instances/details/LineChart.vue
@@ -15,7 +15,7 @@
   -->
 
 <template>
-  <div class="flex w-full">
+  <div class="chart-container">
     <canvas id="chart" ref="chart" />
   </div>
 </template>
@@ -117,6 +117,8 @@ export default {
         datasets,
       },
       options: {
+        responsive: true,
+        maintainAspectRatio: false,
         animation: {
           duration: 0,
         },
@@ -194,3 +196,13 @@ export default {
   },
 };
 </script>
+
+<style scoped>
+.chart-container {
+  position: relative;
+  width: 100%;
+  min-height: 300px;
+  max-height: 450px;
+  height: 100%;
+}
+</style>

--- a/spring-boot-admin-server-ui/src/main/frontend/views/instances/details/index.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/instances/details/index.vue
@@ -21,18 +21,18 @@
       <details-hero :instance="instance" />
     </template>
 
-    <div class="flex gap-6 flex-col lg:flex-row">
-      <div class="flex-1">
+    <div class="instance-grid">
+      <div>
         <details-info v-if="hasInfo" :instance="instance" />
         <details-metadata v-if="hasMetadata" :instance="instance" />
       </div>
-      <div class="flex-1">
+      <div>
         <details-health :instance="instance" />
       </div>
     </div>
 
-    <div class="flex gap-6 flex-col lg:flex-row">
-      <div class="flex-1">
+    <div class="instance-grid">
+      <div>
         <details-process
           v-if="hasProcess"
           :instance="instance"
@@ -40,25 +40,25 @@
         />
         <details-gc v-if="hasGc" :instance="instance" />
       </div>
-      <div class="flex-1">
+      <div>
         <details-threads v-if="hasThreads" :instance="instance" />
       </div>
     </div>
 
-    <div class="flex gap-6 flex-col lg:flex-row">
-      <div class="flex-1">
+    <div class="instance-grid">
+      <div>
         <details-memory v-if="hasMemory" :instance="instance" type="heap" />
       </div>
-      <div class="flex-1">
+      <div>
         <details-memory v-if="hasMemory" :instance="instance" type="nonheap" />
       </div>
     </div>
 
-    <div class="flex gap-6 flex-col lg:flex-row">
-      <div class="flex-1">
+    <div class="instance-grid">
+      <div>
         <details-datasources v-if="hasDatasources" :instance="instance" />
       </div>
-      <div class="flex-1">
+      <div>
         <details-caches v-if="hasCaches" :instance="instance" />
       </div>
     </div>
@@ -204,3 +204,11 @@ export default {
   },
 };
 </script>
+
+<style scoped>
+@reference "../../../index.css";
+
+.instance-grid {
+  @apply grid grid-cols-1 lg:grid-cols-2 gap-4;
+}
+</style>

--- a/spring-boot-admin-server-ui/src/main/frontend/views/instances/details/instance-switcher.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/instances/details/instance-switcher.vue
@@ -107,6 +107,3 @@ export default {
   },
 };
 </script>
-
-<style scoped></style>
-@reference "../../../index.css";


### PR DESCRIPTION
Partially fixes https://github.com/codecentric/spring-boot-admin/issues/5307.

The issue still occurs, as it can be seen below:
<img width="1915" height="995" alt="image" src="https://github.com/user-attachments/assets/5c939451-37f7-4d21-affa-8473d873f719" />

but it's way less evident than the previous one shown in https://github.com/codecentric/spring-boot-admin/issues/5307#issuecomment-4408514770.

It's like, on rendering, it can't detect the width of the parent properly (by a small margin) when it's added to the DOM by opening the accordion, in constrast with when it's already in the DOM to begin with.
I was considering to try with [`resizeDelay`](https://www.chartjs.org/docs/latest/configuration/responsive.html#configuration-options) but I don't know how much it's worthy.

