### PR TITLE
fix(#4389): preserve status updates by their result while compacting the event log

### DIFF
--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/eventstore/ConcurrentMapEventStore.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/eventstore/ConcurrentMapEventStore.java
@@ -27,12 +27,14 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.function.BinaryOperator;
 import java.util.function.Function;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import de.codecentric.boot.admin.server.domain.events.InstanceEvent;
+import de.codecentric.boot.admin.server.domain.events.InstanceStatusChangedEvent;
 import de.codecentric.boot.admin.server.domain.values.InstanceId;
 
 import static java.util.Comparator.comparing;
@@ -117,9 +119,9 @@ public abstract class ConcurrentMapEventStore extends InstanceEventPublisher imp
 
 	private void compact(List<InstanceEvent> events) {
 		BinaryOperator<InstanceEvent> latestEvent = (e1, e2) -> (e1.getVersion() > e2.getVersion()) ? e1 : e2;
-		Map<Class<?>, Optional<InstanceEvent>> latestPerType = events.stream()
-			.collect(groupingBy(InstanceEvent::getClass, reducing(latestEvent)));
-		events.removeIf((e) -> !Objects.equals(e, latestPerType.get(e.getClass()).orElse(null)));
+		Map<DistinctEventType, Optional<InstanceEvent>> latestPerType = events.stream()
+			.collect(groupingBy(ConcurrentMapEventStore::getDistinctEventTypeFor, reducing(latestEvent)));
+		events.removeIf((e) -> !Objects.equals(e, latestPerType.get(getDistinctEventTypeFor(e)).orElse(null)));
 	}
 
 	private OptimisticLockingException createOptimisticLockException(InstanceEvent event, long lastVersion) {
@@ -129,6 +131,33 @@ public abstract class ConcurrentMapEventStore extends InstanceEventPublisher imp
 
 	protected static long getLastVersion(List<InstanceEvent> events) {
 		return events.isEmpty() ? -1 : events.get(events.size() - 1).getVersion();
+	}
+
+	private static DistinctEventType getDistinctEventTypeFor(InstanceEvent event) {
+		return new DistinctEventType(event.getType(),
+				(event instanceof InstanceStatusChangedEvent s) ? s.getStatusInfo().getStatus() : null);
+	}
+
+	/**
+	 * Internal class to distinguish events not only by their type but also by an
+	 * additional optional discriminator. If no additional distinction is necessary apart
+	 * the type itself, the {@code discriminator} can be {@code null}.
+	 * <p>
+	 * The existing use case is to keep, during compaction, at least one
+	 * {@link InstanceStatusChangedEvent} for each status type (UP, DOWN, OUT_OF_SERVICE,
+	 * UNKNOWN, RESTRICTED, OFFLINE) while keeping only the latest entry for all the other
+	 * event types.
+	 * <p>
+	 * For this reason, while for the {@link InstanceStatusChangedEvent} its status value
+	 * will be used as discriminator, for all the other types {@code null} will be used
+	 * instead.
+	 *
+	 * @see ConcurrentMapEventStore#getDistinctEventTypeFor(InstanceEvent)
+	 * @param type the type of the event
+	 * @param discriminator the tiebreaker to use to discriminate multiple events with the
+	 * same type
+	 */
+	private record DistinctEventType(String type, @Nullable Object discriminator) {
 	}
 
 }

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/eventstore/AbstractEventStoreTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/eventstore/AbstractEventStoreTest.java
@@ -33,8 +33,10 @@ import reactor.test.StepVerifier;
 
 import de.codecentric.boot.admin.server.domain.events.InstanceDeregisteredEvent;
 import de.codecentric.boot.admin.server.domain.events.InstanceEvent;
+import de.codecentric.boot.admin.server.domain.events.InstanceInfoChangedEvent;
 import de.codecentric.boot.admin.server.domain.events.InstanceRegisteredEvent;
 import de.codecentric.boot.admin.server.domain.events.InstanceStatusChangedEvent;
+import de.codecentric.boot.admin.server.domain.values.Info;
 import de.codecentric.boot.admin.server.domain.values.InstanceId;
 import de.codecentric.boot.admin.server.domain.values.Registration;
 import de.codecentric.boot.admin.server.domain.values.StatusInfo;
@@ -91,15 +93,20 @@ public abstract class AbstractEventStoreTest {
 
 	@Test
 	public void should_shorten_log_on_exceeded_capacity() {
-		InstanceEventStore store = createStore(2);
+		InstanceEventStore store = createStore(4);
 
 		InstanceEvent event1 = new InstanceRegisteredEvent(id, 0L, registration);
-		InstanceEvent event2 = new InstanceStatusChangedEvent(id, 1L, StatusInfo.ofDown());
-		InstanceEvent event3 = new InstanceStatusChangedEvent(id, 2L, StatusInfo.ofUp());
+		// It will be dropped since there is a newer info event
+		InstanceEvent event2 = new InstanceInfoChangedEvent(id, 1L, Info.empty());
+		// It will be dropped since there is a newer status event with status DOWN
+		InstanceEvent event3 = new InstanceStatusChangedEvent(id, 3L, StatusInfo.ofDown());
+		InstanceEvent event4 = new InstanceStatusChangedEvent(id, 4L, StatusInfo.ofUp());
+		InstanceEvent event5 = new InstanceInfoChangedEvent(id, 5L, Info.empty());
+		InstanceEvent event6 = new InstanceStatusChangedEvent(id, 6L, StatusInfo.ofDown());
 
-		StepVerifier.create(store.append(asList(event1, event2, event3))).verifyComplete();
+		StepVerifier.create(store.append(asList(event1, event2, event3, event4, event5, event6))).verifyComplete();
 
-		StepVerifier.create(store.findAll()).expectNext(event1, event3).verifyComplete();
+		StepVerifier.create(store.findAll()).expectNext(event1, event4, event5, event6).verifyComplete();
 	}
 
 	@Test


### PR DESCRIPTION
Fixes https://github.com/codecentric/spring-boot-admin/issues/4389 by making sure that, for status updates, at least one status update event per result type is preserved so the journal view can indeed be used to investigate what's going on when notifications are received because an instance went, for example, from UP to DOWN.

In the previous implementation, on compaction, the 2 events would be reduced only to the DOWN one preventing therefore to trace down the full status of the instance.