### PR TITLE
Restore HttpExchanges chart time selection

### DIFF
--- a/spring-boot-admin-server-ui/src/main/frontend/views/instances/httpexchanges/exchanges-chart.spec.ts
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/instances/httpexchanges/exchanges-chart.spec.ts
@@ -1,0 +1,231 @@
+import { waitFor } from '@testing-library/vue';
+import { Chart } from 'chart.js';
+import moment from 'moment';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { render } from '@/test-utils';
+import { Exchange } from '@/views/instances/httpexchanges/Exchange';
+import ExchangesChart from '@/views/instances/httpexchanges/exchanges-chart.vue';
+
+vi.mock('chartjs-adapter-moment', () => ({}));
+
+HTMLCanvasElement.prototype.getContext = vi.fn(
+  () => ({}),
+) as unknown as typeof HTMLCanvasElement.prototype.getContext;
+
+const makeExchange = (isoTimestamp: string, status = 200) =>
+  new Exchange({
+    timestamp: isoTimestamp,
+    request: { uri: '/api/test', method: 'GET', headers: {} },
+    response: { status, headers: {} },
+  });
+
+describe('ExchangesChart – time range selection', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(Chart.prototype, 'update').mockImplementation(() => {});
+    vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
+      left: 0,
+      right: 500,
+      top: 0,
+      bottom: 200,
+      width: 500,
+      height: 200,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    } as DOMRect);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const renderChart = (exchanges: Exchange[] = []) => {
+    const result = render(ExchangesChart, { props: { exchanges } });
+    const chartEl = result.container.querySelector(
+      '.exchange-chart',
+    ) as HTMLElement;
+    const vm = (chartEl as any)?.__vueParentComponent?.proxy;
+    if (vm?.chart) {
+      vm.chart.chartArea = { left: 0, right: 500 };
+      vm.chart.scales = { x: { getPixelForValue: () => 0 } };
+    }
+    const fire = (type: string, clientX?: number) =>
+      chartEl.dispatchEvent(new MouseEvent(type, { clientX, bubbles: true }));
+    return { ...result, chartEl, vm, fire };
+  };
+
+  describe('selection overlay', () => {
+    it('is not shown initially', () => {
+      const { container } = renderChart();
+
+      expect(container.querySelector('.exchange-chart__selection')).toBeNull();
+    });
+
+    it('appears while the mouse is dragged', async () => {
+      const { fire, container } = renderChart();
+
+      fire('mousedown', 100);
+      fire('mousemove', 200);
+
+      await waitFor(() =>
+        expect(
+          container.querySelector('.exchange-chart__selection'),
+        ).toBeInTheDocument(),
+      );
+    });
+
+    it('disappears after mouseup', async () => {
+      const { fire, container } = renderChart();
+      fire('mousedown', 100);
+      fire('mousemove', 200);
+      await waitFor(() =>
+        expect(
+          container.querySelector('.exchange-chart__selection'),
+        ).toBeInTheDocument(),
+      );
+
+      fire('mouseup');
+
+      await waitFor(() =>
+        expect(
+          container.querySelector('.exchange-chart__selection'),
+        ).toBeNull(),
+      );
+    });
+
+    it('disappears when the mouse leaves the chart', async () => {
+      const { fire, container } = renderChart();
+      fire('mousedown', 100);
+      fire('mousemove', 200);
+      await waitFor(() =>
+        expect(
+          container.querySelector('.exchange-chart__selection'),
+        ).toBeInTheDocument(),
+      );
+
+      fire('mouseleave');
+
+      await waitFor(() =>
+        expect(
+          container.querySelector('.exchange-chart__selection'),
+        ).toBeNull(),
+      );
+    });
+
+    it('has correct position and width for a left-to-right drag', async () => {
+      const { fire, container } = renderChart();
+
+      fire('mousedown', 100);
+      fire('mousemove', 300);
+
+      await waitFor(() => {
+        const overlay = container.querySelector<HTMLElement>(
+          '.exchange-chart__selection',
+        );
+        expect(overlay?.style.left).toBe('100px');
+        expect(overlay?.style.width).toBe('200px');
+      });
+    });
+
+    it('has correct position and width for a right-to-left drag', async () => {
+      const { fire, container } = renderChart();
+
+      fire('mousedown', 300);
+      fire('mousemove', 100);
+
+      await waitFor(() => {
+        const overlay = container.querySelector<HTMLElement>(
+          '.exchange-chart__selection',
+        );
+        expect(overlay?.style.left).toBe('100px');
+        expect(overlay?.style.width).toBe('200px');
+      });
+    });
+  });
+
+  describe('select event', () => {
+    it('emits null when clicking without dragging', async () => {
+      const { emitted, fire } = renderChart();
+
+      fire('mousedown', 150);
+      fire('mouseup');
+
+      await waitFor(() => expect(emitted().select).toBeTruthy());
+      expect(emitted().select[0]).toEqual([null]);
+    });
+
+    it('emits null when drag distance is less than 5 pixels', async () => {
+      const { emitted, fire } = renderChart();
+
+      fire('mousedown', 100);
+      fire('mousemove', 103);
+      fire('mouseup');
+
+      await waitFor(() => expect(emitted().select).toBeTruthy());
+      expect(emitted().select[0]).toEqual([null]);
+    });
+
+    it('emits null when no exchanges fall within the selected pixel range', async () => {
+      const exchanges = [makeExchange('2024-01-01T10:00:00.050Z')];
+      const { emitted, fire, vm } = renderChart(exchanges);
+      if (vm?.chart) vm.chart.scales.x.getPixelForValue = () => 100;
+
+      fire('mousedown', 300);
+      fire('mousemove', 490);
+      fire('mouseup');
+
+      await waitFor(() => expect(emitted().select).toBeTruthy());
+      expect(emitted().select[0]).toEqual([null]);
+    });
+
+    it('emits [min, max] moments for exchanges within the selected range', async () => {
+      const t1 = '2024-01-01T10:00:00.050Z';
+      const t2 = '2024-01-01T10:00:00.100Z';
+      const t3 = '2024-01-01T10:00:00.200Z';
+      const exchanges = [makeExchange(t3), makeExchange(t2), makeExchange(t1)];
+      const { emitted, fire, vm } = renderChart(exchanges);
+      const pixelMap: Record<string, number> = {
+        [moment(t1).toISOString()]: 50,
+        [moment(t2).toISOString()]: 100,
+        [moment(t3).toISOString()]: 200,
+      };
+      if (vm?.chart) {
+        vm.chart.scales.x.getPixelForValue = (ts: moment.Moment) =>
+          pixelMap[ts.toISOString()] ?? 0;
+      }
+
+      fire('mousedown', 10);
+      fire('mousemove', 400);
+      fire('mouseup');
+
+      await waitFor(() => expect(emitted().select).toBeTruthy());
+      const [range] = emitted().select[0] as [moment.Moment[]];
+      expect(range).toHaveLength(2);
+      expect(range[0].isSame(moment(t1))).toBe(true);
+      expect(range[1].isSame(moment(t3))).toBe(true);
+    });
+
+    it('emits [min, max] regardless of drag direction (right-to-left)', async () => {
+      const t1 = '2024-01-01T10:00:00.050Z';
+      const t2 = '2024-01-01T10:00:00.200Z';
+      const exchanges = [makeExchange(t2), makeExchange(t1)];
+      const { emitted, fire, vm } = renderChart(exchanges);
+      if (vm?.chart) {
+        vm.chart.scales.x.getPixelForValue = (ts: moment.Moment) =>
+          ts.isSame(moment(t1)) ? 50 : 150;
+      }
+
+      fire('mousedown', 400);
+      fire('mousemove', 10);
+      fire('mouseup');
+
+      await waitFor(() => expect(emitted().select).toBeTruthy());
+      const [range] = emitted().select[0] as [moment.Moment[]];
+      expect(range).toHaveLength(2);
+      expect(range[0].isSame(moment(t1))).toBe(true);
+      expect(range[1].isSame(moment(t2))).toBe(true);
+    });
+  });
+});

