### PR TITLE
fix(#5345): remove cross-env dependency and NODE_ENV=development

### DIFF
--- a/spring-boot-admin-server-ui/package-lock.json
+++ b/spring-boot-admin-server-ui/package-lock.json
@@ -75,7 +75,6 @@
         "@vitejs/plugin-vue": "6.0.6",
         "@vue/test-utils": "2.4.10",
         "axios-mock-adapter": "^2.1.0",
-        "cross-env": "^10.1.0",
         "eslint": "^10.0.0",
         "eslint-config-prettier": "^10.0.0",
         "eslint-plugin-prettier": "^5.0.0",
@@ -475,13 +474,6 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
-    },
-    "node_modules/@epic-web/invariant": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
-      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.28.0",
@@ -4667,24 +4659,6 @@
       "license": "MIT",
       "bin": {
         "cronstrue": "bin/cli.js"
-      }
-    },
-    "node_modules/cross-env": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
-      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@epic-web/invariant": "^1.0.0",
-        "cross-spawn": "^7.0.6"
-      },
-      "bin": {
-        "cross-env": "dist/bin/cross-env.js",
-        "cross-env-shell": "dist/bin/cross-env-shell.js"
-      },
-      "engines": {
-        "node": ">=20"
       }
     },
     "node_modules/cross-spawn": {

--- a/spring-boot-admin-server-ui/package.json
+++ b/spring-boot-admin-server-ui/package.json
@@ -4,8 +4,8 @@
   "description": "Spring Boot Admin UI",
   "scripts": {
     "build": "vite build --emptyOutDir --sourcemap",
-    "build:dev": "cross-env NODE_ENV=development vite build --emptyOutDir --sourcemap --mode development",
-    "build:watch": "cross-env NODE_ENV=development vite build --emptyOutDir --sourcemap --watch --mode development",
+    "build:dev": "vite build --emptyOutDir --sourcemap --mode development",
+    "build:watch": "vite build --emptyOutDir --sourcemap --watch --mode development",
     "dev": "vite",
     "test": "vitest run --silent",
     "test:watch": "vitest",
@@ -86,7 +86,6 @@
     "@vitejs/plugin-vue": "6.0.6",
     "@vue/test-utils": "2.4.10",
     "axios-mock-adapter": "^2.1.0",
-    "cross-env": "^10.1.0",
     "eslint": "^10.0.0",
     "eslint-config-prettier": "^10.0.0",
     "eslint-plugin-prettier": "^5.0.0",


### PR DESCRIPTION
This pull request removes the dependency on the `cross-env` package from the `spring-boot-admin-server-ui` project. The build scripts have been updated to no longer require `cross-env`, simplifying the project's development dependencies and scripts.

Dependency cleanup:

* Removed `cross-env` and its related dependency `@epic-web/invariant` from both `package.json` and `package-lock.json`, reducing the number of development dependencies. [[1]](diffhunk://#diff-192d74fcb1bc8b6257714c6e64af2f3a92809e93c6b3705c137216cfbc7de91bL89) [[2]](diffhunk://#diff-3f71f8436f3afb5739c6730152aae3df2c14e9379e3b417758a8153a60353b9aL78) [[3]](diffhunk://#diff-3f71f8436f3afb5739c6730152aae3df2c14e9379e3b417758a8153a60353b9aL4672-L4689) [[4]](diffhunk://#diff-3f71f8436f3afb5739c6730152aae3df2c14e9379e3b417758a8153a60353b9aL479-L485)

Build script updates:

* Updated the `build:dev` and `build:watch` scripts in `package.json` to set the build mode directly, eliminating the need for `cross-env` to set environment variables.

closes #5345 