### PR TITLE
fix(#5452): add optional ssrf check mechanism

### DIFF
--- a/.github/workflows/build-feature.yml
+++ b/.github/workflows/build-feature.yml
@@ -8,6 +8,10 @@ on:
       - 2.*
   pull_request:
 
+concurrency:
+  group: build-feature-${{ github.event.pull_request.head.ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   build:
     strategy:
@@ -15,6 +19,7 @@ jobs:
         os: [ubuntu-latest]
 
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     steps:
 
       - name: free disk space

--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -15,6 +15,7 @@ jobs:
         os: [ ubuntu-latest ]
 
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
 
@@ -56,6 +57,7 @@ jobs:
   publish-snapshot:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v7

--- a/spring-boot-admin-docs/src/site/docs/05-security/30-csrf-protection.md
+++ b/spring-boot-admin-docs/src/site/docs/05-security/30-csrf-protection.md
@@ -758,4 +758,5 @@ public class SecurityConfig {
 
 - [Server Authentication](./10-server-authentication.md) - Configure Spring Security
 - [Actuator Security](./20-actuator-security.md) - Secure client endpoints
+- [SSRF Protection](./40-ssrf-protection.md) - Block SSRF attacks via the instance registration endpoint
 - [Spring Security CSRF Documentation](https://docs.spring.io/spring-security/reference/servlet/exploits/csrf.html)

--- a/spring-boot-admin-docs/src/site/docs/05-security/40-ssrf-protection.md
+++ b/spring-boot-admin-docs/src/site/docs/05-security/40-ssrf-protection.md
@@ -1,0 +1,233 @@
+---
+sidebar_position: 40
+sidebar_custom_props:
+  icon: 'shield'
+---
+
+# SSRF Protection
+
+Spring Boot Admin Server includes opt-in protection against Server-Side Request Forgery (SSRF) attacks that can be
+triggered through the instance registration API.
+
+## The Risk
+
+When a Spring Boot application registers with the Admin Server, it sends a `POST /instances` request containing
+`healthUrl`, `managementUrl`, and `serviceUrl`. The Admin Server immediately begins making outbound HTTP requests to
+those URLs to poll health status and discover actuator endpoints. It also exposes a proxy at
+`/instances/{id}/actuator/**` that forwards requests verbatim to the registered management URL.
+
+Without authentication or URL validation on `POST /instances`, an attacker can:
+
+1. Register a fake instance pointing to `http://169.254.169.254/latest/meta-data/` (AWS IMDSv1)
+2. The Admin Server polls the metadata endpoint automatically and stores the response
+3. The attacker retrieves the response — including IAM credentials — through the actuator proxy
+
+This applies to loopback addresses, RFC 1918 private ranges, and any internal service reachable from the server's
+network, not just cloud metadata endpoints.
+
+:::warning
+SSRF protection is **disabled by default** to avoid breaking existing deployments where the Admin Server legitimately
+communicates with services on private IP ranges. Enable it explicitly and configure an allowlist for any intranet
+services that need to register.
+:::
+
+---
+
+## Enabling SSRF Protection
+
+Add the following to your `application.yml`:
+
+```yaml
+spring:
+  boot:
+    admin:
+      ssrf-protection:
+        enabled: true
+```
+
+When enabled, all URLs submitted during instance registration (`healthUrl`, `managementUrl`, `serviceUrl`) are
+validated before the instance is stored. The proxy also re-validates the resolved target URL before each outbound
+request.
+
+---
+
+## What Gets Blocked
+
+When protection is enabled, the following are rejected by default:
+
+| Category | Examples |
+|---|---|
+| Loopback | `localhost`, `127.0.0.1`, `127.x.x.x`, `::1` |
+| Link-local (cloud metadata) | `169.254.0.0/16` — includes AWS IMDSv1 (`169.254.169.254`), GCP, Azure |
+| RFC 1918 Class A | `10.0.0.0/8` |
+| RFC 1918 Class B | `172.16.0.0/12` (172.16.x – 172.31.x) |
+| RFC 1918 Class C | `192.168.0.0/16` |
+| IPv6 link-local | `fe80::/10` |
+| IPv6 unique-local | `fc00::/7` (fc and fd prefixes) |
+| IPv4-mapped IPv6 | `::ffff:` prefix embedding a private IPv4 |
+| Unspecified address | `0.0.0.0` |
+| Disallowed schemes | Anything other than `http` and `https` (e.g. `file://`, `ftp://`) |
+
+Registration attempts targeting any of these return `400 Bad Request`. Proxy requests that resolve to a blocked address
+return `403 Forbidden`.
+
+:::note
+Hostname-to-IP resolution is **not** performed during validation. Only the literal hostname string from the URL is
+checked. An attacker who controls a public DNS record pointing to a private IP (DNS rebinding) is not blocked by this
+validator alone. Use IMDSv2 on AWS or network-level egress controls as additional layers of defence.
+:::
+
+---
+
+## Allowing Internal Services
+
+If your Admin Server legitimately needs to reach services on private addresses — for example in an on-premises or
+Kubernetes cluster deployment — add those hosts to the allowlist. An allowlisted host bypasses all block checks.
+
+### Exact host match
+
+```yaml
+spring:
+  boot:
+    admin:
+      ssrf-protection:
+        enabled: true
+        allowed-hosts:
+          - 192.168.1.100
+          - monitoring-service.internal
+```
+
+### Glob-style suffix pattern
+
+Use `*.suffix` to allow an entire subdomain:
+
+```yaml
+spring:
+  boot:
+    admin:
+      ssrf-protection:
+        enabled: true
+        allowed-hosts:
+          - "*.svc.cluster.local"   # all Kubernetes services
+          - "*.internal.corp"
+```
+
+The glob `*.svc.cluster.local` matches `my-service.svc.cluster.local` but not `svc.cluster.local` itself. Matching
+is case-insensitive.
+
+---
+
+## Blocking Additional Hosts
+
+To block hostnames beyond the built-in private ranges — for example internal domains that should never register — add
+regex patterns to `blocked-host-patterns`:
+
+```yaml
+spring:
+  boot:
+    admin:
+      ssrf-protection:
+        enabled: true
+        blocked-host-patterns:
+          - ".*\\.internal\\.corp$"
+          - "metadata\\.google\\.internal"
+```
+
+Patterns are matched against the raw hostname using `java.util.regex.Pattern`. Invalid patterns are logged as warnings
+and skipped.
+
+:::note
+The allowlist takes precedence over blocked patterns. A host matching both an `allowed-hosts` entry and a
+`blocked-host-patterns` entry is **allowed**.
+:::
+
+---
+
+## Allowing Additional Schemes
+
+By default only `http` and `https` are permitted. To add a custom scheme:
+
+```yaml
+spring:
+  boot:
+    admin:
+      ssrf-protection:
+        enabled: true
+        allowed-schemes:
+          - http
+          - https
+          - grpc
+```
+
+---
+
+## Configuration Reference
+
+| Property | Type | Default | Description |
+|---|---|---|---|
+| `spring.boot.admin.ssrf-protection.enabled` | `boolean` | `false` | Enable SSRF URL validation |
+| `spring.boot.admin.ssrf-protection.allowed-schemes` | `Set<String>` | `http, https` | URL schemes that are permitted |
+| `spring.boot.admin.ssrf-protection.allowed-hosts` | `List<String>` | _(empty)_ | Hosts exempt from all block checks. Supports exact names and `*.suffix` glob patterns |
+| `spring.boot.admin.ssrf-protection.blocked-host-patterns` | `List<String>` | _(empty)_ | Additional Java regex patterns matched against the raw hostname |
+
+---
+
+## Providing a Custom Validator
+
+Override the default `SsrfUrlValidator` bean to implement custom logic — for example, DNS resolution or CIDR matching:
+
+```java
+import de.codecentric.boot.admin.server.utils.SsrfUrlValidator;
+import de.codecentric.boot.admin.server.config.AdminServerProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class CustomSsrfConfig {
+
+    @Bean
+    public SsrfUrlValidator ssrfUrlValidator(AdminServerProperties properties) {
+        AdminServerProperties.SsrfProtectionProperties ssrfProps =
+            properties.getSsrfProtection();
+        // Wrap or extend the default validator
+        SsrfUrlValidator defaultValidator = new SsrfUrlValidator(ssrfProps);
+        return url -> {
+            defaultValidator.validate(url);
+            // Add custom checks here
+        };
+    }
+}
+```
+
+---
+
+## Dual Validation
+
+SSRF protection runs at two points:
+
+1. **Registration (`POST /instances`)** — `healthUrl`, `managementUrl`, and `serviceUrl` are validated before the
+   instance is stored. Invalid registrations are rejected with `400 Bad Request`.
+
+2. **Proxy (`/instances/{id}/actuator/**`)** — The resolved target URL is re-validated before each outbound request.
+   This provides defence-in-depth against scenarios where an endpoint URL is assembled dynamically after registration.
+   Blocked proxy requests return `403 Forbidden`.
+
+---
+
+## Additional Hardening
+
+SSRF protection alone is not sufficient for a publicly accessible Admin Server. Combine it with:
+
+- **Authentication on `POST /instances`** — The most effective mitigation. See [Server Authentication](./10-server-authentication.md).
+- **AWS IMDSv2** — Require a `PUT` request with a TTL header to obtain a metadata token, which the Admin Server cannot
+  provide without explicit support.
+- **Network egress controls** — Firewall rules or security groups that prevent the Admin Server's outbound traffic from
+  reaching metadata endpoints and internal services.
+- **VPC/private network isolation** — Run the Admin Server in a subnet that has no route to sensitive internal services.
+
+---
+
+## See Also
+
+- [Server Authentication](./10-server-authentication.md) - Require authentication before instance registration
+- [CSRF Protection](./30-csrf-protection.md) - Protect the registration endpoint against cross-origin forged requests

--- a/spring-boot-admin-docs/src/site/docs/05-security/40-ssrf-protection.md
+++ b/spring-boot-admin-docs/src/site/docs/05-security/40-ssrf-protection.md
@@ -86,8 +86,10 @@ Kubernetes cluster deployment — you have two options:
 
 ### Option 1: Configuration properties (recommended)
 
-Add CIDR ranges to `allowed-cidrs`. Both IPv4 and IPv6 CIDR notation are supported. These ranges are ORed with the
-default `externalAddresses()` filter, so public addresses always remain reachable.
+Add entries to `allowed-cidrs`. Both individual IP addresses and CIDR subnet masks are supported for IPv4 and IPv6.
+These ranges are ORed with the default `externalAddresses()` filter, so public addresses always remain reachable.
+
+**Single host** (exact IP address):
 
 ```yaml
 spring:
@@ -96,16 +98,34 @@ spring:
       ssrf-protection:
         enabled: true
         allowed-cidrs:
-          - "192.168.1.0/24"      # single subnet
-          - "10.0.0.0/8"         # entire RFC 1918 Class A
-          - "fd00::/8"           # IPv6 unique-local range
+          - "192.168.1.100"      # single host, equivalent to 192.168.1.100/32
 ```
 
-Single-host entries (equivalent to `/32` or `/128`) are also supported:
+**Subnet** (CIDR mask):
 
 ```yaml
+spring:
+  boot:
+    admin:
+      ssrf-protection:
+        enabled: true
         allowed-cidrs:
-          - "192.168.1.100"      # treated as a /32 host entry
+          - "192.168.1.0/24"     # all hosts in 192.168.1.x
+```
+
+**Multiple ranges** (subnets, whole classes, IPv6):
+
+```yaml
+spring:
+  boot:
+    admin:
+      ssrf-protection:
+        enabled: true
+        allowed-cidrs:
+          - "192.168.1.0/24"     # single subnet
+          - "10.0.0.0/8"         # entire RFC 1918 Class A
+          - "172.16.0.0/12"      # entire RFC 1918 Class B
+          - "fd00::/8"           # IPv6 unique-local range
 ```
 
 ### Option 2: Custom `InetAddressFilter` bean

--- a/spring-boot-admin-docs/src/site/docs/05-security/40-ssrf-protection.md
+++ b/spring-boot-admin-docs/src/site/docs/05-security/40-ssrf-protection.md
@@ -27,8 +27,8 @@ network, not just cloud metadata endpoints.
 
 :::warning
 SSRF protection is **disabled by default** to avoid breaking existing deployments where the Admin Server legitimately
-communicates with services on private IP ranges. Enable it explicitly and configure an allowlist for any intranet
-services that need to register.
+communicates with services on private IP ranges. Enable it explicitly and provide a custom `InetAddressFilter` bean
+for any intranet services that need to register.
 :::
 
 ---
@@ -53,7 +53,9 @@ request.
 
 ## What Gets Blocked
 
-When protection is enabled, the following are rejected by default:
+When protection is enabled, address filtering is delegated to Spring Boot's
+[`InetAddressFilter`](https://docs.spring.io/spring-boot/4.1/api/java/org/springframework/boot/http/client/InetAddressFilter.html).
+The default filter (`InetAddressFilter.externalAddresses()`) blocks all non-external addresses, including:
 
 | Category | Examples |
 |---|---|
@@ -64,7 +66,6 @@ When protection is enabled, the following are rejected by default:
 | RFC 1918 Class C | `192.168.0.0/16` |
 | IPv6 link-local | `fe80::/10` |
 | IPv6 unique-local | `fc00::/7` (fc and fd prefixes) |
-| IPv4-mapped IPv6 | `::ffff:` prefix embedding a private IPv4 |
 | Unspecified address | `0.0.0.0` |
 | Disallowed schemes | Anything other than `http` and `https` (e.g. `file://`, `ftp://`) |
 
@@ -72,9 +73,8 @@ Registration attempts targeting any of these return `400 Bad Request`. Proxy req
 return `403 Forbidden`.
 
 :::note
-Hostname-to-IP resolution is **not** performed during validation. Only the literal hostname string from the URL is
-checked. An attacker who controls a public DNS record pointing to a private IP (DNS rebinding) is not blocked by this
-validator alone. Use IMDSv2 on AWS or network-level egress controls as additional layers of defence.
+Hostnames are **resolved via DNS** during validation. This means a public hostname that resolves to a private IP
+(DNS rebinding) is also blocked — not just hostnames that literally look like private addresses.
 :::
 
 ---
@@ -82,24 +82,12 @@ validator alone. Use IMDSv2 on AWS or network-level egress controls as additiona
 ## Allowing Internal Services
 
 If your Admin Server legitimately needs to reach services on private addresses — for example in an on-premises or
-Kubernetes cluster deployment — add those hosts to the allowlist. An allowlisted host bypasses all block checks.
+Kubernetes cluster deployment — you have two options:
 
-### Exact host match
+### Option 1: Configuration properties (recommended)
 
-```yaml
-spring:
-  boot:
-    admin:
-      ssrf-protection:
-        enabled: true
-        allowed-hosts:
-          - 192.168.1.100
-          - monitoring-service.internal
-```
-
-### Glob-style suffix pattern
-
-Use `*.suffix` to allow an entire subdomain:
+Add CIDR ranges to `allowed-cidrs`. Both IPv4 and IPv6 CIDR notation are supported. These ranges are ORed with the
+default `externalAddresses()` filter, so public addresses always remain reachable.
 
 ```yaml
 spring:
@@ -107,39 +95,44 @@ spring:
     admin:
       ssrf-protection:
         enabled: true
-        allowed-hosts:
-          - "*.svc.cluster.local"   # all Kubernetes services
-          - "*.internal.corp"
+        allowed-cidrs:
+          - "192.168.1.0/24"      # single subnet
+          - "10.0.0.0/8"         # entire RFC 1918 Class A
+          - "fd00::/8"           # IPv6 unique-local range
 ```
 
-The glob `*.svc.cluster.local` matches `my-service.svc.cluster.local` but not `svc.cluster.local` itself. Matching
-is case-insensitive.
-
----
-
-## Blocking Additional Hosts
-
-To block hostnames beyond the built-in private ranges — for example internal domains that should never register — add
-regex patterns to `blocked-host-patterns`:
+Single-host entries (equivalent to `/32` or `/128`) are also supported:
 
 ```yaml
-spring:
-  boot:
-    admin:
-      ssrf-protection:
-        enabled: true
-        blocked-host-patterns:
-          - ".*\\.internal\\.corp$"
-          - "metadata\\.google\\.internal"
+        allowed-cidrs:
+          - "192.168.1.100"      # treated as a /32 host entry
 ```
 
-Patterns are matched against the raw hostname using `java.util.regex.Pattern`. Invalid patterns are logged as warnings
-and skipped.
+### Option 2: Custom `InetAddressFilter` bean
 
-:::note
-The allowlist takes precedence over blocked patterns. A host matching both an `allowed-hosts` entry and a
-`blocked-host-patterns` entry is **allowed**.
-:::
+For more control, expose an `InetAddressFilter` bean. It replaces the auto-configured filter entirely.
+
+```java
+import org.springframework.boot.http.client.InetAddressFilter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SsrfConfig {
+
+    @Bean
+    public InetAddressFilter ssrfInetAddressFilter() {
+        return InetAddressFilter.externalAddresses()
+            .or("10.0.0.0/8")       // pod CIDR
+            .or("172.16.0.0/12");   // service CIDR
+    }
+}
+```
+
+`InetAddressFilter` supports CIDR notation for both IPv4 and IPv6, and can be composed with `.or()`, `.and()`, and
+`.andNot()`. See the
+[Spring Boot reference documentation](https://docs.spring.io/spring-boot/4.1/reference/io/rest-client.html#io.rest-client.global-configuration.inetaddress-filtering)
+for the full API.
 
 ---
 
@@ -167,18 +160,20 @@ spring:
 |---|---|---|---|
 | `spring.boot.admin.ssrf-protection.enabled` | `boolean` | `false` | Enable SSRF URL validation |
 | `spring.boot.admin.ssrf-protection.allowed-schemes` | `Set<String>` | `http, https` | URL schemes that are permitted |
-| `spring.boot.admin.ssrf-protection.allowed-hosts` | `List<String>` | _(empty)_ | Hosts exempt from all block checks. Supports exact names and `*.suffix` glob patterns |
-| `spring.boot.admin.ssrf-protection.blocked-host-patterns` | `List<String>` | _(empty)_ | Additional Java regex patterns matched against the raw hostname |
+| `spring.boot.admin.ssrf-protection.allowed-cidrs` | `List<String>` | _(empty)_ | IP addresses or CIDR ranges (IPv4 and IPv6) that are permitted in addition to public addresses. Examples: `192.168.1.0/24`, `10.0.0.0/8`, `fd00::/8` |
+
+For finer-grained control over address filtering, expose a custom `InetAddressFilter` bean (see [Allowing Internal Services](#allowing-internal-services)).
 
 ---
 
 ## Providing a Custom Validator
 
-Override the default `SsrfUrlValidator` bean to implement custom logic — for example, DNS resolution or CIDR matching:
+Override the entire `SsrfUrlValidator` bean to implement fully custom logic:
 
 ```java
 import de.codecentric.boot.admin.server.utils.SsrfUrlValidator;
 import de.codecentric.boot.admin.server.config.AdminServerProperties;
+import org.springframework.boot.http.client.InetAddressFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -186,15 +181,9 @@ import org.springframework.context.annotation.Configuration;
 public class CustomSsrfConfig {
 
     @Bean
-    public SsrfUrlValidator ssrfUrlValidator(AdminServerProperties properties) {
-        AdminServerProperties.SsrfProtectionProperties ssrfProps =
-            properties.getSsrfProtection();
-        // Wrap or extend the default validator
-        SsrfUrlValidator defaultValidator = new SsrfUrlValidator(ssrfProps);
-        return url -> {
-            defaultValidator.validate(url);
-            // Add custom checks here
-        };
+    public SsrfUrlValidator ssrfUrlValidator(AdminServerProperties properties,
+                                             InetAddressFilter ssrfInetAddressFilter) {
+        return new SsrfUrlValidator(properties.getSsrfProtection(), ssrfInetAddressFilter);
     }
 }
 ```

--- a/spring-boot-admin-docs/src/site/docs/05-security/index.md
+++ b/spring-boot-admin-docs/src/site/docs/05-security/index.md
@@ -52,7 +52,18 @@ Configure CSRF tokens for Admin UI while allowing client registration:
 
 **See**: [CSRF Protection](./30-csrf-protection.md)
 
-### 4. Mutual TLS (Optional)
+### 4. SSRF Protection
+
+Prevent Server-Side Request Forgery via the instance registration API:
+
+- **IP Range Blocking**: Reject private/internal addresses in registered URLs
+- **Scheme Allowlist**: Permit only `http` and `https`
+- **Allowlist Override**: Explicitly permit intranet services by hostname
+- **Proxy-time Validation**: Re-validate resolved URLs before each outbound request
+
+**See**: [SSRF Protection](./40-ssrf-protection.md)
+
+### 5. Mutual TLS (Optional)
 
 Enhanced security with client certificates:
 
@@ -144,6 +155,7 @@ Use this checklist to ensure your deployment is secure:
 - [ ] Configure form login for UI access
 - [ ] Enable HTTP Basic for API/programmatic access
 - [ ] Configure CSRF protection with exemptions for `/instances`
+- [ ] Enable SSRF protection (`spring.boot.admin.ssrf-protection.enabled=true`)
 - [ ] Set up remember-me with secure random key
 - [ ] Use HTTPS for deployments
 - [ ] Restrict access by IP (if applicable)
@@ -476,6 +488,7 @@ public InMemoryUserDetailsManager userDetailsService(PasswordEncoder encoder) {
 - [Server Authentication](./10-server-authentication.md) - Secure Admin Server with Spring Security
 - [Actuator Security](./20-actuator-security.md) - Secure client actuator endpoints
 - [CSRF Protection](./30-csrf-protection.md) - Configure CSRF for UI and API
+- [SSRF Protection](./40-ssrf-protection.md) - Block SSRF attacks via instance registration
 
 ---
 

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerAutoConfiguration.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2023 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,6 +55,7 @@ import de.codecentric.boot.admin.server.services.StatusUpdater;
 import de.codecentric.boot.admin.server.services.endpoints.ChainingStrategy;
 import de.codecentric.boot.admin.server.services.endpoints.ProbeEndpointsStrategy;
 import de.codecentric.boot.admin.server.services.endpoints.QueryIndexEndpointStrategy;
+import de.codecentric.boot.admin.server.utils.SsrfUrlValidator;
 import de.codecentric.boot.admin.server.web.client.InstanceWebClient;
 
 @Configuration(proxyBeanMethods = false)
@@ -81,9 +82,15 @@ public class AdminServerAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
+	public SsrfUrlValidator ssrfUrlValidator() {
+		return new SsrfUrlValidator(this.adminServerProperties.getSsrfProtection());
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
 	public InstanceRegistry instanceRegistry(InstanceRepository instanceRepository,
-			InstanceIdGenerator instanceIdGenerator, InstanceFilter instanceFilter) {
-		return new InstanceRegistry(instanceRepository, instanceIdGenerator, instanceFilter);
+			InstanceIdGenerator instanceIdGenerator, InstanceFilter instanceFilter, SsrfUrlValidator ssrfUrlValidator) {
+		return new InstanceRegistry(instanceRepository, instanceIdGenerator, instanceFilter, ssrfUrlValidator);
 	}
 
 	@Bean

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerAutoConfiguration.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerAutoConfiguration.java
@@ -21,10 +21,13 @@ import java.util.List;
 
 import lombok.extern.slf4j.Slf4j;
 import org.reactivestreams.Publisher;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.http.client.InetAddressFilter;
 import org.springframework.boot.webclient.autoconfigure.WebClientAutoConfiguration;
@@ -86,6 +89,7 @@ public class AdminServerAutoConfiguration {
 
 	@Bean(name = SSRF_INET_ADDRESS_FILTER_BEAN_NAME)
 	@ConditionalOnMissingBean(name = SSRF_INET_ADDRESS_FILTER_BEAN_NAME)
+	@ConditionalOnProperty(prefix = "spring.boot.admin.ssrf-protection", name = "enabled", havingValue = "true")
 	public InetAddressFilter ssrfInetAddressFilter() {
 		InetAddressFilter filter = InetAddressFilter.externalAddresses();
 		List<String> allowedCidrs = this.adminServerProperties.getSsrfProtection().getAllowedCidrs();
@@ -97,8 +101,14 @@ public class AdminServerAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public SsrfUrlValidator ssrfUrlValidator(InetAddressFilter ssrfInetAddressFilter) {
-		return new SsrfUrlValidator(this.adminServerProperties.getSsrfProtection(), ssrfInetAddressFilter);
+	public SsrfUrlValidator ssrfUrlValidator(
+			@Qualifier(SSRF_INET_ADDRESS_FILTER_BEAN_NAME) ObjectProvider<InetAddressFilter> ssrfInetAddressFilter) {
+		// The InetAddressFilter bean is only registered when SSRF protection is enabled
+		// (see ssrfInetAddressFilter()). When absent, fall back to the default external
+		// filter; SsrfUrlValidator only consults it while protection is enabled, so this
+		// fallback is never exercised in the default (disabled) configuration.
+		InetAddressFilter filter = ssrfInetAddressFilter.getIfAvailable(InetAddressFilter::externalAddresses);
+		return new SsrfUrlValidator(this.adminServerProperties.getSsrfProtection(), filter);
 	}
 
 	@Bean

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerAutoConfiguration.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerAutoConfiguration.java
@@ -17,6 +17,7 @@
 package de.codecentric.boot.admin.server.config;
 
 import java.time.Duration;
+import java.util.List;
 
 import lombok.extern.slf4j.Slf4j;
 import org.reactivestreams.Publisher;
@@ -25,6 +26,7 @@ import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.http.client.InetAddressFilter;
 import org.springframework.boot.webclient.autoconfigure.WebClientAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
@@ -82,8 +84,19 @@ public class AdminServerAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public SsrfUrlValidator ssrfUrlValidator() {
-		return new SsrfUrlValidator(this.adminServerProperties.getSsrfProtection());
+	public InetAddressFilter ssrfInetAddressFilter() {
+		InetAddressFilter filter = InetAddressFilter.externalAddresses();
+		List<String> allowedCidrs = this.adminServerProperties.getSsrfProtection().getAllowedCidrs();
+		if (!allowedCidrs.isEmpty()) {
+			filter = filter.or(allowedCidrs.toArray(String[]::new));
+		}
+		return filter;
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public SsrfUrlValidator ssrfUrlValidator(InetAddressFilter ssrfInetAddressFilter) {
+		return new SsrfUrlValidator(this.adminServerProperties.getSsrfProtection(), ssrfInetAddressFilter);
 	}
 
 	@Bean

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerAutoConfiguration.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerAutoConfiguration.java
@@ -70,6 +70,8 @@ import de.codecentric.boot.admin.server.web.client.InstanceWebClient;
 @Lazy(false)
 public class AdminServerAutoConfiguration {
 
+	public static final String SSRF_INET_ADDRESS_FILTER_BEAN_NAME = "ssrfInetAddressFilter";
+
 	private final AdminServerProperties adminServerProperties;
 
 	public AdminServerAutoConfiguration(AdminServerProperties adminServerProperties) {
@@ -82,8 +84,8 @@ public class AdminServerAutoConfiguration {
 		return (instance) -> true;
 	}
 
-	@Bean
-	@ConditionalOnMissingBean(name = "ssrfInetAddressFilter")
+	@Bean(name = SSRF_INET_ADDRESS_FILTER_BEAN_NAME)
+	@ConditionalOnMissingBean(name = SSRF_INET_ADDRESS_FILTER_BEAN_NAME)
 	public InetAddressFilter ssrfInetAddressFilter() {
 		InetAddressFilter filter = InetAddressFilter.externalAddresses();
 		List<String> allowedCidrs = this.adminServerProperties.getSsrfProtection().getAllowedCidrs();

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerAutoConfiguration.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerAutoConfiguration.java
@@ -83,7 +83,7 @@ public class AdminServerAutoConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnMissingBean
+	@ConditionalOnMissingBean(name = "ssrfInetAddressFilter")
 	public InetAddressFilter ssrfInetAddressFilter() {
 		InetAddressFilter filter = InetAddressFilter.externalAddresses();
 		List<String> allowedCidrs = this.adminServerProperties.getSsrfProtection().getAllowedCidrs();

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerProperties.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerProperties.java
@@ -266,8 +266,8 @@ public class AdminServerProperties {
 
 		/**
 		 * Whether SSRF protection is enabled. When enabled, registration URLs are
-		 * validated against blocked schemes and private/internal IP ranges. Default:
-		 * false (opt-in).
+		 * validated against blocked schemes and non-external IP addresses. Default: false
+		 * (opt-in).
 		 */
 		private boolean enabled = false;
 
@@ -278,22 +278,15 @@ public class AdminServerProperties {
 		private Set<String> allowedSchemes = new HashSet<>(asList("http", "https"));
 
 		/**
-		 * Hosts (exact match or glob-style suffix patterns) that are explicitly allowed
-		 * even if they would otherwise match a blocked range. Useful for intranet
-		 * deployments where SBA must reach private-IP services.
+		 * Additional IP addresses or CIDR ranges (IPv4 and IPv6) that are permitted even
+		 * if they would otherwise be blocked by the default
+		 * {@code InetAddressFilter.externalAddresses()} filter. Useful for intranet
+		 * deployments where the Admin Server must reach services on private IP ranges.
 		 * <p>
-		 * Example: {@code 192.168.1.100}, {@code *.internal.corp}
+		 * Examples: {@code 192.168.1.100}, {@code 192.168.1.0/24}, {@code 10.0.0.0/8},
+		 * {@code fd00::/8}
 		 */
-		private List<String> allowedHosts = new ArrayList<>();
-
-		/**
-		 * Additional hostname patterns (regex) to block beyond the built-in private
-		 * ranges. Matched against the raw hostname from the URL (before any DNS
-		 * resolution).
-		 * <p>
-		 * Example: {@code .*\.internal\.corp$}
-		 */
-		private List<String> blockedHostPatterns = new ArrayList<>();
+		private List<String> allowedCidrs = new ArrayList<>();
 
 	}
 

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerProperties.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2023 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,10 @@ package de.codecentric.boot.admin.server.config;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -51,6 +53,8 @@ public class AdminServerProperties {
 	private InstanceAuthProperties instanceAuth = new InstanceAuthProperties();
 
 	private InstanceProxyProperties instanceProxy = new InstanceProxyProperties();
+
+	private SsrfProtectionProperties ssrfProtection = new SsrfProtectionProperties();
 
 	/**
 	 * The metadata keys which should be sanitized when serializing to JSON
@@ -254,6 +258,42 @@ public class AdminServerProperties {
 		 * Headers not to be forwarded when making requests to clients.
 		 */
 		private Set<String> ignoredHeaders = new HashSet<>(asList("Cookie", "Set-Cookie", "Authorization"));
+
+	}
+
+	@lombok.Data
+	public static class SsrfProtectionProperties {
+
+		/**
+		 * Whether SSRF protection is enabled. When enabled, registration URLs are
+		 * validated against blocked schemes and private/internal IP ranges. Default:
+		 * false (opt-in).
+		 */
+		private boolean enabled = false;
+
+		/**
+		 * URL schemes that are permitted. Any scheme not in this list is blocked.
+		 * Default: http, https.
+		 */
+		private Set<String> allowedSchemes = new HashSet<>(asList("http", "https"));
+
+		/**
+		 * Hosts (exact match or glob-style suffix patterns) that are explicitly allowed
+		 * even if they would otherwise match a blocked range. Useful for intranet
+		 * deployments where SBA must reach private-IP services.
+		 * <p>
+		 * Example: {@code 192.168.1.100}, {@code *.internal.corp}
+		 */
+		private List<String> allowedHosts = new ArrayList<>();
+
+		/**
+		 * Additional hostname patterns (regex) to block beyond the built-in private
+		 * ranges. Matched against the raw hostname from the URL (before any DNS
+		 * resolution).
+		 * <p>
+		 * Example: {@code .*\.internal\.corp$}
+		 */
+		private List<String> blockedHostPatterns = new ArrayList<>();
 
 	}
 

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerWebConfiguration.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerWebConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import de.codecentric.boot.admin.server.eventstore.InstanceEventStore;
 import de.codecentric.boot.admin.server.services.ApplicationRegistry;
 import de.codecentric.boot.admin.server.services.HealthGroupsCache;
 import de.codecentric.boot.admin.server.services.InstanceRegistry;
+import de.codecentric.boot.admin.server.utils.SsrfUrlValidator;
 import de.codecentric.boot.admin.server.utils.jackson.AdminServerModule;
 import de.codecentric.boot.admin.server.web.ApplicationsController;
 import de.codecentric.boot.admin.server.web.InstancesController;
@@ -77,11 +78,12 @@ public class AdminServerWebConfiguration {
 		@Bean
 		@ConditionalOnMissingBean
 		public de.codecentric.boot.admin.server.web.reactive.InstancesProxyController instancesProxyController(
-				InstanceRegistry instanceRegistry, InstanceWebClient.Builder instanceWebClientBuilder) {
+				InstanceRegistry instanceRegistry, InstanceWebClient.Builder instanceWebClientBuilder,
+				SsrfUrlValidator ssrfUrlValidator) {
 			return new de.codecentric.boot.admin.server.web.reactive.InstancesProxyController(
 					this.adminServerProperties.getContextPath(),
 					this.adminServerProperties.getInstanceProxy().getIgnoredHeaders(), instanceRegistry,
-					instanceWebClientBuilder.build());
+					instanceWebClientBuilder.build(), ssrfUrlValidator);
 		}
 
 		@Bean
@@ -110,11 +112,12 @@ public class AdminServerWebConfiguration {
 		@Bean
 		@ConditionalOnMissingBean
 		public de.codecentric.boot.admin.server.web.servlet.InstancesProxyController instancesProxyController(
-				InstanceRegistry instanceRegistry, InstanceWebClient.Builder instanceWebClientBuilder) {
+				InstanceRegistry instanceRegistry, InstanceWebClient.Builder instanceWebClientBuilder,
+				SsrfUrlValidator ssrfUrlValidator) {
 			return new de.codecentric.boot.admin.server.web.servlet.InstancesProxyController(
 					this.adminServerProperties.getContextPath(),
 					this.adminServerProperties.getInstanceProxy().getIgnoredHeaders(), instanceRegistry,
-					instanceWebClientBuilder.build());
+					instanceWebClientBuilder.build(), ssrfUrlValidator);
 		}
 
 		@Bean

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/InstanceRegistry.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/InstanceRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2023 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import de.codecentric.boot.admin.server.domain.entities.Instance;
 import de.codecentric.boot.admin.server.domain.entities.InstanceRepository;
 import de.codecentric.boot.admin.server.domain.values.InstanceId;
 import de.codecentric.boot.admin.server.domain.values.Registration;
+import de.codecentric.boot.admin.server.utils.SsrfUrlValidator;
 
 /**
  * Registry for all application instances that should be managed/administrated by the
@@ -38,10 +39,19 @@ public class InstanceRegistry {
 
 	private final InstanceFilter filter;
 
+	private final SsrfUrlValidator ssrfUrlValidator;
+
 	public InstanceRegistry(InstanceRepository repository, InstanceIdGenerator generator, InstanceFilter filter) {
+		this(repository, generator, filter, new SsrfUrlValidator(
+				new de.codecentric.boot.admin.server.config.AdminServerProperties.SsrfProtectionProperties()));
+	}
+
+	public InstanceRegistry(InstanceRepository repository, InstanceIdGenerator generator, InstanceFilter filter,
+			SsrfUrlValidator ssrfUrlValidator) {
 		this.repository = repository;
 		this.generator = generator;
 		this.filter = filter;
+		this.ssrfUrlValidator = ssrfUrlValidator;
 	}
 
 	/**
@@ -51,6 +61,9 @@ public class InstanceRegistry {
 	 */
 	public Mono<InstanceId> register(Registration registration) {
 		Assert.notNull(registration, "'registration' must not be null");
+		ssrfUrlValidator.validate(registration.getHealthUrl());
+		ssrfUrlValidator.validate(registration.getManagementUrl());
+		ssrfUrlValidator.validate(registration.getServiceUrl());
 		InstanceId id = generator.generateId(registration);
 		Assert.notNull(id, "'id' must not be null");
 		return repository.compute(id, (key, instance) -> {

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/InstanceRegistry.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/InstanceRegistry.java
@@ -16,10 +16,12 @@
 
 package de.codecentric.boot.admin.server.services;
 
+import org.springframework.boot.http.client.InetAddressFilter;
 import org.springframework.util.Assert;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import de.codecentric.boot.admin.server.config.AdminServerProperties.SsrfProtectionProperties;
 import de.codecentric.boot.admin.server.domain.entities.Instance;
 import de.codecentric.boot.admin.server.domain.entities.InstanceRepository;
 import de.codecentric.boot.admin.server.domain.values.InstanceId;
@@ -42,8 +44,8 @@ public class InstanceRegistry {
 	private final SsrfUrlValidator ssrfUrlValidator;
 
 	public InstanceRegistry(InstanceRepository repository, InstanceIdGenerator generator, InstanceFilter filter) {
-		this(repository, generator, filter, new SsrfUrlValidator(
-				new de.codecentric.boot.admin.server.config.AdminServerProperties.SsrfProtectionProperties()));
+		this(repository, generator, filter,
+				new SsrfUrlValidator(new SsrfProtectionProperties(), InetAddressFilter.externalAddresses()));
 	}
 
 	public InstanceRegistry(InstanceRepository repository, InstanceIdGenerator generator, InstanceFilter filter,

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/utils/SsrfUrlValidator.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/utils/SsrfUrlValidator.java
@@ -74,10 +74,7 @@ public class SsrfUrlValidator {
 	 * protection is enabled
 	 */
 	public void validate(@Nullable String url) {
-		if (!properties.isEnabled()) {
-			return;
-		}
-		if (!StringUtils.hasText(url)) {
+		if (!properties.isEnabled() || !StringUtils.hasText(url)) {
 			return;
 		}
 
@@ -87,9 +84,34 @@ public class SsrfUrlValidator {
 		}
 		catch (URISyntaxException ex) {
 			throw new SsrfProtectionException(
-					"URL '" + url + "' is not a valid URI and cannot be validated: " + ex.getMessage());
+					"URL '" + url + "' is not a valid URI and cannot be validated: " + ex.getMessage(), ex);
 		}
 
+		validate(uri);
+	}
+
+	/**
+	 * Validates the given URI against the configured SSRF protection rules.
+	 * @param uri the URI to validate (may be {@code null}, which is skipped)
+	 * @throws SsrfProtectionException if the URI violates a protection rule and
+	 * protection is enabled
+	 */
+	public void validate(@Nullable URI uri) {
+		if (!properties.isEnabled()) {
+			return;
+		}
+		if (uri == null) {
+			return;
+		}
+		// Relative URIs (e.g. path-only proxy requests built by the proxy controllers)
+		// have no host to validate; the actual host is supplied downstream by the HTTP
+		// client and enforced there via the InetAddressFilter. Only absolute URIs carry
+		// a scheme/host we can inspect here.
+		if (!uri.isAbsolute()) {
+			return;
+		}
+
+		String url = uri.toString();
 		checkScheme(url, uri.getScheme());
 
 		String host = uri.getHost();

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/utils/SsrfUrlValidator.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/utils/SsrfUrlValidator.java
@@ -16,14 +16,13 @@
 
 package de.codecentric.boot.admin.server.utils;
 
+import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
+import java.net.UnknownHostException;
 
 import org.jspecify.annotations.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.springframework.boot.http.client.InetAddressFilter;
 import org.springframework.util.StringUtils;
 
 import de.codecentric.boot.admin.server.config.AdminServerProperties.SsrfProtectionProperties;
@@ -40,26 +39,17 @@ import de.codecentric.boot.admin.server.web.client.exception.SsrfProtectionExcep
  * <li><b>Scheme</b> – only schemes listed in
  * {@code spring.boot.admin.ssrf-protection.allowed-schemes} are accepted (default:
  * {@code http}, {@code https}).</li>
- * <li><b>Private / internal IP ranges</b> – the raw hostname is compared against
- * well-known private and special-purpose address literals without performing DNS
- * resolution. Blocked by default: loopback ({@code 127.x}, {@code ::1},
- * {@code localhost}), link-local ({@code 169.254.x} / {@code fe80:}), RFC 1918
- * ({@code 10.x}, {@code 172.16-31.x}, {@code 192.168.x}), unique-local IPv6
- * ({@code fc}/{@code fd}), and the unspecified address ({@code 0.0.0.0}).</li>
- * <li><b>User-supplied block patterns</b> – additional regex patterns provided via
- * {@code spring.boot.admin.ssrf-protection.blocked-host-patterns} are matched against the
- * hostname.</li>
- * <li><b>Allowlist override</b> – hosts listed in
- * {@code spring.boot.admin.ssrf-protection.allowed-hosts} bypass all block checks.
- * Supports exact host names and glob-style suffix patterns (e.g.
- * {@code *.internal.corp}).</li>
+ * <li><b>Address filtering</b> – the hostname is resolved and the resulting
+ * {@link InetAddress} is tested against a {@link InetAddressFilter}. The default filter
+ * (auto-configured via {@code AdminServerAutoConfiguration}) blocks all private,
+ * loopback, and link-local addresses via
+ * {@link InetAddressFilter#externalAddresses()}.</li>
  * </ol>
  *
  * <p>
- * <b>Limitation:</b> Only literal hostname strings are inspected; no DNS resolution is
- * performed. An attacker who controls a public DNS record that resolves to a private IP
- * (DNS rebinding) is not blocked by this validator alone. Use IMDSv2 or network-level
- * egress controls as additional layers of defence.
+ * To allow access to internal/private hosts (e.g. for intranet SBA deployments), expose a
+ * custom {@link InetAddressFilter} {@code @Bean} in your application context. The bean
+ * replaces the default filter for all SSRF checks.
  *
  * <p>
  * When SSRF protection is disabled
@@ -68,12 +58,13 @@ import de.codecentric.boot.admin.server.web.client.exception.SsrfProtectionExcep
  */
 public class SsrfUrlValidator {
 
-	private static final Logger log = LoggerFactory.getLogger(SsrfUrlValidator.class);
-
 	private final SsrfProtectionProperties properties;
 
-	public SsrfUrlValidator(SsrfProtectionProperties properties) {
+	private final InetAddressFilter inetAddressFilter;
+
+	public SsrfUrlValidator(SsrfProtectionProperties properties, InetAddressFilter inetAddressFilter) {
 		this.properties = properties;
+		this.inetAddressFilter = inetAddressFilter;
 	}
 
 	/**
@@ -98,19 +89,9 @@ public class SsrfUrlValidator {
 			return;
 		}
 
-		String scheme = uri.getScheme();
-		String host = uri.getHost();
-
-		checkScheme(url, scheme);
-		if (host != null && !isAllowed(host)) {
-			checkPrivateHost(url, host);
-			checkBlockedPatterns(url, host);
-		}
+		checkScheme(url, uri.getScheme());
+		checkAddress(url, uri.getHost());
 	}
-
-	// -------------------------------------------------------------------------
-	// Scheme check
-	// -------------------------------------------------------------------------
 
 	private void checkScheme(String url, @Nullable String scheme) {
 		if (scheme == null) {
@@ -119,162 +100,32 @@ public class SsrfUrlValidator {
 		if (!properties.getAllowedSchemes().contains(scheme.toLowerCase())) {
 			throw new SsrfProtectionException("URL '" + url + "' uses disallowed scheme '" + scheme
 					+ "'. Allowed schemes: " + properties.getAllowedSchemes()
-					+ ". Configure 'spring.boot.admin.ssrf-protection" + ".allowed-schemes' to adjust.");
+					+ ". Configure 'spring.boot.admin.ssrf-protection.allowed-schemes' to adjust.");
 		}
 	}
 
-	// -------------------------------------------------------------------------
-	// Allowlist check
-	// -------------------------------------------------------------------------
-
-	/**
-	 * Returns {@code true} if the host matches any entry in the configured
-	 * {@code allowedHosts} list. Supports exact matches and glob-style suffix wildcards
-	 * (e.g. {@code *.internal.corp} matches {@code svc.internal.corp}).
-	 * @param host the raw hostname from the URL (not null)
-	 * @return true if the host is explicitly allowed
-	 */
-	private boolean isAllowed(String host) {
-		String lowerHost = host.toLowerCase();
-		for (String allowed : properties.getAllowedHosts()) {
-			String lowerAllowed = allowed.toLowerCase();
-			if (lowerAllowed.startsWith("*.")) {
-				// Glob suffix: *.example.com matches foo.example.com
-				String suffix = lowerAllowed.substring(1); // -> .example.com
-				if (lowerHost.endsWith(suffix) || lowerHost.equals(suffix.substring(1))) {
-					return true;
-				}
-			}
-			else if (lowerHost.equals(lowerAllowed)) {
-				return true;
-			}
+	private void checkAddress(String url, @Nullable String host) {
+		if (host == null || host.isBlank()) {
+			return;
 		}
-		return false;
-	}
-
-	// -------------------------------------------------------------------------
-	// Private / internal host check (no DNS resolution — literal strings only)
-	// -------------------------------------------------------------------------
-
-	private void checkPrivateHost(String url, String host) {
-		String lowerHost = host.toLowerCase();
-
-		// Loopback
-		if (lowerHost.equals("localhost") || lowerHost.equals("0:0:0:0:0:0:0:1") || lowerHost.equals("::1")) {
-			rejectPrivate(url, host, "loopback");
+		InetAddress[] addresses;
+		try {
+			addresses = InetAddress.getAllByName(host);
 		}
-
-		// Unspecified
-		if (lowerHost.equals("0.0.0.0")) {
-			rejectPrivate(url, host, "unspecified address");
+		catch (UnknownHostException ex) {
+			// Host cannot be resolved at registration time (service may not be running
+			// yet). Allow it through — the InetAddressFilter on the HTTP client will
+			// enforce the policy when an actual connection is attempted.
+			return;
 		}
-
-		// IPv4 — parse only if it looks like a dotted-decimal address
-		if (looksLikeIpv4(lowerHost)) {
-			checkPrivateIpv4(url, host, lowerHost);
-			return; // don't run IPv6 checks on IPv4 addresses
-		}
-
-		// IPv6
-		checkPrivateIpv6(url, host, lowerHost);
-	}
-
-	private boolean looksLikeIpv4(String host) {
-		// Simple heuristic: all chars are digits or dots, at least one dot
-		return host.chars().allMatch((c) -> Character.isDigit(c) || c == '.') && host.contains(".");
-	}
-
-	private void checkPrivateIpv4(String url, String host, String lowerHost) {
-		// Loopback: 127.0.0.0/8
-		if (lowerHost.startsWith("127.")) {
-			rejectPrivate(url, host, "loopback (127.0.0.0/8)");
-		}
-		// Link-local / AWS metadata: 169.254.0.0/16
-		if (lowerHost.startsWith("169.254.")) {
-			rejectPrivate(url, host, "link-local (169.254.0.0/16, includes cloud metadata endpoints)");
-		}
-		// RFC 1918 — Class A: 10.0.0.0/8
-		if (lowerHost.startsWith("10.")) {
-			rejectPrivate(url, host, "private (10.0.0.0/8)");
-		}
-		// RFC 1918 — Class C: 192.168.0.0/16
-		if (lowerHost.startsWith("192.168.")) {
-			rejectPrivate(url, host, "private (192.168.0.0/16)");
-		}
-		// RFC 1918 — Class B: 172.16.0.0/12 (172.16.x.x – 172.31.x.x)
-		if (lowerHost.startsWith("172.")) {
-			String[] parts = lowerHost.split("\\.");
-			if (parts.length >= 2) {
-				try {
-					int second = Integer.parseInt(parts[1]);
-					if (second >= 16 && second <= 31) {
-						rejectPrivate(url, host, "private (172.16.0.0/12)");
-					}
-				}
-				catch (NumberFormatException ignored) {
-					// not a valid IPv4 — fall through
-				}
-			}
-		}
-	}
-
-	private void checkPrivateIpv6(String url, String host, String lowerHost) {
-		// Strip surrounding brackets that URI.getHost() may leave on IPv6 literals
-		String stripped = (lowerHost.startsWith("[") && lowerHost.endsWith("]"))
-				? lowerHost.substring(1, lowerHost.length() - 1) : lowerHost;
-
-		// Loopback ::1
-		if (stripped.equals("::1") || stripped.equals("0:0:0:0:0:0:0:1")) {
-			rejectPrivate(url, host, "loopback (::1)");
-		}
-		// Link-local fe80::/10
-		if (stripped.startsWith("fe80:") || stripped.startsWith("fe8") || stripped.startsWith("fe9")
-				|| stripped.startsWith("fea") || stripped.startsWith("feb")) {
-			rejectPrivate(url, host, "link-local (fe80::/10)");
-		}
-		// Unique-local fc00::/7 — covers fc and fd prefixes
-		if (stripped.startsWith("fc") || stripped.startsWith("fd")) {
-			rejectPrivate(url, host, "unique-local (fc00::/7)");
-		}
-		// IPv4-mapped IPv6: ::ffff:0:0/96 — e.g. ::ffff:192.168.1.1
-		if (stripped.startsWith("::ffff:")) {
-			String embedded = stripped.substring("::ffff:".length());
-			// Recursively validate the embedded IPv4 part
-			checkPrivateIpv4(url, embedded, embedded.toLowerCase());
-		}
-	}
-
-	// -------------------------------------------------------------------------
-	// User-supplied blocked patterns
-	// -------------------------------------------------------------------------
-
-	private void checkBlockedPatterns(String url, String host) {
-		for (String rawPattern : properties.getBlockedHostPatterns()) {
-			if (!StringUtils.hasText(rawPattern)) {
-				continue;
-			}
-			try {
-				if (Pattern.compile(rawPattern).matcher(host).matches()) {
-					throw new SsrfProtectionException("URL '" + url + "' is blocked: host '" + host
-							+ "' matches configured blocked pattern '" + rawPattern
-							+ "'. Configure 'spring.boot.admin.ssrf-protection.blocked-host-patterns' to adjust.");
-				}
-			}
-			catch (PatternSyntaxException ex) {
-				log.warn("Invalid SSRF blocked-host-pattern '{}': {}", rawPattern, ex.getMessage());
-			}
-		}
-	}
-
-	// -------------------------------------------------------------------------
-	// Helpers
-	// -------------------------------------------------------------------------
-
-	private void rejectPrivate(String url, String host, String rangeDescription) {
-		throw new SsrfProtectionException(
-				"URL '" + url + "' is blocked: host '" + host + "' resolves to a " + rangeDescription + " address. "
-						+ "Add this host to 'spring.boot.admin.ssrf-protection.allowed-hosts' to permit it, "
+		for (InetAddress address : addresses) {
+			if (!inetAddressFilter.matches(address)) {
+				throw new SsrfProtectionException("URL '" + url + "' is blocked: address '" + address.getHostAddress()
+						+ "' for host '" + host + "' is not permitted by the configured InetAddressFilter. "
+						+ "Provide a custom InetAddressFilter @Bean to allow internal addresses, "
 						+ "or disable protection with 'spring.boot.admin.ssrf-protection.enabled=false'.");
+			}
+		}
 	}
 
 }

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/utils/SsrfUrlValidator.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/utils/SsrfUrlValidator.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright 2014-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.codecentric.boot.admin.server.utils;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.StringUtils;
+
+import de.codecentric.boot.admin.server.config.AdminServerProperties.SsrfProtectionProperties;
+import de.codecentric.boot.admin.server.web.client.exception.SsrfProtectionException;
+
+/**
+ * Validates URLs submitted for instance registration and proxying against SSRF (Server-
+ * Side Request Forgery) attack patterns.
+ *
+ * <p>
+ * When SSRF protection is enabled
+ * ({@code spring.boot.admin.ssrf-protection.enabled=true}), this validator checks:
+ * <ol>
+ * <li><b>Scheme</b> – only schemes listed in
+ * {@code spring.boot.admin.ssrf-protection.allowed-schemes} are accepted (default:
+ * {@code http}, {@code https}).</li>
+ * <li><b>Private / internal IP ranges</b> – the raw hostname is compared against
+ * well-known private and special-purpose address literals without performing DNS
+ * resolution. Blocked by default: loopback ({@code 127.x}, {@code ::1},
+ * {@code localhost}), link-local ({@code 169.254.x} / {@code fe80:}), RFC 1918
+ * ({@code 10.x}, {@code 172.16-31.x}, {@code 192.168.x}), unique-local IPv6
+ * ({@code fc}/{@code fd}), and the unspecified address ({@code 0.0.0.0}).</li>
+ * <li><b>User-supplied block patterns</b> – additional regex patterns provided via
+ * {@code spring.boot.admin.ssrf-protection.blocked-host-patterns} are matched against the
+ * hostname.</li>
+ * <li><b>Allowlist override</b> – hosts listed in
+ * {@code spring.boot.admin.ssrf-protection.allowed-hosts} bypass all block checks.
+ * Supports exact host names and glob-style suffix patterns (e.g.
+ * {@code *.internal.corp}).</li>
+ * </ol>
+ *
+ * <p>
+ * <b>Limitation:</b> Only literal hostname strings are inspected; no DNS resolution is
+ * performed. An attacker who controls a public DNS record that resolves to a private IP
+ * (DNS rebinding) is not blocked by this validator alone. Use IMDSv2 or network-level
+ * egress controls as additional layers of defence.
+ *
+ * <p>
+ * When SSRF protection is disabled
+ * ({@code spring.boot.admin.ssrf-protection.enabled=false}, which is the default) all
+ * URLs are accepted without further inspection.
+ */
+public class SsrfUrlValidator {
+
+	private static final Logger log = LoggerFactory.getLogger(SsrfUrlValidator.class);
+
+	private final SsrfProtectionProperties properties;
+
+	public SsrfUrlValidator(SsrfProtectionProperties properties) {
+		this.properties = properties;
+	}
+
+	/**
+	 * Validates the given URL against the configured SSRF protection rules.
+	 * @param url the URL to validate (may be {@code null} or blank, which is skipped)
+	 * @throws SsrfProtectionException if the URL violates a protection rule and
+	 * protection is enabled
+	 */
+	public void validate(@Nullable String url) {
+		if (!properties.isEnabled()) {
+			return;
+		}
+		if (!StringUtils.hasText(url)) {
+			return;
+		}
+
+		URI uri;
+		try {
+			uri = new URI(url);
+		}
+		catch (URISyntaxException ex) {
+			return;
+		}
+
+		String scheme = uri.getScheme();
+		String host = uri.getHost();
+
+		checkScheme(url, scheme);
+		if (host != null && !isAllowed(host)) {
+			checkPrivateHost(url, host);
+			checkBlockedPatterns(url, host);
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Scheme check
+	// -------------------------------------------------------------------------
+
+	private void checkScheme(String url, @Nullable String scheme) {
+		if (scheme == null) {
+			return;
+		}
+		if (!properties.getAllowedSchemes().contains(scheme.toLowerCase())) {
+			throw new SsrfProtectionException("URL '" + url + "' uses disallowed scheme '" + scheme
+					+ "'. Allowed schemes: " + properties.getAllowedSchemes()
+					+ ". Configure 'spring.boot.admin.ssrf-protection" + ".allowed-schemes' to adjust.");
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Allowlist check
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Returns {@code true} if the host matches any entry in the configured
+	 * {@code allowedHosts} list. Supports exact matches and glob-style suffix wildcards
+	 * (e.g. {@code *.internal.corp} matches {@code svc.internal.corp}).
+	 * @param host the raw hostname from the URL (not null)
+	 * @return true if the host is explicitly allowed
+	 */
+	private boolean isAllowed(String host) {
+		String lowerHost = host.toLowerCase();
+		for (String allowed : properties.getAllowedHosts()) {
+			String lowerAllowed = allowed.toLowerCase();
+			if (lowerAllowed.startsWith("*.")) {
+				// Glob suffix: *.example.com matches foo.example.com
+				String suffix = lowerAllowed.substring(1); // -> .example.com
+				if (lowerHost.endsWith(suffix) || lowerHost.equals(suffix.substring(1))) {
+					return true;
+				}
+			}
+			else if (lowerHost.equals(lowerAllowed)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	// -------------------------------------------------------------------------
+	// Private / internal host check (no DNS resolution — literal strings only)
+	// -------------------------------------------------------------------------
+
+	private void checkPrivateHost(String url, String host) {
+		String lowerHost = host.toLowerCase();
+
+		// Loopback
+		if (lowerHost.equals("localhost") || lowerHost.equals("0:0:0:0:0:0:0:1") || lowerHost.equals("::1")) {
+			rejectPrivate(url, host, "loopback");
+		}
+
+		// Unspecified
+		if (lowerHost.equals("0.0.0.0")) {
+			rejectPrivate(url, host, "unspecified address");
+		}
+
+		// IPv4 — parse only if it looks like a dotted-decimal address
+		if (looksLikeIpv4(lowerHost)) {
+			checkPrivateIpv4(url, host, lowerHost);
+			return; // don't run IPv6 checks on IPv4 addresses
+		}
+
+		// IPv6
+		checkPrivateIpv6(url, host, lowerHost);
+	}
+
+	private boolean looksLikeIpv4(String host) {
+		// Simple heuristic: all chars are digits or dots, at least one dot
+		return host.chars().allMatch((c) -> Character.isDigit(c) || c == '.') && host.contains(".");
+	}
+
+	private void checkPrivateIpv4(String url, String host, String lowerHost) {
+		// Loopback: 127.0.0.0/8
+		if (lowerHost.startsWith("127.")) {
+			rejectPrivate(url, host, "loopback (127.0.0.0/8)");
+		}
+		// Link-local / AWS metadata: 169.254.0.0/16
+		if (lowerHost.startsWith("169.254.")) {
+			rejectPrivate(url, host, "link-local (169.254.0.0/16, includes cloud metadata endpoints)");
+		}
+		// RFC 1918 — Class A: 10.0.0.0/8
+		if (lowerHost.startsWith("10.")) {
+			rejectPrivate(url, host, "private (10.0.0.0/8)");
+		}
+		// RFC 1918 — Class C: 192.168.0.0/16
+		if (lowerHost.startsWith("192.168.")) {
+			rejectPrivate(url, host, "private (192.168.0.0/16)");
+		}
+		// RFC 1918 — Class B: 172.16.0.0/12 (172.16.x.x – 172.31.x.x)
+		if (lowerHost.startsWith("172.")) {
+			String[] parts = lowerHost.split("\\.");
+			if (parts.length >= 2) {
+				try {
+					int second = Integer.parseInt(parts[1]);
+					if (second >= 16 && second <= 31) {
+						rejectPrivate(url, host, "private (172.16.0.0/12)");
+					}
+				}
+				catch (NumberFormatException ignored) {
+					// not a valid IPv4 — fall through
+				}
+			}
+		}
+	}
+
+	private void checkPrivateIpv6(String url, String host, String lowerHost) {
+		// Strip surrounding brackets that URI.getHost() may leave on IPv6 literals
+		String stripped = (lowerHost.startsWith("[") && lowerHost.endsWith("]"))
+				? lowerHost.substring(1, lowerHost.length() - 1) : lowerHost;
+
+		// Loopback ::1
+		if (stripped.equals("::1") || stripped.equals("0:0:0:0:0:0:0:1")) {
+			rejectPrivate(url, host, "loopback (::1)");
+		}
+		// Link-local fe80::/10
+		if (stripped.startsWith("fe80:") || stripped.startsWith("fe8") || stripped.startsWith("fe9")
+				|| stripped.startsWith("fea") || stripped.startsWith("feb")) {
+			rejectPrivate(url, host, "link-local (fe80::/10)");
+		}
+		// Unique-local fc00::/7 — covers fc and fd prefixes
+		if (stripped.startsWith("fc") || stripped.startsWith("fd")) {
+			rejectPrivate(url, host, "unique-local (fc00::/7)");
+		}
+		// IPv4-mapped IPv6: ::ffff:0:0/96 — e.g. ::ffff:192.168.1.1
+		if (stripped.startsWith("::ffff:")) {
+			String embedded = stripped.substring("::ffff:".length());
+			// Recursively validate the embedded IPv4 part
+			checkPrivateIpv4(url, embedded, embedded.toLowerCase());
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// User-supplied blocked patterns
+	// -------------------------------------------------------------------------
+
+	private void checkBlockedPatterns(String url, String host) {
+		for (String rawPattern : properties.getBlockedHostPatterns()) {
+			if (!StringUtils.hasText(rawPattern)) {
+				continue;
+			}
+			try {
+				if (Pattern.compile(rawPattern).matcher(host).matches()) {
+					throw new SsrfProtectionException("URL '" + url + "' is blocked: host '" + host
+							+ "' matches configured blocked pattern '" + rawPattern
+							+ "'. Configure 'spring.boot.admin.ssrf-protection.blocked-host-patterns' to adjust.");
+				}
+			}
+			catch (PatternSyntaxException ex) {
+				log.warn("Invalid SSRF blocked-host-pattern '{}': {}", rawPattern, ex.getMessage());
+			}
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Helpers
+	// -------------------------------------------------------------------------
+
+	private void rejectPrivate(String url, String host, String rangeDescription) {
+		throw new SsrfProtectionException(
+				"URL '" + url + "' is blocked: host '" + host + "' resolves to a " + rangeDescription + " address. "
+						+ "Add this host to 'spring.boot.admin.ssrf-protection.allowed-hosts' to permit it, "
+						+ "or disable protection with 'spring.boot.admin.ssrf-protection.enabled=false'.");
+	}
+
+}

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/utils/SsrfUrlValidator.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/utils/SsrfUrlValidator.java
@@ -86,7 +86,8 @@ public class SsrfUrlValidator {
 			uri = new URI(url);
 		}
 		catch (URISyntaxException ex) {
-			return;
+			throw new SsrfProtectionException(
+					"URL '" + url + "' is not a valid URI and cannot be validated: " + ex.getMessage());
 		}
 
 		checkScheme(url, uri.getScheme());

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/utils/SsrfUrlValidator.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/utils/SsrfUrlValidator.java
@@ -91,7 +91,17 @@ public class SsrfUrlValidator {
 		}
 
 		checkScheme(url, uri.getScheme());
-		checkAddress(url, uri.getHost());
+
+		String host = uri.getHost();
+		// If the URI has an authority component but getHost() returned null, the host
+		// literal could not be parsed as a standard hostname or IP by java.net.URI
+		// (e.g. octal notation "0251.0376.0251.0376", Unicode digits). Reject it —
+		// we cannot safely validate what we cannot parse.
+		if (host == null && uri.getAuthority() != null) {
+			throw new SsrfProtectionException("URL '" + url
+					+ "' contains a host that cannot be parsed and validated. Rejecting to prevent bypass.");
+		}
+		checkAddress(url, host);
 	}
 
 	private void checkScheme(String url, @Nullable String scheme) {

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/InstanceWebProxy.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/InstanceWebProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2023 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,8 +41,10 @@ import reactor.core.publisher.Mono;
 
 import de.codecentric.boot.admin.server.domain.entities.Instance;
 import de.codecentric.boot.admin.server.domain.values.InstanceId;
+import de.codecentric.boot.admin.server.utils.SsrfUrlValidator;
 import de.codecentric.boot.admin.server.web.client.InstanceWebClient;
 import de.codecentric.boot.admin.server.web.client.exception.ResolveEndpointException;
+import de.codecentric.boot.admin.server.web.client.exception.SsrfProtectionException;
 
 import static org.springframework.http.HttpMethod.PATCH;
 import static org.springframework.http.HttpMethod.POST;
@@ -65,8 +67,16 @@ public class InstanceWebProxy {
 
 	private final ExchangeStrategies strategies = ExchangeStrategies.withDefaults();
 
+	private final SsrfUrlValidator ssrfUrlValidator;
+
 	public InstanceWebProxy(InstanceWebClient instanceWebClient) {
+		this(instanceWebClient, new SsrfUrlValidator(
+				new de.codecentric.boot.admin.server.config.AdminServerProperties.SsrfProtectionProperties()));
+	}
+
+	public InstanceWebProxy(InstanceWebClient instanceWebClient, SsrfUrlValidator ssrfUrlValidator) {
 		this.instanceWebClient = instanceWebClient;
+		this.ssrfUrlValidator = ssrfUrlValidator;
 	}
 
 	public <V> Mono<V> forward(Mono<Instance> instanceMono, ForwardRequest forwardRequest,
@@ -98,6 +108,14 @@ public class InstanceWebProxy {
 	private <V> Mono<V> forward(Instance instance, ForwardRequest forwardRequest,
 			Function<ClientResponse, Mono<V>> responseHandler) {
 		log.trace("Proxy-Request for instance {} with URL '{}'", instance.getId(), forwardRequest.getUri());
+		try {
+			ssrfUrlValidator.validate(forwardRequest.getUri().isAbsolute() ? forwardRequest.getUri().toString() : null);
+		}
+		catch (SsrfProtectionException ex) {
+			log.warn("SSRF protection blocked proxy request for instance {} to '{}': {}", instance.getId(),
+					forwardRequest.getUri(), ex.getMessage());
+			return responseHandler.apply(ClientResponse.create(HttpStatus.FORBIDDEN, this.strategies).build());
+		}
 		WebClient.RequestBodySpec bodySpec = this.instanceWebClient.instance(instance)
 			.method(forwardRequest.getMethod())
 			.uri(forwardRequest.getUri())

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/InstanceWebProxy.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/InstanceWebProxy.java
@@ -27,6 +27,7 @@ import io.netty.handler.timeout.ReadTimeoutException;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.http.client.InetAddressFilter;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
@@ -68,11 +69,6 @@ public class InstanceWebProxy {
 	private final ExchangeStrategies strategies = ExchangeStrategies.withDefaults();
 
 	private final SsrfUrlValidator ssrfUrlValidator;
-
-	public InstanceWebProxy(InstanceWebClient instanceWebClient) {
-		this(instanceWebClient, new SsrfUrlValidator(
-				new de.codecentric.boot.admin.server.config.AdminServerProperties.SsrfProtectionProperties()));
-	}
 
 	public InstanceWebProxy(InstanceWebClient instanceWebClient, SsrfUrlValidator ssrfUrlValidator) {
 		this.instanceWebClient = instanceWebClient;

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/InstanceWebProxy.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/InstanceWebProxy.java
@@ -106,9 +106,9 @@ public class InstanceWebProxy {
 		try {
 			// ForwardRequest.uri is a relative path built by the proxy controllers (no
 			// host). The actual host is supplied by InstanceWebClient when it resolves
-			// the instance's management URL. Absolute URIs (if ever present) are
-			// validated; relative ones have no host to check.
-			ssrfUrlValidator.validate(forwardRequest.getUri().isAbsolute() ? forwardRequest.getUri().toString() : null);
+			// the instance's management URL. The validator skips relative URIs and only
+			// inspects absolute ones (if ever present).
+			ssrfUrlValidator.validate(forwardRequest.getUri());
 		}
 		catch (SsrfProtectionException ex) {
 			log.warn("SSRF protection blocked proxy request for instance {} to '{}': {}", instance.getId(),

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/InstanceWebProxy.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/InstanceWebProxy.java
@@ -27,7 +27,6 @@ import io.netty.handler.timeout.ReadTimeoutException;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.http.client.InetAddressFilter;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
@@ -105,6 +104,10 @@ public class InstanceWebProxy {
 			Function<ClientResponse, Mono<V>> responseHandler) {
 		log.trace("Proxy-Request for instance {} with URL '{}'", instance.getId(), forwardRequest.getUri());
 		try {
+			// ForwardRequest.uri is a relative path built by the proxy controllers (no
+			// host). The actual host is supplied by InstanceWebClient when it resolves
+			// the instance's management URL. Absolute URIs (if ever present) are
+			// validated; relative ones have no host to check.
 			ssrfUrlValidator.validate(forwardRequest.getUri().isAbsolute() ? forwardRequest.getUri().toString() : null);
 		}
 		catch (SsrfProtectionException ex) {

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/client/exception/SsrfProtectionException.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/client/exception/SsrfProtectionException.java
@@ -26,4 +26,8 @@ public class SsrfProtectionException extends IllegalArgumentException {
 		super(message);
 	}
 
+	public SsrfProtectionException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
 }

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/client/exception/SsrfProtectionException.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/client/exception/SsrfProtectionException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2014-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.codecentric.boot.admin.server.web.client.exception;
+
+/**
+ * Thrown when a URL submitted for instance registration or proxying is rejected by the
+ * SSRF protection rules (e.g. private IP range, disallowed scheme).
+ */
+public class SsrfProtectionException extends IllegalArgumentException {
+
+	public SsrfProtectionException(String message) {
+		super(message);
+	}
+
+}

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/reactive/InstancesProxyController.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/reactive/InstancesProxyController.java
@@ -19,6 +19,7 @@ package de.codecentric.boot.admin.server.web.reactive;
 import java.net.URI;
 import java.util.Set;
 
+import org.springframework.boot.http.client.InetAddressFilter;
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.core.io.buffer.DataBufferFactory;
 import org.springframework.core.io.buffer.DataBufferUtils;
@@ -66,12 +67,6 @@ public class InstancesProxyController {
 	private final String adminContextPath;
 
 	private final HttpHeaderFilter httpHeadersFilter;
-
-	public InstancesProxyController(String adminContextPath, Set<String> ignoredHeaders, InstanceRegistry registry,
-			InstanceWebClient instanceWebClient) {
-		this(adminContextPath, ignoredHeaders, registry, instanceWebClient, new SsrfUrlValidator(
-				new de.codecentric.boot.admin.server.config.AdminServerProperties.SsrfProtectionProperties()));
-	}
 
 	public InstancesProxyController(String adminContextPath, Set<String> ignoredHeaders, InstanceRegistry registry,
 			InstanceWebClient instanceWebClient, SsrfUrlValidator ssrfUrlValidator) {

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/reactive/InstancesProxyController.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/reactive/InstancesProxyController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2023 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ import reactor.core.publisher.Mono;
 
 import de.codecentric.boot.admin.server.domain.values.InstanceId;
 import de.codecentric.boot.admin.server.services.InstanceRegistry;
+import de.codecentric.boot.admin.server.utils.SsrfUrlValidator;
 import de.codecentric.boot.admin.server.web.AdminController;
 import de.codecentric.boot.admin.server.web.HttpHeaderFilter;
 import de.codecentric.boot.admin.server.web.InstanceWebProxy;
@@ -68,10 +69,16 @@ public class InstancesProxyController {
 
 	public InstancesProxyController(String adminContextPath, Set<String> ignoredHeaders, InstanceRegistry registry,
 			InstanceWebClient instanceWebClient) {
+		this(adminContextPath, ignoredHeaders, registry, instanceWebClient, new SsrfUrlValidator(
+				new de.codecentric.boot.admin.server.config.AdminServerProperties.SsrfProtectionProperties()));
+	}
+
+	public InstancesProxyController(String adminContextPath, Set<String> ignoredHeaders, InstanceRegistry registry,
+			InstanceWebClient instanceWebClient, SsrfUrlValidator ssrfUrlValidator) {
 		this.adminContextPath = adminContextPath;
 		this.registry = registry;
 		this.httpHeadersFilter = new HttpHeaderFilter(ignoredHeaders);
-		this.instanceWebProxy = new InstanceWebProxy(instanceWebClient);
+		this.instanceWebProxy = new InstanceWebProxy(instanceWebClient, ssrfUrlValidator);
 	}
 
 	@RequestMapping(path = INSTANCE_MAPPED_PATH, method = { RequestMethod.GET, RequestMethod.HEAD, RequestMethod.POST,

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/reactive/InstancesProxyController.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/reactive/InstancesProxyController.java
@@ -19,7 +19,6 @@ package de.codecentric.boot.admin.server.web.reactive;
 import java.net.URI;
 import java.util.Set;
 
-import org.springframework.boot.http.client.InetAddressFilter;
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.core.io.buffer.DataBufferFactory;
 import org.springframework.core.io.buffer.DataBufferUtils;

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/servlet/InstancesProxyController.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/servlet/InstancesProxyController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2023 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,7 @@ import reactor.core.publisher.Mono;
 
 import de.codecentric.boot.admin.server.domain.values.InstanceId;
 import de.codecentric.boot.admin.server.services.InstanceRegistry;
+import de.codecentric.boot.admin.server.utils.SsrfUrlValidator;
 import de.codecentric.boot.admin.server.web.AdminController;
 import de.codecentric.boot.admin.server.web.HttpHeaderFilter;
 import de.codecentric.boot.admin.server.web.InstanceWebProxy;
@@ -75,10 +76,16 @@ public class InstancesProxyController {
 
 	public InstancesProxyController(String adminContextPath, Set<String> ignoredHeaders, InstanceRegistry registry,
 			InstanceWebClient instanceWebClient) {
+		this(adminContextPath, ignoredHeaders, registry, instanceWebClient, new SsrfUrlValidator(
+				new de.codecentric.boot.admin.server.config.AdminServerProperties.SsrfProtectionProperties()));
+	}
+
+	public InstancesProxyController(String adminContextPath, Set<String> ignoredHeaders, InstanceRegistry registry,
+			InstanceWebClient instanceWebClient, SsrfUrlValidator ssrfUrlValidator) {
 		this.adminContextPath = adminContextPath;
 		this.registry = registry;
 		this.httpHeadersFilter = new HttpHeaderFilter(ignoredHeaders);
-		this.instanceWebProxy = new InstanceWebProxy(instanceWebClient);
+		this.instanceWebProxy = new InstanceWebProxy(instanceWebClient, ssrfUrlValidator);
 	}
 
 	@ResponseBody

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/servlet/InstancesProxyController.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/servlet/InstancesProxyController.java
@@ -74,9 +74,8 @@ public class InstancesProxyController {
 
 	private final String adminContextPath;
 
-
 	public InstancesProxyController(String adminContextPath, Set<String> ignoredHeaders, InstanceRegistry registry,
-	                                InstanceWebClient instanceWebClient, SsrfUrlValidator ssrfUrlValidator) {
+			InstanceWebClient instanceWebClient, SsrfUrlValidator ssrfUrlValidator) {
 		this.adminContextPath = adminContextPath;
 		this.registry = registry;
 		this.httpHeadersFilter = new HttpHeaderFilter(ignoredHeaders);
@@ -84,8 +83,8 @@ public class InstancesProxyController {
 	}
 
 	@ResponseBody
-	@RequestMapping(path = INSTANCE_MAPPED_PATH, method = {RequestMethod.GET, RequestMethod.HEAD, RequestMethod.POST,
-		RequestMethod.PUT, RequestMethod.PATCH, RequestMethod.DELETE, RequestMethod.OPTIONS})
+	@RequestMapping(path = INSTANCE_MAPPED_PATH, method = { RequestMethod.GET, RequestMethod.HEAD, RequestMethod.POST,
+			RequestMethod.PUT, RequestMethod.PATCH, RequestMethod.DELETE, RequestMethod.OPTIONS })
 	public void instanceProxy(@PathVariable("instanceId") String instanceId, HttpServletRequest servletRequest) {
 		// start async because we will commit from different thread.
 		// otherwise incorrect thread local objects (session and security context) will be
@@ -97,15 +96,15 @@ public class InstancesProxyController {
 		// for us
 		try {
 			ServletServerHttpRequest request = new ServletServerHttpRequest(
-				(HttpServletRequest) asyncContext.getRequest());
+					(HttpServletRequest) asyncContext.getRequest());
 			Flux<DataBuffer> requestBody = DataBufferUtils.readInputStream(request::getBody, this.bufferFactory, 4096);
 			InstanceWebProxy.ForwardRequest fwdRequest = createForwardRequest(request, requestBody,
-				this.adminContextPath + INSTANCE_MAPPED_PATH);
+					this.adminContextPath + INSTANCE_MAPPED_PATH);
 
 			this.instanceWebProxy
 				.forward(this.registry.getInstance(InstanceId.of(instanceId)), fwdRequest, (clientResponse) -> {
 					ServerHttpResponse response = new ServletServerHttpResponse(
-						(HttpServletResponse) asyncContext.getResponse());
+							(HttpServletResponse) asyncContext.getResponse());
 					response.setStatusCode(clientResponse.statusCode());
 					response.getHeaders()
 						.addAll(this.httpHeadersFilter.filterHeaders(clientResponse.headers().asHttpHeaders()));
@@ -133,22 +132,22 @@ public class InstancesProxyController {
 	}
 
 	@ResponseBody
-	@RequestMapping(path = APPLICATION_MAPPED_PATH, method = {RequestMethod.GET, RequestMethod.HEAD,
-		RequestMethod.POST, RequestMethod.PUT, RequestMethod.PATCH, RequestMethod.DELETE, RequestMethod.OPTIONS})
+	@RequestMapping(path = APPLICATION_MAPPED_PATH, method = { RequestMethod.GET, RequestMethod.HEAD,
+			RequestMethod.POST, RequestMethod.PUT, RequestMethod.PATCH, RequestMethod.DELETE, RequestMethod.OPTIONS })
 	public Flux<InstanceWebProxy.InstanceResponse> endpointProxy(
-		@PathVariable("applicationName") String applicationName, HttpServletRequest servletRequest) {
+			@PathVariable("applicationName") String applicationName, HttpServletRequest servletRequest) {
 
 		ServletServerHttpRequest request = new ServletServerHttpRequest(servletRequest);
 		Flux<DataBuffer> cachedBody = DataBufferUtils.readInputStream(request::getBody, this.bufferFactory, 4096)
 			.cache();
 
 		InstanceWebProxy.ForwardRequest fwdRequest = createForwardRequest(request, cachedBody,
-			this.adminContextPath + APPLICATION_MAPPED_PATH);
+				this.adminContextPath + APPLICATION_MAPPED_PATH);
 		return this.instanceWebProxy.forward(this.registry.getInstances(applicationName), fwdRequest);
 	}
 
 	private InstanceWebProxy.ForwardRequest createForwardRequest(ServletServerHttpRequest request,
-	                                                             Flux<DataBuffer> body, String pathPattern) {
+			Flux<DataBuffer> body, String pathPattern) {
 		String endpointLocalPath = this.getLocalPath(pathPattern, request);
 		URI uri = UriComponentsBuilder.fromPath(endpointLocalPath)
 			.query(request.getURI().getRawQuery())

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/servlet/InstancesProxyController.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/web/servlet/InstancesProxyController.java
@@ -74,14 +74,9 @@ public class InstancesProxyController {
 
 	private final String adminContextPath;
 
-	public InstancesProxyController(String adminContextPath, Set<String> ignoredHeaders, InstanceRegistry registry,
-			InstanceWebClient instanceWebClient) {
-		this(adminContextPath, ignoredHeaders, registry, instanceWebClient, new SsrfUrlValidator(
-				new de.codecentric.boot.admin.server.config.AdminServerProperties.SsrfProtectionProperties()));
-	}
 
 	public InstancesProxyController(String adminContextPath, Set<String> ignoredHeaders, InstanceRegistry registry,
-			InstanceWebClient instanceWebClient, SsrfUrlValidator ssrfUrlValidator) {
+	                                InstanceWebClient instanceWebClient, SsrfUrlValidator ssrfUrlValidator) {
 		this.adminContextPath = adminContextPath;
 		this.registry = registry;
 		this.httpHeadersFilter = new HttpHeaderFilter(ignoredHeaders);
@@ -89,8 +84,8 @@ public class InstancesProxyController {
 	}
 
 	@ResponseBody
-	@RequestMapping(path = INSTANCE_MAPPED_PATH, method = { RequestMethod.GET, RequestMethod.HEAD, RequestMethod.POST,
-			RequestMethod.PUT, RequestMethod.PATCH, RequestMethod.DELETE, RequestMethod.OPTIONS })
+	@RequestMapping(path = INSTANCE_MAPPED_PATH, method = {RequestMethod.GET, RequestMethod.HEAD, RequestMethod.POST,
+		RequestMethod.PUT, RequestMethod.PATCH, RequestMethod.DELETE, RequestMethod.OPTIONS})
 	public void instanceProxy(@PathVariable("instanceId") String instanceId, HttpServletRequest servletRequest) {
 		// start async because we will commit from different thread.
 		// otherwise incorrect thread local objects (session and security context) will be
@@ -102,15 +97,15 @@ public class InstancesProxyController {
 		// for us
 		try {
 			ServletServerHttpRequest request = new ServletServerHttpRequest(
-					(HttpServletRequest) asyncContext.getRequest());
+				(HttpServletRequest) asyncContext.getRequest());
 			Flux<DataBuffer> requestBody = DataBufferUtils.readInputStream(request::getBody, this.bufferFactory, 4096);
 			InstanceWebProxy.ForwardRequest fwdRequest = createForwardRequest(request, requestBody,
-					this.adminContextPath + INSTANCE_MAPPED_PATH);
+				this.adminContextPath + INSTANCE_MAPPED_PATH);
 
 			this.instanceWebProxy
 				.forward(this.registry.getInstance(InstanceId.of(instanceId)), fwdRequest, (clientResponse) -> {
 					ServerHttpResponse response = new ServletServerHttpResponse(
-							(HttpServletResponse) asyncContext.getResponse());
+						(HttpServletResponse) asyncContext.getResponse());
 					response.setStatusCode(clientResponse.statusCode());
 					response.getHeaders()
 						.addAll(this.httpHeadersFilter.filterHeaders(clientResponse.headers().asHttpHeaders()));
@@ -138,22 +133,22 @@ public class InstancesProxyController {
 	}
 
 	@ResponseBody
-	@RequestMapping(path = APPLICATION_MAPPED_PATH, method = { RequestMethod.GET, RequestMethod.HEAD,
-			RequestMethod.POST, RequestMethod.PUT, RequestMethod.PATCH, RequestMethod.DELETE, RequestMethod.OPTIONS })
+	@RequestMapping(path = APPLICATION_MAPPED_PATH, method = {RequestMethod.GET, RequestMethod.HEAD,
+		RequestMethod.POST, RequestMethod.PUT, RequestMethod.PATCH, RequestMethod.DELETE, RequestMethod.OPTIONS})
 	public Flux<InstanceWebProxy.InstanceResponse> endpointProxy(
-			@PathVariable("applicationName") String applicationName, HttpServletRequest servletRequest) {
+		@PathVariable("applicationName") String applicationName, HttpServletRequest servletRequest) {
 
 		ServletServerHttpRequest request = new ServletServerHttpRequest(servletRequest);
 		Flux<DataBuffer> cachedBody = DataBufferUtils.readInputStream(request::getBody, this.bufferFactory, 4096)
 			.cache();
 
 		InstanceWebProxy.ForwardRequest fwdRequest = createForwardRequest(request, cachedBody,
-				this.adminContextPath + APPLICATION_MAPPED_PATH);
+			this.adminContextPath + APPLICATION_MAPPED_PATH);
 		return this.instanceWebProxy.forward(this.registry.getInstances(applicationName), fwdRequest);
 	}
 
 	private InstanceWebProxy.ForwardRequest createForwardRequest(ServletServerHttpRequest request,
-			Flux<DataBuffer> body, String pathPattern) {
+	                                                             Flux<DataBuffer> body, String pathPattern) {
 		String endpointLocalPath = this.getLocalPath(pathPattern, request);
 		URI uri = UriComponentsBuilder.fromPath(endpointLocalPath)
 			.query(request.getURI().getRawQuery())

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/config/AdminServerAutoConfigurationTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/config/AdminServerAutoConfigurationTest.java
@@ -22,6 +22,7 @@ import com.hazelcast.config.Config;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.hazelcast.autoconfigure.HazelcastAutoConfiguration;
+import org.springframework.boot.http.client.InetAddressFilter;
 import org.springframework.boot.http.client.autoconfigure.reactive.ReactiveHttpClientAutoConfiguration;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 import org.springframework.boot.webclient.autoconfigure.WebClientAutoConfiguration;
@@ -39,6 +40,7 @@ import de.codecentric.boot.admin.server.notify.MailNotifier;
 import de.codecentric.boot.admin.server.notify.NotificationTrigger;
 import de.codecentric.boot.admin.server.notify.Notifier;
 import de.codecentric.boot.admin.server.services.StatusUpdater;
+import de.codecentric.boot.admin.server.utils.SsrfUrlValidator;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -87,6 +89,22 @@ class AdminServerAutoConfigurationTest {
 				StatusUpdater updater = context.getBean(StatusUpdater.class);
 				assertThat(updater).extracting("timeout").isEqualTo(Duration.ofSeconds(10));
 			});
+	}
+
+	@Test
+	void shouldNotRegisterInetAddressFilterByDefault() {
+		this.contextRunner.run((context) -> {
+			assertThat(context).doesNotHaveBean(InetAddressFilter.class);
+			assertThat(context).hasSingleBean(SsrfUrlValidator.class);
+		});
+	}
+
+	@Test
+	void shouldRegisterInetAddressFilterWhenSsrfProtectionEnabled() {
+		this.contextRunner.withPropertyValues("spring.boot.admin.ssrf-protection.enabled=true").run((context) -> {
+			assertThat(context).hasSingleBean(InetAddressFilter.class);
+			assertThat(context).hasSingleBean(SsrfUrlValidator.class);
+		});
 	}
 
 	public static class TestHazelcastConfig {

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/services/InstanceRegistryTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/services/InstanceRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2024 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,9 +20,11 @@ import java.util.ArrayList;
 import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
 
+import de.codecentric.boot.admin.server.config.AdminServerProperties.SsrfProtectionProperties;
 import de.codecentric.boot.admin.server.domain.entities.EventsourcingInstanceRepository;
 import de.codecentric.boot.admin.server.domain.entities.Instance;
 import de.codecentric.boot.admin.server.domain.entities.InstanceRepository;
@@ -31,6 +33,8 @@ import de.codecentric.boot.admin.server.domain.values.InstanceId;
 import de.codecentric.boot.admin.server.domain.values.Registration;
 import de.codecentric.boot.admin.server.domain.values.StatusInfo;
 import de.codecentric.boot.admin.server.eventstore.InMemoryEventStore;
+import de.codecentric.boot.admin.server.utils.SsrfUrlValidator;
+import de.codecentric.boot.admin.server.web.client.exception.SsrfProtectionException;
 
 import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -135,6 +139,66 @@ class InstanceRegistryTest {
 			.consumeRecordedWith(
 					(applications) -> assertThat(applications.stream().map(Instance::getId)).containsExactly(id1))
 			.verifyComplete();
+	}
+
+	@Nested
+	class SsrfProtection {
+
+		private InstanceRegistry ssrfRegistry;
+
+		@BeforeEach
+		void setUp() {
+			SsrfProtectionProperties ssrfProps = new SsrfProtectionProperties();
+			ssrfProps.setEnabled(true);
+			SsrfUrlValidator ssrfValidator = new SsrfUrlValidator(ssrfProps);
+			ssrfRegistry = new InstanceRegistry(repository, idGenerator, (instance) -> true, ssrfValidator);
+		}
+
+		@Test
+		void register_rejects_awsMetadataHealthUrl() {
+			Registration reg = Registration.create("evil", "http://169.254.169.254/latest/meta-data/").build();
+			assertThatThrownBy(() -> ssrfRegistry.register(reg).block()).isInstanceOf(SsrfProtectionException.class)
+				.hasMessageContaining("link-local");
+		}
+
+		@Test
+		void register_rejects_loopbackManagementUrl() {
+			Registration reg = Registration.create("evil", "http://example.com/health")
+				.managementUrl("http://127.0.0.1:8080/actuator")
+				.build();
+			assertThatThrownBy(() -> ssrfRegistry.register(reg).block()).isInstanceOf(SsrfProtectionException.class)
+				.hasMessageContaining("loopback");
+		}
+
+		@Test
+		void register_rejects_privateRangeServiceUrl() {
+			Registration reg = Registration.create("evil", "http://example.com/health")
+				.serviceUrl("http://192.168.1.1/")
+				.build();
+			assertThatThrownBy(() -> ssrfRegistry.register(reg).block()).isInstanceOf(SsrfProtectionException.class)
+				.hasMessageContaining("192.168.0.0/16");
+		}
+
+		@Test
+		void register_allows_externalUrl_whenSsrfEnabled() {
+			Registration reg = Registration.create("legit", "http://example.com/actuator/health").build();
+			InstanceId id = ssrfRegistry.register(reg).block();
+			assertThat(id).isNotNull();
+		}
+
+		@Test
+		void register_allows_allowlistedPrivateHost() {
+			SsrfProtectionProperties ssrfProps = new SsrfProtectionProperties();
+			ssrfProps.setEnabled(true);
+			ssrfProps.getAllowedHosts().add("192.168.1.100");
+			ssrfRegistry = new InstanceRegistry(repository, idGenerator, (instance) -> true,
+					new SsrfUrlValidator(ssrfProps));
+
+			Registration reg = Registration.create("intranet-svc", "http://192.168.1.100/actuator/health").build();
+			InstanceId id = ssrfRegistry.register(reg).block();
+			assertThat(id).isNotNull();
+		}
+
 	}
 
 }

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/services/InstanceRegistryTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/services/InstanceRegistryTest.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.http.client.InetAddressFilter;
 import reactor.test.StepVerifier;
 
 import de.codecentric.boot.admin.server.config.AdminServerProperties.SsrfProtectionProperties;
@@ -150,7 +151,7 @@ class InstanceRegistryTest {
 		void setUp() {
 			SsrfProtectionProperties ssrfProps = new SsrfProtectionProperties();
 			ssrfProps.setEnabled(true);
-			SsrfUrlValidator ssrfValidator = new SsrfUrlValidator(ssrfProps);
+			SsrfUrlValidator ssrfValidator = new SsrfUrlValidator(ssrfProps, InetAddressFilter.externalAddresses());
 			ssrfRegistry = new InstanceRegistry(repository, idGenerator, (instance) -> true, ssrfValidator);
 		}
 
@@ -158,7 +159,7 @@ class InstanceRegistryTest {
 		void register_rejects_awsMetadataHealthUrl() {
 			Registration reg = Registration.create("evil", "http://169.254.169.254/latest/meta-data/").build();
 			assertThatThrownBy(() -> ssrfRegistry.register(reg).block()).isInstanceOf(SsrfProtectionException.class)
-				.hasMessageContaining("link-local");
+				.hasMessageContaining("not permitted by the configured InetAddressFilter");
 		}
 
 		@Test
@@ -167,7 +168,7 @@ class InstanceRegistryTest {
 				.managementUrl("http://127.0.0.1:8080/actuator")
 				.build();
 			assertThatThrownBy(() -> ssrfRegistry.register(reg).block()).isInstanceOf(SsrfProtectionException.class)
-				.hasMessageContaining("loopback");
+				.hasMessageContaining("not permitted by the configured InetAddressFilter");
 		}
 
 		@Test
@@ -176,7 +177,7 @@ class InstanceRegistryTest {
 				.serviceUrl("http://192.168.1.1/")
 				.build();
 			assertThatThrownBy(() -> ssrfRegistry.register(reg).block()).isInstanceOf(SsrfProtectionException.class)
-				.hasMessageContaining("192.168.0.0/16");
+				.hasMessageContaining("not permitted by the configured InetAddressFilter");
 		}
 
 		@Test
@@ -187,16 +188,48 @@ class InstanceRegistryTest {
 		}
 
 		@Test
-		void register_allows_allowlistedPrivateHost() {
+		void register_allows_privateHost_whenCustomFilterPermitsIt() {
 			SsrfProtectionProperties ssrfProps = new SsrfProtectionProperties();
 			ssrfProps.setEnabled(true);
-			ssrfProps.getAllowedHosts().add("192.168.1.100");
+			// Extend the default external filter to also allow 192.168.1.0/24
+			InetAddressFilter customFilter = InetAddressFilter.externalAddresses().or("192.168.1.0/24");
 			ssrfRegistry = new InstanceRegistry(repository, idGenerator, (instance) -> true,
-					new SsrfUrlValidator(ssrfProps));
+					new SsrfUrlValidator(ssrfProps, customFilter));
 
 			Registration reg = Registration.create("intranet-svc", "http://192.168.1.100/actuator/health").build();
 			InstanceId id = ssrfRegistry.register(reg).block();
 			assertThat(id).isNotNull();
+		}
+
+		@Test
+		void register_allows_cidrRange_whenConfiguredViaProperty() {
+			SsrfProtectionProperties ssrfProps = new SsrfProtectionProperties();
+			ssrfProps.setEnabled(true);
+			ssrfProps.setAllowedCidrs(java.util.List.of("10.0.0.0/8"));
+			InetAddressFilter filter = InetAddressFilter.externalAddresses()
+				.or(ssrfProps.getAllowedCidrs().toArray(String[]::new));
+			ssrfRegistry = new InstanceRegistry(repository, idGenerator, (instance) -> true,
+					new SsrfUrlValidator(ssrfProps, filter));
+
+			Registration reg = Registration.create("pod", "http://10.42.0.5/actuator/health").build();
+			InstanceId id = ssrfRegistry.register(reg).block();
+			assertThat(id).isNotNull();
+		}
+
+		@Test
+		void register_rejects_addressOutsideAllowedCidr() {
+			SsrfProtectionProperties ssrfProps = new SsrfProtectionProperties();
+			ssrfProps.setEnabled(true);
+			ssrfProps.setAllowedCidrs(java.util.List.of("192.168.1.0/24"));
+			InetAddressFilter filter = InetAddressFilter.externalAddresses()
+				.or(ssrfProps.getAllowedCidrs().toArray(String[]::new));
+			ssrfRegistry = new InstanceRegistry(repository, idGenerator, (instance) -> true,
+					new SsrfUrlValidator(ssrfProps, filter));
+
+			// 192.168.2.1 is outside the allowed 192.168.1.0/24
+			Registration reg = Registration.create("evil", "http://192.168.2.1/actuator/health").build();
+			assertThatThrownBy(() -> ssrfRegistry.register(reg).block()).isInstanceOf(SsrfProtectionException.class)
+				.hasMessageContaining("not permitted by the configured InetAddressFilter");
 		}
 
 	}

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/utils/SsrfUrlValidatorTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/utils/SsrfUrlValidatorTest.java
@@ -84,6 +84,59 @@ class SsrfUrlValidatorTest {
 	}
 
 	// -------------------------------------------------------------------------
+	// URL encoding / notation bypass attempts
+	// -------------------------------------------------------------------------
+
+	@Nested
+	class BypassAttempts {
+
+		@Test
+		void blocks_decimalEncodedPrivateIp() {
+			// 169.254.169.254 expressed as a single 32-bit decimal integer.
+			// java.net.URI parses "2852039166" as a hostname; InetAddress resolves
+			// it to the link-local metadata address. Verifies SBA relies correctly
+			// on InetAddress resolution rather than string matching.
+			assertThatThrownBy(() -> validator.validate("http://2852039166/latest/meta-data"))
+				.isInstanceOf(SsrfProtectionException.class);
+		}
+
+		@Test
+		void blocks_decimalEncodedLoopback() {
+			// 127.0.0.1 as a 32-bit decimal integer (2130706433).
+			assertThatThrownBy(() -> validator.validate("http://2130706433/"))
+				.isInstanceOf(SsrfProtectionException.class);
+		}
+
+		@Test
+		void rejects_octalEncodedPrivateIp() {
+			// 0251.0376.0251.0376 is octal for 169.254.169.254.
+			// java.net.URI cannot parse octal notation and returns host=null with a
+			// non-null authority — rejected to prevent bypass.
+			assertThatThrownBy(() -> validator.validate("http://0251.0376.0251.0376/"))
+				.isInstanceOf(SsrfProtectionException.class)
+				.hasMessageContaining("cannot be parsed and validated");
+		}
+
+		@Test
+		void rejects_unicodeDigitHost() {
+			// Unicode digit characters that look like "127.0.0.1" — URI returns
+			// host=null with a non-null authority, so we reject rather than skip.
+			assertThatThrownBy(() -> validator.validate("http://①②⑦.0.0.1/"))
+				.isInstanceOf(SsrfProtectionException.class)
+				.hasMessageContaining("cannot be parsed and validated");
+		}
+
+		@Test
+		void blocks_schemeCaseVariant_upper() {
+			// HTTP:// (uppercase) must still be normalised and blocked when pointing
+			// to a private address — SBA's checkScheme() uses scheme.toLowerCase().
+			assertThatThrownBy(() -> validator.validate("HTTP://127.0.0.1/"))
+				.isInstanceOf(SsrfProtectionException.class);
+		}
+
+	}
+
+	// -------------------------------------------------------------------------
 	// Scheme checks
 	// -------------------------------------------------------------------------
 

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/utils/SsrfUrlValidatorTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/utils/SsrfUrlValidatorTest.java
@@ -16,13 +16,12 @@
 
 package de.codecentric.boot.admin.server.utils;
 
-import java.util.List;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.boot.http.client.InetAddressFilter;
 
 import de.codecentric.boot.admin.server.config.AdminServerProperties.SsrfProtectionProperties;
 import de.codecentric.boot.admin.server.web.client.exception.SsrfProtectionException;
@@ -40,7 +39,7 @@ class SsrfUrlValidatorTest {
 	void setUp() {
 		properties = new SsrfProtectionProperties();
 		properties.setEnabled(true);
-		validator = new SsrfUrlValidator(properties);
+		validator = new SsrfUrlValidator(properties, InetAddressFilter.externalAddresses());
 	}
 
 	@Test
@@ -59,16 +58,16 @@ class SsrfUrlValidatorTest {
 	}
 
 	@Test
-	void blocks_unspecifiedAddress() {
-		assertThatThrownBy(() -> validator.validate("http://0.0.0.0/")).isInstanceOf(SsrfProtectionException.class)
-			.hasMessageContaining("unspecified address");
+	void ignores_unresolvableHost() {
+		// Unknown hosts cannot be resolved at registration time; the HTTP client's
+		// InetAddressFilter will enforce the policy when a connection is attempted.
+		assertThatCode(() -> validator.validate("http://this-host-does-not-exist.invalid/health"))
+			.doesNotThrowAnyException();
 	}
 
 	@ParameterizedTest
 	@ValueSource(strings = { "http://example.com/actuator/health", "https://api.example.com/admin/health",
-			"https://93.184.216.34/health", // example.com IP
-			"http://172.15.0.1/health", // just outside 172.16-31 range
-			"http://172.32.0.1/health" // just above 172.16-31 range
+			"https://93.184.216.34/health" // example.com IP
 	})
 	void allows_publicUrls(String url) {
 		assertThatCode(() -> validator.validate(url)).doesNotThrowAnyException();
@@ -125,14 +124,14 @@ class SsrfUrlValidatorTest {
 				"http://127.255.255.255/health" })
 		void blocks_loopbackIpv4(String url) {
 			assertThatThrownBy(() -> validator.validate(url)).isInstanceOf(SsrfProtectionException.class)
-				.hasMessageContaining("loopback");
+				.hasMessageContaining("not permitted by the configured InetAddressFilter");
 		}
 
 		@ParameterizedTest
 		@ValueSource(strings = { "http://[::1]/health", "http://[0:0:0:0:0:0:0:1]/health" })
 		void blocks_loopbackIpv6(String url) {
 			assertThatThrownBy(() -> validator.validate(url)).isInstanceOf(SsrfProtectionException.class)
-				.hasMessageContaining("loopback");
+				.hasMessageContaining("not permitted by the configured InetAddressFilter");
 		}
 
 	}
@@ -149,14 +148,14 @@ class SsrfUrlValidatorTest {
 				"http://169.254.169.254/latest/meta-data/iam/security-credentials/", "http://169.254.0.1/anything" })
 		void blocks_awsMetadataEndpoint(String url) {
 			assertThatThrownBy(() -> validator.validate(url)).isInstanceOf(SsrfProtectionException.class)
-				.hasMessageContaining("link-local");
+				.hasMessageContaining("not permitted by the configured InetAddressFilter");
 		}
 
 		@Test
 		void blocks_ipv6LinkLocal() {
 			assertThatThrownBy(() -> validator.validate("http://[fe80::1]/path"))
 				.isInstanceOf(SsrfProtectionException.class)
-				.hasMessageContaining("link-local");
+				.hasMessageContaining("not permitted by the configured InetAddressFilter");
 		}
 
 	}
@@ -172,21 +171,21 @@ class SsrfUrlValidatorTest {
 		@ValueSource(strings = { "http://10.0.0.1/", "http://10.255.255.255/health" })
 		void blocks_classA(String url) {
 			assertThatThrownBy(() -> validator.validate(url)).isInstanceOf(SsrfProtectionException.class)
-				.hasMessageContaining("10.0.0.0/8");
+				.hasMessageContaining("not permitted by the configured InetAddressFilter");
 		}
 
 		@ParameterizedTest
 		@ValueSource(strings = { "http://192.168.0.1/", "http://192.168.255.254/" })
 		void blocks_classC(String url) {
 			assertThatThrownBy(() -> validator.validate(url)).isInstanceOf(SsrfProtectionException.class)
-				.hasMessageContaining("192.168.0.0/16");
+				.hasMessageContaining("not permitted by the configured InetAddressFilter");
 		}
 
 		@ParameterizedTest
 		@ValueSource(strings = { "http://172.16.0.1/", "http://172.20.1.1/", "http://172.31.255.255/" })
 		void blocks_classB(String url) {
 			assertThatThrownBy(() -> validator.validate(url)).isInstanceOf(SsrfProtectionException.class)
-				.hasMessageContaining("172.16.0.0/12");
+				.hasMessageContaining("not permitted by the configured InetAddressFilter");
 		}
 
 		@ParameterizedTest
@@ -199,7 +198,7 @@ class SsrfUrlValidatorTest {
 	}
 
 	// -------------------------------------------------------------------------
-	// IPv6 unique-local and IPv4-mapped
+	// IPv6 special ranges
 	// -------------------------------------------------------------------------
 
 	@Nested
@@ -209,88 +208,120 @@ class SsrfUrlValidatorTest {
 		@ValueSource(strings = { "http://[fc00::1]/", "http://[fd12:3456:789a::1]/" })
 		void blocks_uniqueLocal(String url) {
 			assertThatThrownBy(() -> validator.validate(url)).isInstanceOf(SsrfProtectionException.class)
-				.hasMessageContaining("unique-local");
-		}
-
-		@Test
-		void blocks_ipv4MappedPrivate() {
-			// ::ffff:192.168.1.1 embeds a private IPv4 address
-			assertThatThrownBy(() -> validator.validate("http://[::ffff:192.168.1.1]/"))
-				.isInstanceOf(SsrfProtectionException.class)
-				.hasMessageContaining("192.168.0.0/16");
-		}
-
-		@Test
-		void allows_ipv4MappedPublic() {
-			// ::ffff:93.184.216.34 embeds a public IPv4 address (example.com)
-			assertThatCode(() -> validator.validate("http://[::ffff:93.184.216.34]/")).doesNotThrowAnyException();
+				.hasMessageContaining("not permitted by the configured InetAddressFilter");
 		}
 
 	}
 
 	// -------------------------------------------------------------------------
-	// Allowlist overrides
+	// Allowed CIDRs (property-driven filter extension)
 	// -------------------------------------------------------------------------
 
 	@Nested
-	class AllowlistOverrides {
+	class AllowedCidrs {
 
-		@Test
-		void allowedHost_exactMatch_overridesBlockedRange() {
-			properties.setAllowedHosts(List.of("192.168.1.100"));
-			assertThatCode(() -> validator.validate("http://192.168.1.100/actuator/health")).doesNotThrowAnyException();
+		private SsrfUrlValidator cidrValidator(String... cidrs) {
+			properties.setAllowedCidrs(java.util.List.of(cidrs));
+			InetAddressFilter filter = buildFilterFromProperties(properties);
+			return new SsrfUrlValidator(properties, filter);
+		}
+
+		// Mirrors the logic in AdminServerAutoConfiguration.ssrfInetAddressFilter()
+		private InetAddressFilter buildFilterFromProperties(
+				de.codecentric.boot.admin.server.config.AdminServerProperties.SsrfProtectionProperties props) {
+			InetAddressFilter filter = InetAddressFilter.externalAddresses();
+			if (!props.getAllowedCidrs().isEmpty()) {
+				filter = filter.or(props.getAllowedCidrs().toArray(String[]::new));
+			}
+			return filter;
 		}
 
 		@Test
-		void allowedHost_globSuffix_overridesBlockedPatterns() {
-			properties.setAllowedHosts(List.of("*.internal.corp"));
-			assertThatCode(() -> validator.validate("http://svc.internal.corp/actuator/health"))
+		void allows_exactIpInAllowedCidr() {
+			SsrfUrlValidator v = cidrValidator("192.168.1.0/24");
+			assertThatCode(() -> v.validate("http://192.168.1.100/actuator/health")).doesNotThrowAnyException();
+		}
+
+		@Test
+		void allows_firstAddressInCidr() {
+			SsrfUrlValidator v = cidrValidator("10.0.0.0/8");
+			assertThatCode(() -> v.validate("http://10.0.0.1/health")).doesNotThrowAnyException();
+		}
+
+		@Test
+		void allows_lastAddressInCidr() {
+			SsrfUrlValidator v = cidrValidator("192.168.1.0/24");
+			assertThatCode(() -> v.validate("http://192.168.1.254/health")).doesNotThrowAnyException();
+		}
+
+		@Test
+		void blocks_addressOutsideAllowedCidr() {
+			SsrfUrlValidator v = cidrValidator("192.168.1.0/24");
+			// 192.168.2.1 is outside 192.168.1.0/24
+			assertThatThrownBy(() -> v.validate("http://192.168.2.1/health"))
+				.isInstanceOf(SsrfProtectionException.class)
+				.hasMessageContaining("not permitted by the configured InetAddressFilter");
+		}
+
+		@Test
+		void allows_singleHostCidr() {
+			SsrfUrlValidator v = cidrValidator("10.1.2.3/32");
+			assertThatCode(() -> v.validate("http://10.1.2.3/health")).doesNotThrowAnyException();
+		}
+
+		@Test
+		void blocks_neighbourOfSingleHostCidr() {
+			SsrfUrlValidator v = cidrValidator("10.1.2.3/32");
+			assertThatThrownBy(() -> v.validate("http://10.1.2.4/health")).isInstanceOf(SsrfProtectionException.class)
+				.hasMessageContaining("not permitted by the configured InetAddressFilter");
+		}
+
+		@Test
+		void allows_ipv6Cidr() {
+			SsrfUrlValidator v = cidrValidator("fd00::/8");
+			assertThatCode(() -> v.validate("http://[fd12:3456:789a::1]/health")).doesNotThrowAnyException();
+		}
+
+		@Test
+		void allows_multipleCidrs() {
+			SsrfUrlValidator v = cidrValidator("10.0.0.0/8", "192.168.1.0/24");
+			assertThatCode(() -> v.validate("http://10.0.0.1/health")).doesNotThrowAnyException();
+			assertThatCode(() -> v.validate("http://192.168.1.50/health")).doesNotThrowAnyException();
+		}
+
+		@Test
+		void allows_externalAddressWithCidrConfigured() {
+			// Configuring a CIDR allowlist must not break external address access
+			SsrfUrlValidator v = cidrValidator("192.168.1.0/24");
+			assertThatCode(() -> v.validate("http://example.com/health")).doesNotThrowAnyException();
+		}
+
+	}
+
+	// -------------------------------------------------------------------------
+	// Custom InetAddressFilter
+	// -------------------------------------------------------------------------
+
+	@Nested
+	class CustomInetAddressFilter {
+
+		@Test
+		void allowsPrivateAddress_whenFilterPermitsIt() {
+			// A custom filter that also allows 192.168.1.0/24
+			InetAddressFilter customFilter = InetAddressFilter.externalAddresses().or("192.168.1.0/24");
+			SsrfUrlValidator customValidator = new SsrfUrlValidator(properties, customFilter);
+			assertThatCode(() -> customValidator.validate("http://192.168.1.100/actuator/health"))
 				.doesNotThrowAnyException();
 		}
 
 		@Test
-		void allowedHost_globSuffix_doesNotMatchUnrelatedHost() {
-			properties.setAllowedHosts(List.of("*.internal.corp"));
-			properties.setBlockedHostPatterns(List.of(".*\\.evil\\.corp$"));
-			assertThatThrownBy(() -> validator.validate("http://svc.evil.corp/actuator/health"))
+		void blocksAddress_whenFilterRejectsIt() {
+			// A filter that only allows a specific public IP
+			InetAddressFilter customFilter = InetAddressFilter.of("93.184.216.34/32");
+			SsrfUrlValidator customValidator = new SsrfUrlValidator(properties, customFilter);
+			assertThatThrownBy(() -> customValidator.validate("http://10.0.0.1/health"))
 				.isInstanceOf(SsrfProtectionException.class)
-				.hasMessageContaining("blocked pattern");
-		}
-
-		@Test
-		void allowedHost_exactMatch_isCaseInsensitive() {
-			properties.setAllowedHosts(List.of("MY-INTERNAL-HOST"));
-			assertThatCode(() -> validator.validate("http://my-internal-host/health")).doesNotThrowAnyException();
-		}
-
-	}
-
-	// -------------------------------------------------------------------------
-	// User-supplied blocked patterns
-	// -------------------------------------------------------------------------
-
-	@Nested
-	class BlockedHostPatterns {
-
-		@Test
-		void blocks_hostMatchingCustomPattern() {
-			properties.setBlockedHostPatterns(List.of(".*\\.internal\\.corp$"));
-			assertThatThrownBy(() -> validator.validate("http://svc.internal.corp/health"))
-				.isInstanceOf(SsrfProtectionException.class)
-				.hasMessageContaining("blocked pattern");
-		}
-
-		@Test
-		void ignores_invalidRegexPattern_withoutThrowing() {
-			properties.setBlockedHostPatterns(List.of("[invalid-regex"));
-			// Should log a warning but not throw
-			assertThatCode(() -> validator.validate("http://example.com/health")).doesNotThrowAnyException();
-		}
-
-		@Test
-		void allows_hostNotMatchingCustomPattern() {
-			properties.setBlockedHostPatterns(List.of(".*\\.internal\\.corp$"));
-			assertThatCode(() -> validator.validate("http://example.com/health")).doesNotThrowAnyException();
+				.hasMessageContaining("not permitted by the configured InetAddressFilter");
 		}
 
 	}

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/utils/SsrfUrlValidatorTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/utils/SsrfUrlValidatorTest.java
@@ -58,6 +58,16 @@ class SsrfUrlValidatorTest {
 	}
 
 	@Test
+	void rejects_malformedUrl() {
+		// A syntactically invalid URI must be rejected, not silently accepted.
+		// Otherwise a crafted string that new URI() cannot parse but an HTTP client
+		// would normalise to a private address bypasses all checks.
+		assertThatThrownBy(() -> validator.validate("http://169.254.169.254\\ @evil.com/"))
+			.isInstanceOf(SsrfProtectionException.class)
+			.hasMessageContaining("not a valid URI");
+	}
+
+	@Test
 	void ignores_unresolvableHost() {
 		// Unknown hosts cannot be resolved at registration time; the HTTP client's
 		// InetAddressFilter will enforce the policy when a connection is attempted.

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/utils/SsrfUrlValidatorTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/utils/SsrfUrlValidatorTest.java
@@ -1,0 +1,298 @@
+/*
+ * Copyright 2014-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.codecentric.boot.admin.server.utils;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import de.codecentric.boot.admin.server.config.AdminServerProperties.SsrfProtectionProperties;
+import de.codecentric.boot.admin.server.web.client.exception.SsrfProtectionException;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class SsrfUrlValidatorTest {
+
+	private SsrfProtectionProperties properties;
+
+	private SsrfUrlValidator validator;
+
+	@BeforeEach
+	void setUp() {
+		properties = new SsrfProtectionProperties();
+		properties.setEnabled(true);
+		validator = new SsrfUrlValidator(properties);
+	}
+
+	@Test
+	void doesNothing_whenDisabled() {
+		properties.setEnabled(false);
+		assertThatCode(() -> validator.validate("http://169.254.169.254/latest/meta-data")).doesNotThrowAnyException();
+		assertThatCode(() -> validator.validate("http://127.0.0.1/")).doesNotThrowAnyException();
+		assertThatCode(() -> validator.validate("file:///etc/passwd")).doesNotThrowAnyException();
+	}
+
+	@Test
+	void ignores_nullAndBlankUrls() {
+		assertThatCode(() -> validator.validate(null)).doesNotThrowAnyException();
+		assertThatCode(() -> validator.validate("")).doesNotThrowAnyException();
+		assertThatCode(() -> validator.validate("   ")).doesNotThrowAnyException();
+	}
+
+	@Test
+	void blocks_unspecifiedAddress() {
+		assertThatThrownBy(() -> validator.validate("http://0.0.0.0/")).isInstanceOf(SsrfProtectionException.class)
+			.hasMessageContaining("unspecified address");
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "http://example.com/actuator/health", "https://api.example.com/admin/health",
+			"https://93.184.216.34/health", // example.com IP
+			"http://172.15.0.1/health", // just outside 172.16-31 range
+			"http://172.32.0.1/health" // just above 172.16-31 range
+	})
+	void allows_publicUrls(String url) {
+		assertThatCode(() -> validator.validate(url)).doesNotThrowAnyException();
+	}
+
+	// -------------------------------------------------------------------------
+	// Scheme checks
+	// -------------------------------------------------------------------------
+
+	@Nested
+	class SchemeValidation {
+
+		@Test
+		void allows_http() {
+			assertThatCode(() -> validator.validate("http://example.com/health")).doesNotThrowAnyException();
+		}
+
+		@Test
+		void allows_https() {
+			assertThatCode(() -> validator.validate("https://example.com/health")).doesNotThrowAnyException();
+		}
+
+		@Test
+		void blocks_fileScheme() {
+			assertThatThrownBy(() -> validator.validate("file:///etc/passwd"))
+				.isInstanceOf(SsrfProtectionException.class)
+				.hasMessageContaining("disallowed scheme");
+		}
+
+		@Test
+		void blocks_ftpScheme() {
+			assertThatThrownBy(() -> validator.validate("ftp://internal-host/"))
+				.isInstanceOf(SsrfProtectionException.class)
+				.hasMessageContaining("disallowed scheme");
+		}
+
+		@Test
+		void allows_customScheme_whenConfigured() {
+			properties.getAllowedSchemes().add("ftp");
+			assertThatCode(() -> validator.validate("ftp://public-ftp.example.com/")).doesNotThrowAnyException();
+		}
+
+	}
+
+	// -------------------------------------------------------------------------
+	// Loopback addresses
+	// -------------------------------------------------------------------------
+
+	@Nested
+	class LoopbackAddresses {
+
+		@ParameterizedTest
+		@ValueSource(strings = { "http://localhost/health", "http://127.0.0.1/health", "http://127.0.0.2/health",
+				"http://127.255.255.255/health" })
+		void blocks_loopbackIpv4(String url) {
+			assertThatThrownBy(() -> validator.validate(url)).isInstanceOf(SsrfProtectionException.class)
+				.hasMessageContaining("loopback");
+		}
+
+		@ParameterizedTest
+		@ValueSource(strings = { "http://[::1]/health", "http://[0:0:0:0:0:0:0:1]/health" })
+		void blocks_loopbackIpv6(String url) {
+			assertThatThrownBy(() -> validator.validate(url)).isInstanceOf(SsrfProtectionException.class)
+				.hasMessageContaining("loopback");
+		}
+
+	}
+
+	// -------------------------------------------------------------------------
+	// Link-local (cloud metadata endpoints)
+	// -------------------------------------------------------------------------
+
+	@Nested
+	class LinkLocalAddresses {
+
+		@ParameterizedTest
+		@ValueSource(strings = { "http://169.254.169.254/latest/meta-data",
+				"http://169.254.169.254/latest/meta-data/iam/security-credentials/", "http://169.254.0.1/anything" })
+		void blocks_awsMetadataEndpoint(String url) {
+			assertThatThrownBy(() -> validator.validate(url)).isInstanceOf(SsrfProtectionException.class)
+				.hasMessageContaining("link-local");
+		}
+
+		@Test
+		void blocks_ipv6LinkLocal() {
+			assertThatThrownBy(() -> validator.validate("http://[fe80::1]/path"))
+				.isInstanceOf(SsrfProtectionException.class)
+				.hasMessageContaining("link-local");
+		}
+
+	}
+
+	// -------------------------------------------------------------------------
+	// RFC 1918 private ranges
+	// -------------------------------------------------------------------------
+
+	@Nested
+	class PrivateRanges {
+
+		@ParameterizedTest
+		@ValueSource(strings = { "http://10.0.0.1/", "http://10.255.255.255/health" })
+		void blocks_classA(String url) {
+			assertThatThrownBy(() -> validator.validate(url)).isInstanceOf(SsrfProtectionException.class)
+				.hasMessageContaining("10.0.0.0/8");
+		}
+
+		@ParameterizedTest
+		@ValueSource(strings = { "http://192.168.0.1/", "http://192.168.255.254/" })
+		void blocks_classC(String url) {
+			assertThatThrownBy(() -> validator.validate(url)).isInstanceOf(SsrfProtectionException.class)
+				.hasMessageContaining("192.168.0.0/16");
+		}
+
+		@ParameterizedTest
+		@ValueSource(strings = { "http://172.16.0.1/", "http://172.20.1.1/", "http://172.31.255.255/" })
+		void blocks_classB(String url) {
+			assertThatThrownBy(() -> validator.validate(url)).isInstanceOf(SsrfProtectionException.class)
+				.hasMessageContaining("172.16.0.0/12");
+		}
+
+		@ParameterizedTest
+		@ValueSource(strings = { "http://172.15.0.1/", "http://172.32.0.1/" })
+		void doesNotBlock_outsideClassBRange(String url) {
+			// 172.15.x and 172.32.x are NOT in 172.16-31.x
+			assertThatCode(() -> validator.validate(url)).doesNotThrowAnyException();
+		}
+
+	}
+
+	// -------------------------------------------------------------------------
+	// IPv6 unique-local and IPv4-mapped
+	// -------------------------------------------------------------------------
+
+	@Nested
+	class Ipv6SpecialRanges {
+
+		@ParameterizedTest
+		@ValueSource(strings = { "http://[fc00::1]/", "http://[fd12:3456:789a::1]/" })
+		void blocks_uniqueLocal(String url) {
+			assertThatThrownBy(() -> validator.validate(url)).isInstanceOf(SsrfProtectionException.class)
+				.hasMessageContaining("unique-local");
+		}
+
+		@Test
+		void blocks_ipv4MappedPrivate() {
+			// ::ffff:192.168.1.1 embeds a private IPv4 address
+			assertThatThrownBy(() -> validator.validate("http://[::ffff:192.168.1.1]/"))
+				.isInstanceOf(SsrfProtectionException.class)
+				.hasMessageContaining("192.168.0.0/16");
+		}
+
+		@Test
+		void allows_ipv4MappedPublic() {
+			// ::ffff:93.184.216.34 embeds a public IPv4 address (example.com)
+			assertThatCode(() -> validator.validate("http://[::ffff:93.184.216.34]/")).doesNotThrowAnyException();
+		}
+
+	}
+
+	// -------------------------------------------------------------------------
+	// Allowlist overrides
+	// -------------------------------------------------------------------------
+
+	@Nested
+	class AllowlistOverrides {
+
+		@Test
+		void allowedHost_exactMatch_overridesBlockedRange() {
+			properties.setAllowedHosts(List.of("192.168.1.100"));
+			assertThatCode(() -> validator.validate("http://192.168.1.100/actuator/health")).doesNotThrowAnyException();
+		}
+
+		@Test
+		void allowedHost_globSuffix_overridesBlockedPatterns() {
+			properties.setAllowedHosts(List.of("*.internal.corp"));
+			assertThatCode(() -> validator.validate("http://svc.internal.corp/actuator/health"))
+				.doesNotThrowAnyException();
+		}
+
+		@Test
+		void allowedHost_globSuffix_doesNotMatchUnrelatedHost() {
+			properties.setAllowedHosts(List.of("*.internal.corp"));
+			properties.setBlockedHostPatterns(List.of(".*\\.evil\\.corp$"));
+			assertThatThrownBy(() -> validator.validate("http://svc.evil.corp/actuator/health"))
+				.isInstanceOf(SsrfProtectionException.class)
+				.hasMessageContaining("blocked pattern");
+		}
+
+		@Test
+		void allowedHost_exactMatch_isCaseInsensitive() {
+			properties.setAllowedHosts(List.of("MY-INTERNAL-HOST"));
+			assertThatCode(() -> validator.validate("http://my-internal-host/health")).doesNotThrowAnyException();
+		}
+
+	}
+
+	// -------------------------------------------------------------------------
+	// User-supplied blocked patterns
+	// -------------------------------------------------------------------------
+
+	@Nested
+	class BlockedHostPatterns {
+
+		@Test
+		void blocks_hostMatchingCustomPattern() {
+			properties.setBlockedHostPatterns(List.of(".*\\.internal\\.corp$"));
+			assertThatThrownBy(() -> validator.validate("http://svc.internal.corp/health"))
+				.isInstanceOf(SsrfProtectionException.class)
+				.hasMessageContaining("blocked pattern");
+		}
+
+		@Test
+		void ignores_invalidRegexPattern_withoutThrowing() {
+			properties.setBlockedHostPatterns(List.of("[invalid-regex"));
+			// Should log a warning but not throw
+			assertThatCode(() -> validator.validate("http://example.com/health")).doesNotThrowAnyException();
+		}
+
+		@Test
+		void allows_hostNotMatchingCustomPattern() {
+			properties.setBlockedHostPatterns(List.of(".*\\.internal\\.corp$"));
+			assertThatCode(() -> validator.validate("http://example.com/health")).doesNotThrowAnyException();
+		}
+
+	}
+
+}

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/utils/SsrfUrlValidatorTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/utils/SsrfUrlValidatorTest.java
@@ -16,6 +16,8 @@
 
 package de.codecentric.boot.admin.server.utils;
 
+import java.net.URI;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -52,7 +54,8 @@ class SsrfUrlValidatorTest {
 
 	@Test
 	void ignores_nullAndBlankUrls() {
-		assertThatCode(() -> validator.validate(null)).doesNotThrowAnyException();
+		assertThatCode(() -> validator.validate((String) null)).doesNotThrowAnyException();
+		assertThatCode(() -> validator.validate((URI) null)).doesNotThrowAnyException();
 		assertThatCode(() -> validator.validate("")).doesNotThrowAnyException();
 		assertThatCode(() -> validator.validate("   ")).doesNotThrowAnyException();
 	}


### PR DESCRIPTION
This pull request introduces opt-in protection against Server-Side Request Forgery (SSRF) attacks in Spring Boot Admin Server, focusing on validating and restricting instance registration URLs and proxy targets. It adds configuration options for enabling SSRF protection, customizing allowed IP ranges and schemes, and provides extension points for advanced use cases. Documentation is updated to explain the risks, configuration, and best practices.

**SSRF Protection Feature:**

* Added new SSRF protection mechanism to validate `healthUrl`, `managementUrl`, and `serviceUrl` during instance registration and proxying, blocking requests to private/internal addresses and non-HTTP(S) schemes. This is disabled by default and can be enabled via configuration. [[1]](diffhunk://#diff-5e5bc30ab29db6c62a4723be0f6f6cda3d1b0923bfba39ea9496f9c74401652bR1-R242) [[2]](diffhunk://#diff-dfe5a0b68ff905f6251b102db3915defd52257af139a3a70955133facbfb8abeR210-R238)
* Introduced configuration properties in `AdminServerProperties` (`ssrf-protection.enabled`, `allowed-cidrs`, `allowed-schemes`) and supporting beans (`InetAddressFilter`, `SsrfUrlValidator`) for flexible address and scheme allowlisting. [[1]](diffhunk://#diff-dfe5a0b68ff905f6251b102db3915defd52257af139a3a70955133facbfb8abeR54-R55) [[2]](diffhunk://#diff-dfe5a0b68ff905f6251b102db3915defd52257af139a3a70955133facbfb8abeR210-R238) [[3]](diffhunk://#diff-99c8731fb83d97e520bbebab29e08e638de3c415d0c41c14f8ba445312056a5bR82-R103)
* Updated `InstanceRegistry` and both servlet and reactive `InstancesProxyController` to enforce SSRF validation at registration and proxy time. [[1]](diffhunk://#diff-99c8731fb83d97e520bbebab29e08e638de3c415d0c41c14f8ba445312056a5bR82-R103) [[2]](diffhunk://#diff-a7686838869d7f7f5ed3b4ae1a445b68aec7b1e4c1d84ad81cc0c70478110edcL78-R84) [[3]](diffhunk://#diff-a7686838869d7f7f5ed3b4ae1a445b68aec7b1e4c1d84ad81cc0c70478110edcL111-R118)

**Documentation Updates:**

* Added a comprehensive SSRF protection guide (`40-ssrf-protection.md`) covering risks, configuration, extension, and integration with other security features.
* Updated security index, navigation, and checklist to include SSRF protection as a recommended step for securing deployments. [[1]](diffhunk://#diff-ddf827b0a9786e71e130bda31888cb2e5c6ac9b123a02324e0755a52e7b93fc8L55-R66) [[2]](diffhunk://#diff-ddf827b0a9786e71e130bda31888cb2e5c6ac9b123a02324e0755a52e7b93fc8R158) [[3]](diffhunk://#diff-8284f9dd817ff4c3b117e043f26f9dc09d0ca4a14c175fb4d2957d3c741222bfR761) [[4]](diffhunk://#diff-ddf827b0a9786e71e130bda31888cb2e5c6ac9b123a02324e0755a52e7b93fc8R491)

**General/Other:**

* Copyright years updated to 2026 in affected files. [[1]](diffhunk://#diff-99c8731fb83d97e520bbebab29e08e638de3c415d0c41c14f8ba445312056a5bL2-R2) [[2]](diffhunk://#diff-dfe5a0b68ff905f6251b102db3915defd52257af139a3a70955133facbfb8abeL2-R2) [[3]](diffhunk://#diff-a7686838869d7f7f5ed3b4ae1a445b68aec7b1e4c1d84ad81cc0c70478110edcL2-R2) [[4]](diffhunk://#diff-20d7184bf23a88ba8ed21c5448780aa35d547455df55330522189282f6950f3aL2-R2)

These changes significantly improve the security posture of Spring Boot Admin Server by providing robust, configurable defenses against SSRF attacks.

closes #5452