--- a/spring-boot-admin-server-ui/src/main/frontend/views/instances/httpexchanges/exchanges-chart.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/instances/httpexchanges/exchanges-chart.vue
@@ -15,8 +15,19 @@
   -->
 
 <template>
-  <div class="exchange-chart">
+  <div
+    class="exchange-chart"
+    @mousedown="startSelection"
+    @mousemove="updateSelection"
+    @mouseup="finishSelection"
+    @mouseleave="cancelSelection"
+  >
     <canvas ref="chartCanvas" />
+    <div
+      v-if="selectionStyle"
+      class="exchange-chart__selection"
+      :style="selectionStyle"
+    />
   </div>
 </template>
 
@@ -32,6 +43,7 @@ import {
 } from 'chart.js';
 import 'chartjs-adapter-moment';
 import { parse } from 'iso8601-duration';
+import moment from 'moment';
 import { markRaw } from 'vue';
 
 import { toMilliseconds } from '@/utils/iso8601-duration';
@@ -54,11 +66,27 @@ export default {
       default: () => [],
     },
   },
+  emits: ['select'],
   data: () => ({
     chart: null,
     cachedChartData: [],
+    selectionStartX: null,
+    selectionEndX: null,
   }),
   computed: {
+    selectionStyle() {
+      if (this.selectionStartX === null || this.selectionEndX === null) {
+        return null;
+      }
+
+      const left = Math.min(this.selectionStartX, this.selectionEndX);
+      const width = Math.abs(this.selectionEndX - this.selectionStartX);
+
+      return {
+        left: `${left}px`,
+        width: `${width}px`,
+      };
+    },
     chartData() {
       if (this.exchanges.length <= 0) {
         return [];
@@ -131,6 +159,78 @@ export default {
     }
   },
   methods: {
+    getChartPixel(event) {
+      if (!this.chart) {
+        return null;
+      }
+
+      const canvas = this.$refs.chartCanvas;
+      const rect = canvas.getBoundingClientRect();
+      const chartArea = this.chart.chartArea;
+      const x = event.clientX - rect.left;
+
+      return Math.max(chartArea.left, Math.min(chartArea.right, x));
+    },
+
+    startSelection(event) {
+      const x = this.getChartPixel(event);
+
+      if (x === null) {
+        return;
+      }
+
+      this.selectionStartX = x;
+      this.selectionEndX = x;
+    },
+
+    updateSelection(event) {
+      if (this.selectionStartX === null) {
+        return;
+      }
+
+      this.selectionEndX = this.getChartPixel(event);
+    },
+
+    finishSelection() {
+      if (this.selectionStartX === null || this.selectionEndX === null) {
+        return;
+      }
+
+      const startPixel = Math.min(this.selectionStartX, this.selectionEndX);
+      const endPixel = Math.max(this.selectionStartX, this.selectionEndX);
+
+      this.selectionStartX = null;
+      this.selectionEndX = null;
+
+      if (endPixel - startPixel < 5) {
+        this.$emit('select', null);
+        return;
+      }
+
+      const xScale = this.chart.scales.x;
+
+      const selectedExchanges = this.exchanges.filter((exchange) => {
+        const exchangePixel = xScale.getPixelForValue(exchange.timestamp);
+
+        return exchangePixel >= startPixel && exchangePixel <= endPixel;
+      });
+
+      if (selectedExchanges.length === 0) {
+        this.$emit('select', null);
+        return;
+      }
+
+      const timestamps = selectedExchanges.map(
+        (exchange) => exchange.timestamp,
+      );
+
+      this.$emit('select', [moment.min(timestamps), moment.max(timestamps)]);
+    },
+
+    cancelSelection() {
+      this.selectionStartX = null;
+      this.selectionEndX = null;
+    },
     initChart() {
       const ctx = this.$refs.chartCanvas.getContext('2d');
       const chartDataRef = this.cachedChartData;
@@ -245,10 +345,17 @@ export default {
 @reference "../../../index.css";
 .exchange-chart {
   height: 200px;
+  position: relative;
+  user-select: none;
   width: 100%;
 }
 
-.exchange-chart canvas {
-  max-height: 200px;
+.exchange-chart__selection {
+  background: rgba(50, 115, 220, 0.2);
+  border: 1px solid rgba(50, 115, 220, 0.6);
+  bottom: 0;
+  pointer-events: none;
+  position: absolute;
+  top: 0;
 }
 </style>

--- a/spring-boot-admin-server-ui/src/main/frontend/views/instances/httpexchanges/index.vue
+++ b/spring-boot-admin-server-ui/src/main/frontend/views/instances/httpexchanges/index.vue
@@ -90,7 +90,11 @@
     </template>
 
     <sba-panel>
-      <sba-exchanges-chart :exchanges="listedExchanges" class="mb-6" />
+      <sba-exchanges-chart
+        :exchanges="visibleExchanges"
+        class="mb-6"
+        @select="selectTimeRange"
+      />
     </sba-panel>
 
     <sba-panel seamless>
@@ -156,14 +160,20 @@ export default {
     filteredExchanges() {
       return this.filterExchanges(this.exchanges);
     },
+
+    visibleExchanges() {
+      return this.filterExchanges(this.exchanges.slice(this.listOffset));
+    },
+
     listedExchanges() {
-      const exchanges = this.filterExchanges(
-        this.exchanges.slice(this.listOffset),
-      );
+      const exchanges = this.visibleExchanges;
+
       if (!this.selection) {
         return exchanges;
       }
+
       const [start, end] = this.selection;
+
       return exchanges.filter(
         (exchange) =>
           !exchange.timestamp.isBefore(start) &&
@@ -176,6 +186,7 @@ export default {
         : moment(0);
     },
   },
+
   watch: {
     limit: debounce(function (value) {
       if (this.exchanges.length > value) {
@@ -189,6 +200,9 @@ export default {
     },
   },
   methods: {
+    selectTimeRange(selection) {
+      this.selection = selection;
+    },
     showNewExchanges() {
       this.listOffset = 0;
     },


### PR DESCRIPTION
Fixes #5212.

Restores chart-based time-window selection in the HttpExchanges view.

The parent view already had selection state and filtering logic, but the chart no longer emitted a selected time range back to the parent. This change wires drag selection in the chart back to the existing list filtering behavior.

Tests run:
- npm run lint
- npx vitest run --silent=true src/main/frontend/views/instances/httpexchanges
- npm run build