### PR TITLE
chore: Add 'localNpm' Maven build profile and 'npm.registry' Maven property to accomodate the UI build in corporate environments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,7 @@
         <spring-javaformat-maven-plugin.version>0.0.47</spring-javaformat-maven-plugin.version>
         <central-publishing-maven-plugin.version>0.11.0</central-publishing-maven-plugin.version>
         <spring-conf-prop-documenter-maven-plugin.version>0.7.2</spring-conf-prop-documenter-maven-plugin.version>
+        <exec-maven-plugin.version>3.6.3</exec-maven-plugin.version>
     </properties>
 
     <modules>
@@ -431,6 +432,11 @@
                     <groupId>org.rodnansol</groupId>
                     <artifactId>spring-configuration-property-documenter-maven-plugin</artifactId>
                     <version>${spring-conf-prop-documenter-maven-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>exec-maven-plugin</artifactId>
+                    <version>${exec-maven-plugin.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
         <maven-dependency-plugin.version>3.11.0</maven-dependency-plugin.version>
         <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
         <maven-enforcer-plugin.version>3.6.3</maven-enforcer-plugin.version>
+        <maven-exec-plugin.version>3.6.3</maven-exec-plugin.version>
         <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
         <maven-failsafe-plugin.version>3.5.6</maven-failsafe-plugin.version>
         <maven-install-plugin.version>3.1.4</maven-install-plugin.version>
@@ -88,7 +89,6 @@
         <spring-javaformat-maven-plugin.version>0.0.47</spring-javaformat-maven-plugin.version>
         <central-publishing-maven-plugin.version>0.11.0</central-publishing-maven-plugin.version>
         <spring-conf-prop-documenter-maven-plugin.version>0.7.2</spring-conf-prop-documenter-maven-plugin.version>
-        <exec-maven-plugin.version>3.6.3</exec-maven-plugin.version>
     </properties>
 
     <modules>
@@ -436,7 +436,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>exec-maven-plugin</artifactId>
-                    <version>${exec-maven-plugin.version}</version>
+                    <version>${maven-exec-plugin.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/spring-boot-admin-server-ui/pom.xml
+++ b/spring-boot-admin-server-ui/pom.xml
@@ -38,8 +38,8 @@
         <npm.build.args>run build</npm.build.args>
         <npm.lint.args>run lint</npm.lint.args>
         <npm.test.args>run test</npm.test.args>
-        <!-- To be set explicitly with -Dnpm.registry=https://foo.bar if the standard registry is not wanted or not accessible -->
-        <npm.registry />
+        <!-- To be overridden with -Dnpm.registry=https://foo.bar if the standard registry is not wanted or not accessible -->
+        <npm.registry>https://registry.npmjs.org/</npm.registry>
     </properties>
 
     <dependencies>

--- a/spring-boot-admin-server-ui/pom.xml
+++ b/spring-boot-admin-server-ui/pom.xml
@@ -33,6 +33,13 @@
 
     <properties>
         <ui-resources.relative-path>META-INF/spring-boot-admin-server-ui</ui-resources.relative-path>
+
+        <npm.install.args>ci --prefer-offline --no-progress --no-audit --silent</npm.install.args>
+        <npm.build.args>run build</npm.build.args>
+        <npm.lint.args>run lint</npm.lint.args>
+        <npm.test.args>run test</npm.test.args>
+        <!-- To be set explicitly with -Dnpm.registry=https://foo.bar if the standard registry is not wanted or not accessible -->
+        <npm.registry />
     </properties>
 
     <dependencies>
@@ -122,6 +129,83 @@
                 </plugins>
             </build>
         </profile>
+        <!--
+        Profile: localNpm
+        Set this profile to run frontend related build steps using the local NPM installation.
+        Skipping frontend tests can be achieved by using default flag -D skipTests.
+        -->
+        <profile>
+            <id>localNpm</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.eirslett</groupId>
+                        <artifactId>frontend-maven-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>npm-install</id>
+                                <phase>generate-resources</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>npm</executable>
+                                    <commandlineArgs>${npm.install.args}</commandlineArgs>
+                                    <environmentVariables>
+                                        <NPM_CONFIG_REGISTRY>${npm.registry}</NPM_CONFIG_REGISTRY>
+                                    </environmentVariables>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>npm-build</id>
+                                <phase>generate-resources</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>npm</executable>
+                                    <commandlineArgs>${npm.build.args}</commandlineArgs>
+                                    <environmentVariables>
+                                        <PROJECT_VERSION>${project.version}</PROJECT_VERSION>
+                                    </environmentVariables>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>npm-lint</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>npm</executable>
+                                    <commandlineArgs>${npm.lint.args}</commandlineArgs>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>npm-test</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>${skipTests}</skip>
+                                    <executable>npm</executable>
+                                    <commandlineArgs>${npm.test.args}</commandlineArgs>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <build>
@@ -155,7 +239,7 @@
                             <goal>npm</goal>
                         </goals>
                         <configuration>
-                            <arguments>ci --prefer-offline --no-progress --no-audit --silent</arguments>
+                            <arguments>${npm.install.args}</arguments>
                         </configuration>
                     </execution>
                     <execution>
@@ -164,7 +248,7 @@
                             <goal>npm</goal>
                         </goals>
                         <configuration>
-                            <arguments>run build</arguments>
+                            <arguments>${npm.build.args}</arguments>
                             <environmentVariables>
                                 <PROJECT_VERSION>${project.version}</PROJECT_VERSION>
                             </environmentVariables>
@@ -177,7 +261,7 @@
                         </goals>
                         <phase>verify</phase>
                         <configuration>
-                            <arguments>run lint</arguments>
+                            <arguments>${npm.lint.args}</arguments>
                         </configuration>
                     </execution>
                     <execution>
@@ -187,7 +271,7 @@
                         </goals>
                         <phase>test</phase>
                         <configuration>
-                            <arguments>run test</arguments>
+                            <arguments>${npm.test.args}</arguments>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
Hi.

In corporate environments the access to certain resources may be blocked, may need some proxy settings or these resources may be provided through different channels (e.g.: an internal package manager).

This PR adds the possibility to build the UI locally with the available toolchain by:

1. executing the necessary `npm` steps with the `exec-maven-plugin`, to leverage the already installed NodeJS and NPM and already available on the `PATH`
2. adding a Maven property named `npm.registry` which can be externally set with `-Dnpm.registry=https://my.corporate.registry` during the build in order to point to the corporate internal registry rather than to `https://registry.npmjs.org/`