### PR TITLE
feat(#5476): Add configuration property to allow the selection of the mismatch strategy to use for status update events

### DIFF
--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerAutoConfiguration.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerAutoConfiguration.java
@@ -104,7 +104,7 @@ public class AdminServerAutoConfiguration {
 		AdminServerProperties.MonitorProperties monitorProperties = this.adminServerProperties.getMonitor();
 
 		StatusUpdater updater = new StatusUpdater(instanceRepository, instanceWebClientBuilder.build(),
-				new ApiMediaTypeHandler(), monitorProperties.getStatusMismatchStrategy().asPredicate());
+				new ApiMediaTypeHandler(), monitorProperties.getStatusChangeDetectionStrategy().asPredicate());
 
 		Duration timeout = monitorProperties.getDefaultTimeout();
 		Duration interval = monitorProperties.getStatusInterval();

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerAutoConfiguration.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerAutoConfiguration.java
@@ -101,10 +101,10 @@ public class AdminServerAutoConfiguration {
 	public StatusUpdater statusUpdater(InstanceRepository instanceRepository,
 			InstanceWebClient.Builder instanceWebClientBuilder) {
 
-		StatusUpdater updater = new StatusUpdater(instanceRepository, instanceWebClientBuilder.build(),
-				new ApiMediaTypeHandler());
-
 		AdminServerProperties.MonitorProperties monitorProperties = this.adminServerProperties.getMonitor();
+
+		StatusUpdater updater = new StatusUpdater(instanceRepository, instanceWebClientBuilder.build(),
+				new ApiMediaTypeHandler(), monitorProperties.getStatusMismatchStrategy().asPredicate());
 
 		Duration timeout = monitorProperties.getDefaultTimeout();
 		Duration interval = monitorProperties.getStatusInterval();

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerProperties.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerProperties.java
@@ -21,11 +21,14 @@ import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import java.util.function.BiPredicate;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.convert.DurationUnit;
 
+import de.codecentric.boot.admin.server.domain.values.StatusInfo;
 import de.codecentric.boot.admin.server.web.PathUtils;
 import de.codecentric.boot.admin.server.web.client.BasicAuthHttpHeaderProvider.InstanceCredentials;
 
@@ -95,6 +98,12 @@ public class AdminServerProperties {
 	public static class MonitorProperties {
 
 		/**
+		 * Default {@link StatusInfoMismatchStrategy} applied if nothing different is
+		 * configured for {@link MonitorProperties#statusMismatchStrategy}.
+		 */
+		public static final StatusInfoMismatchStrategy DEFAULT_STATUS_MISMATCH_STRATEGY = StatusInfoMismatchStrategy.FULL;
+
+		/**
 		 * Time interval to check the status of instances, must be greater than 1 second.
 		 */
 		@DurationUnit(ChronoUnit.MILLIS)
@@ -106,6 +115,17 @@ public class AdminServerProperties {
 		 */
 		@DurationUnit(ChronoUnit.MILLIS)
 		private Duration statusLifetime = Duration.ofMillis(10_000L);
+
+		/**
+		 * Strategy to use to determinate if, given two {@link StatusInfo} instances,
+		 * they're different or not in order to decide if a {@code STATUS_UPDATED} event
+		 * should be published or not.
+		 * <p>
+		 * Defaults to
+		 * {@link AdminServerProperties.MonitorProperties#DEFAULT_STATUS_MISMATCH_STRATEGY}
+		 * unless a different value is specified.
+		 */
+		private StatusInfoMismatchStrategy statusMismatchStrategy = DEFAULT_STATUS_MISMATCH_STRATEGY;
 
 		/**
 		 * The maximal backoff for status check retries (retry after error has exponential
@@ -147,7 +167,7 @@ public class AdminServerProperties {
 
 		/**
 		 * Default timeout when making requests. Individual values for specific endpoints
-		 * can be overriden using `spring.boot.admin.monitor.timeout.*`.
+		 * can be overridden using `spring.boot.admin.monitor.timeout.*`.
 		 */
 		@DurationUnit(ChronoUnit.MILLIS)
 		private Duration defaultTimeout = Duration.ofMillis(10_000L);
@@ -157,6 +177,41 @@ public class AdminServerProperties {
 		 */
 		@DurationUnit(ChronoUnit.MILLIS)
 		private Map<String, Duration> timeout = new HashMap<>();
+
+		/**
+		 * Strategy to determinate if two {@link StatusInfo} instances are different or
+		 * not.
+		 */
+		public enum StatusInfoMismatchStrategy {
+
+			/**
+			 * It considers two {@link StatusInfo} instances different if they're not
+			 * equal.
+			 */
+			FULL {
+				@Override
+				public boolean mismatch(StatusInfo statusInfo, StatusInfo newStatusInfo) {
+					return !Objects.equals(statusInfo, newStatusInfo);
+				}
+			},
+			/**
+			 * It considers two {@link StatusInfo} instances different if only their
+			 * {@code status} is not equal.
+			 */
+			STATUS_ONLY {
+				@Override
+				public boolean mismatch(StatusInfo statusInfo, StatusInfo newStatusInfo) {
+					return !Objects.equals(statusInfo.getStatus(), newStatusInfo.getStatus());
+				}
+			};
+
+			public abstract boolean mismatch(StatusInfo statusInfo, StatusInfo newStatusInfo);
+
+			public BiPredicate<StatusInfo, StatusInfo> asPredicate() {
+				return this::mismatch;
+			}
+
+		}
 
 	}
 

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerProperties.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/config/AdminServerProperties.java
@@ -98,10 +98,10 @@ public class AdminServerProperties {
 	public static class MonitorProperties {
 
 		/**
-		 * Default {@link StatusInfoMismatchStrategy} applied if nothing different is
-		 * configured for {@link MonitorProperties#statusMismatchStrategy}.
+		 * Default {@link StatusChangeDetectionStrategy} applied if nothing different is
+		 * configured for {@link MonitorProperties#statusChangeDetectionStrategy}.
 		 */
-		public static final StatusInfoMismatchStrategy DEFAULT_STATUS_MISMATCH_STRATEGY = StatusInfoMismatchStrategy.FULL;
+		public static final StatusChangeDetectionStrategy DEFAULT_STATUS_CHANGE_DETECTION_STRATEGY = StatusChangeDetectionStrategy.STATUS_ONLY;
 
 		/**
 		 * Time interval to check the status of instances, must be greater than 1 second.
@@ -117,15 +117,15 @@ public class AdminServerProperties {
 		private Duration statusLifetime = Duration.ofMillis(10_000L);
 
 		/**
-		 * Strategy to use to determinate if, given two {@link StatusInfo} instances,
+		 * Strategy to use to determine if, given two {@link StatusInfo} instances,
 		 * they're different or not in order to decide if a {@code STATUS_UPDATED} event
 		 * should be published or not.
 		 * <p>
 		 * Defaults to
-		 * {@link AdminServerProperties.MonitorProperties#DEFAULT_STATUS_MISMATCH_STRATEGY}
+		 * {@link AdminServerProperties.MonitorProperties#DEFAULT_STATUS_CHANGE_DETECTION_STRATEGY}
 		 * unless a different value is specified.
 		 */
-		private StatusInfoMismatchStrategy statusMismatchStrategy = DEFAULT_STATUS_MISMATCH_STRATEGY;
+		private StatusChangeDetectionStrategy statusChangeDetectionStrategy = DEFAULT_STATUS_CHANGE_DETECTION_STRATEGY;
 
 		/**
 		 * The maximal backoff for status check retries (retry after error has exponential
@@ -179,10 +179,9 @@ public class AdminServerProperties {
 		private Map<String, Duration> timeout = new HashMap<>();
 
 		/**
-		 * Strategy to determinate if two {@link StatusInfo} instances are different or
-		 * not.
+		 * Strategy to determine if two {@link StatusInfo} instances are different or not.
 		 */
-		public enum StatusInfoMismatchStrategy {
+		public enum StatusChangeDetectionStrategy {
 
 			/**
 			 * It considers two {@link StatusInfo} instances different if they're not

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/domain/entities/Instance.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/domain/entities/Instance.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.BiPredicate;
 
 import org.jspecify.annotations.Nullable;
 import org.springframework.util.Assert;
@@ -44,6 +45,7 @@ import de.codecentric.boot.admin.server.domain.values.Registration;
 import de.codecentric.boot.admin.server.domain.values.StatusInfo;
 import de.codecentric.boot.admin.server.domain.values.Tags;
 
+import static de.codecentric.boot.admin.server.config.AdminServerProperties.MonitorProperties.DEFAULT_STATUS_MISMATCH_STRATEGY;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableList;
@@ -57,6 +59,9 @@ import static java.util.Collections.unmodifiableList;
 @lombok.EqualsAndHashCode(exclude = { "unsavedEvents", "statusTimestamp" })
 @lombok.ToString(exclude = "unsavedEvents")
 public final class Instance implements Serializable {
+
+	private static final BiPredicate<StatusInfo, StatusInfo> defaultStatusMismatchPredicate = DEFAULT_STATUS_MISMATCH_STRATEGY
+		.asPredicate();
 
 	private final InstanceId id;
 
@@ -140,11 +145,16 @@ public final class Instance implements Serializable {
 	}
 
 	public Instance withStatusInfo(StatusInfo statusInfo) {
+		return withStatusInfo(statusInfo, defaultStatusMismatchPredicate);
+	}
+
+	public Instance withStatusInfo(StatusInfo statusInfo,
+			BiPredicate<StatusInfo, StatusInfo> statusInfoMismatchPredicate) {
 		Assert.notNull(statusInfo, "'statusInfo' must not be null");
-		if (Objects.equals(this.statusInfo, statusInfo)) {
-			return this;
-		}
-		return this.apply(new InstanceStatusChangedEvent(this.id, this.nextVersion(), statusInfo), true);
+		Assert.notNull(statusInfo, "'statusInfoMismatchPredicate' must not be null");
+
+		return (statusInfoMismatchPredicate.test(this.statusInfo, statusInfo))
+				? this.apply(new InstanceStatusChangedEvent(this.id, this.nextVersion(), statusInfo), true) : this;
 	}
 
 	public Instance withEndpoints(Endpoints endpoints) {
@@ -155,10 +165,6 @@ public final class Instance implements Serializable {
 			return this;
 		}
 		return this.apply(new InstanceEndpointsDetectedEvent(this.id, this.nextVersion(), endpoints), true);
-	}
-
-	public boolean isRegistered() {
-		return this.registered;
 	}
 
 	public Registration getRegistration() {

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/domain/entities/Instance.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/domain/entities/Instance.java
@@ -45,7 +45,7 @@ import de.codecentric.boot.admin.server.domain.values.Registration;
 import de.codecentric.boot.admin.server.domain.values.StatusInfo;
 import de.codecentric.boot.admin.server.domain.values.Tags;
 
-import static de.codecentric.boot.admin.server.config.AdminServerProperties.MonitorProperties.DEFAULT_STATUS_MISMATCH_STRATEGY;
+import static de.codecentric.boot.admin.server.config.AdminServerProperties.MonitorProperties.DEFAULT_STATUS_CHANGE_DETECTION_STRATEGY;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableList;
@@ -60,7 +60,7 @@ import static java.util.Collections.unmodifiableList;
 @lombok.ToString(exclude = "unsavedEvents")
 public final class Instance implements Serializable {
 
-	private static final BiPredicate<StatusInfo, StatusInfo> defaultStatusMismatchPredicate = DEFAULT_STATUS_MISMATCH_STRATEGY
+	private static final BiPredicate<StatusInfo, StatusInfo> defaultStatusChangeDetectionStrategyPredicate = DEFAULT_STATUS_CHANGE_DETECTION_STRATEGY
 		.asPredicate();
 
 	private final InstanceId id;
@@ -145,15 +145,16 @@ public final class Instance implements Serializable {
 	}
 
 	public Instance withStatusInfo(StatusInfo statusInfo) {
-		return withStatusInfo(statusInfo, defaultStatusMismatchPredicate);
+		return withStatusInfo(statusInfo, defaultStatusChangeDetectionStrategyPredicate);
 	}
 
 	public Instance withStatusInfo(StatusInfo statusInfo,
-			BiPredicate<StatusInfo, StatusInfo> statusInfoMismatchPredicate) {
+			BiPredicate<StatusInfo, StatusInfo> statusChangeDetectionStrategyPredicate) {
 		Assert.notNull(statusInfo, "'statusInfo' must not be null");
-		Assert.notNull(statusInfo, "'statusInfoMismatchPredicate' must not be null");
+		Assert.notNull(statusChangeDetectionStrategyPredicate,
+				"'statusChangeDetectionStrategyPredicate' must not be null");
 
-		return (statusInfoMismatchPredicate.test(this.statusInfo, statusInfo))
+		return (statusChangeDetectionStrategyPredicate.test(this.statusInfo, statusInfo))
 				? this.apply(new InstanceStatusChangedEvent(this.id, this.nextVersion(), statusInfo), true) : this;
 	}
 

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/domain/values/StatusInfo.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/domain/values/StatusInfo.java
@@ -145,6 +145,14 @@ public final class StatusInfo implements Serializable {
 		return Comparator.comparingInt(STATUS_ORDER::indexOf);
 	}
 
+	public StatusInfo withStatus(String status) {
+		return StatusInfo.valueOf(status, details);
+	}
+
+	public StatusInfo withDetails(@Nullable Map<String, ?> details) {
+		return StatusInfo.valueOf(status, details);
+	}
+
 	@SuppressWarnings("unchecked")
 	public static StatusInfo from(Map<String, ?> body) {
 		Map<String, ?> details = Collections.emptyMap();

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/StatusUpdater.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/StatusUpdater.java
@@ -40,7 +40,7 @@ import de.codecentric.boot.admin.server.domain.values.InstanceId;
 import de.codecentric.boot.admin.server.domain.values.StatusInfo;
 import de.codecentric.boot.admin.server.web.client.InstanceWebClient;
 
-import static de.codecentric.boot.admin.server.config.AdminServerProperties.MonitorProperties.DEFAULT_STATUS_MISMATCH_STRATEGY;
+import static de.codecentric.boot.admin.server.config.AdminServerProperties.MonitorProperties.DEFAULT_STATUS_CHANGE_DETECTION_STRATEGY;
 import static java.util.Collections.emptyMap;
 
 /**
@@ -62,11 +62,12 @@ public class StatusUpdater {
 
 	private final ApiMediaTypeHandler apiMediaTypeHandler;
 
-	private final BiPredicate<StatusInfo, StatusInfo> statusInfoMismatchPredicate;
+	private final BiPredicate<StatusInfo, StatusInfo> statusChangeDetectionPredicate;
 
 	public StatusUpdater(InstanceRepository repository, InstanceWebClient instanceWebClient,
 			ApiMediaTypeHandler apiMediaTypeHandler) {
-		this(repository, instanceWebClient, apiMediaTypeHandler, DEFAULT_STATUS_MISMATCH_STRATEGY.asPredicate());
+		this(repository, instanceWebClient, apiMediaTypeHandler,
+				DEFAULT_STATUS_CHANGE_DETECTION_STRATEGY.asPredicate());
 	}
 
 	private Duration timeout = Duration.ofSeconds(10);
@@ -94,7 +95,7 @@ public class StatusUpdater {
 			.timeout(getTimeoutWithMargin())
 			.doOnError((ex) -> logError(instance, ex))
 			.onErrorResume(this::handleError)
-			.map((statusInfo) -> instance.withStatusInfo(statusInfo, statusInfoMismatchPredicate));
+			.map((statusInfo) -> instance.withStatusInfo(statusInfo, statusChangeDetectionPredicate));
 	}
 
 	/*

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/StatusUpdater.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/services/StatusUpdater.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.BiPredicate;
 import java.util.logging.Level;
 
 import lombok.RequiredArgsConstructor;
@@ -39,6 +40,7 @@ import de.codecentric.boot.admin.server.domain.values.InstanceId;
 import de.codecentric.boot.admin.server.domain.values.StatusInfo;
 import de.codecentric.boot.admin.server.web.client.InstanceWebClient;
 
+import static de.codecentric.boot.admin.server.config.AdminServerProperties.MonitorProperties.DEFAULT_STATUS_MISMATCH_STRATEGY;
 import static java.util.Collections.emptyMap;
 
 /**
@@ -59,6 +61,13 @@ public class StatusUpdater {
 	private final InstanceWebClient instanceWebClient;
 
 	private final ApiMediaTypeHandler apiMediaTypeHandler;
+
+	private final BiPredicate<StatusInfo, StatusInfo> statusInfoMismatchPredicate;
+
+	public StatusUpdater(InstanceRepository repository, InstanceWebClient instanceWebClient,
+			ApiMediaTypeHandler apiMediaTypeHandler) {
+		this(repository, instanceWebClient, apiMediaTypeHandler, DEFAULT_STATUS_MISMATCH_STRATEGY.asPredicate());
+	}
 
 	private Duration timeout = Duration.ofSeconds(10);
 
@@ -85,7 +94,7 @@ public class StatusUpdater {
 			.timeout(getTimeoutWithMargin())
 			.doOnError((ex) -> logError(instance, ex))
 			.onErrorResume(this::handleError)
-			.map(instance::withStatusInfo);
+			.map((statusInfo) -> instance.withStatusInfo(statusInfo, statusInfoMismatchPredicate));
 	}
 
 	/*

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/config/AdminServerPropertiesTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/config/AdminServerPropertiesTest.java
@@ -23,6 +23,8 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import de.codecentric.boot.admin.server.config.AdminServerProperties.MonitorProperties.StatusInfoMismatchStrategy;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(SpringExtension.class)
@@ -36,6 +38,9 @@ class AdminServerPropertiesTest {
 	@Test
 	void testLoadConfigurationProperties() {
 		assertThat(serverConfig.getContextPath()).isEqualTo("/admin");
+
+		assertThat(serverConfig.getMonitor().getStatusMismatchStrategy())
+			.isEqualTo(StatusInfoMismatchStrategy.STATUS_ONLY);
 
 		assertThat(serverConfig.getInstanceAuth().getDefaultUserName()).isEqualTo("admin");
 		assertThat(serverConfig.getInstanceAuth().getDefaultPassword()).isEqualTo("topsecret");

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/config/AdminServerPropertiesTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/config/AdminServerPropertiesTest.java
@@ -23,7 +23,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import de.codecentric.boot.admin.server.config.AdminServerProperties.MonitorProperties.StatusInfoMismatchStrategy;
+import de.codecentric.boot.admin.server.config.AdminServerProperties.MonitorProperties.StatusChangeDetectionStrategy;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -39,8 +39,8 @@ class AdminServerPropertiesTest {
 	void testLoadConfigurationProperties() {
 		assertThat(serverConfig.getContextPath()).isEqualTo("/admin");
 
-		assertThat(serverConfig.getMonitor().getStatusMismatchStrategy())
-			.isEqualTo(StatusInfoMismatchStrategy.STATUS_ONLY);
+		assertThat(serverConfig.getMonitor().getStatusChangeDetectionStrategy())
+			.isEqualTo(StatusChangeDetectionStrategy.STATUS_ONLY);
 
 		assertThat(serverConfig.getInstanceAuth().getDefaultUserName()).isEqualTo("admin");
 		assertThat(serverConfig.getInstanceAuth().getDefaultPassword()).isEqualTo("topsecret");

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/config/StatusChangeDetectionStrategyTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/config/StatusChangeDetectionStrategyTest.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.junit.jupiter.params.support.ParameterDeclarations;
 
-import de.codecentric.boot.admin.server.config.AdminServerProperties.MonitorProperties.StatusInfoMismatchStrategy;
+import de.codecentric.boot.admin.server.config.AdminServerProperties.MonitorProperties.StatusChangeDetectionStrategy;
 import de.codecentric.boot.admin.server.domain.values.StatusInfo;
 
 import static java.util.Collections.emptyMap;
@@ -35,7 +35,7 @@ import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.of;
 
-public class StatusInfoMismatchStrategyTest {
+public class StatusChangeDetectionStrategyTest {
 
 	@ParameterizedTest
 	@ArgumentsSource(FullStrategyArgumentsProvider.class)
@@ -43,7 +43,7 @@ public class StatusInfoMismatchStrategyTest {
 		// given -> test setup
 
 		// when
-		boolean result = StatusInfoMismatchStrategy.FULL.mismatch(s1, s2);
+		boolean result = StatusChangeDetectionStrategy.FULL.mismatch(s1, s2);
 
 		// then
 		assertThat(result).isEqualTo(expectedResult);
@@ -55,7 +55,7 @@ public class StatusInfoMismatchStrategyTest {
 		// given -> test setup
 
 		// when
-		boolean result = StatusInfoMismatchStrategy.STATUS_ONLY.mismatch(s1, s2);
+		boolean result = StatusChangeDetectionStrategy.STATUS_ONLY.mismatch(s1, s2);
 
 		// then
 		assertThat(result).isEqualTo(expectedResult);

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/config/StatusInfoMismatchStrategyTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/config/StatusInfoMismatchStrategyTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2014-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.codecentric.boot.admin.server.config;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.support.ParameterDeclarations;
+
+import de.codecentric.boot.admin.server.config.AdminServerProperties.MonitorProperties.StatusInfoMismatchStrategy;
+import de.codecentric.boot.admin.server.domain.values.StatusInfo;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.of;
+
+public class StatusInfoMismatchStrategyTest {
+
+	@ParameterizedTest
+	@ArgumentsSource(FullStrategyArgumentsProvider.class)
+	public void shouldConsiderStatusesDifferentByFullEquality(StatusInfo s1, StatusInfo s2, boolean expectedResult) {
+		// given -> test setup
+
+		// when
+		boolean result = StatusInfoMismatchStrategy.FULL.mismatch(s1, s2);
+
+		// then
+		assertThat(result).isEqualTo(expectedResult);
+	}
+
+	@ParameterizedTest
+	@ArgumentsSource(StatusOnlyStrategyArgumentsProvider.class)
+	public void shouldConsiderStatusesDifferentOnlyByStatusCode(StatusInfo s1, StatusInfo s2, boolean expectedResult) {
+		// given -> test setup
+
+		// when
+		boolean result = StatusInfoMismatchStrategy.STATUS_ONLY.mismatch(s1, s2);
+
+		// then
+		assertThat(result).isEqualTo(expectedResult);
+	}
+
+	private static final class FullStrategyArgumentsProvider implements ArgumentsProvider {
+
+		@Override
+		public @NonNull Stream<? extends Arguments> provideArguments(@NonNull ParameterDeclarations parameters,
+				@NonNull ExtensionContext context) {
+			String statusCode1 = "S1";
+			String statusCode2 = "S2";
+			Map<String, String> details = singletonMap("test", "junit");
+			StatusInfo s1 = StatusInfo.valueOf(statusCode1);
+			StatusInfo s2 = StatusInfo.valueOf(statusCode1);
+
+			return Stream.of(of(s1, s2, false), of(s1.withDetails(details), s2.withDetails(details), false),
+					of(s1, s2.withStatus(statusCode2), true), of(s1, s2.withDetails(details), true),
+					of(s1.withDetails(details), StatusInfo.valueOf(statusCode2, emptyMap()), true));
+		}
+
+	}
+
+	private static final class StatusOnlyStrategyArgumentsProvider implements ArgumentsProvider {
+
+		@Override
+		public @NonNull Stream<? extends Arguments> provideArguments(@NonNull ParameterDeclarations parameters,
+				@NonNull ExtensionContext context) {
+			String statusCode1 = "JUNIT#1";
+			String statusCode2 = "JUNIT#2";
+			Map<String, String> details = singletonMap("test", "junit");
+			StatusInfo s1 = StatusInfo.valueOf(statusCode1);
+			StatusInfo s2 = StatusInfo.valueOf(statusCode1);
+
+			return Stream.of(of(s1, s2, false), of(s1.withDetails(details), s2.withDetails(details), false),
+					of(s1, s2.withStatus(statusCode2), true), of(s1, s2.withDetails(details), false),
+					of(s1.withDetails(details), StatusInfo.valueOf(statusCode2, emptyMap()), true));
+		}
+
+	}
+
+}

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/services/StatusUpdaterTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/services/StatusUpdaterTest.java
@@ -32,6 +32,7 @@ import org.springframework.http.MediaType;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+import de.codecentric.boot.admin.server.config.AdminServerProperties.MonitorProperties.StatusChangeDetectionStrategy;
 import de.codecentric.boot.admin.server.domain.entities.EventsourcingInstanceRepository;
 import de.codecentric.boot.admin.server.domain.entities.Instance;
 import de.codecentric.boot.admin.server.domain.entities.InstanceRepository;
@@ -90,13 +91,17 @@ class StatusUpdaterTest {
 			.register(Registration.create("foo", this.wireMock.url("/health")).build());
 		StepVerifier.create(this.repository.save(this.instance)).expectNextCount(1).verifyComplete();
 
-		this.updater = new StatusUpdater(this.repository,
+		this.updater = createWith(StatusChangeDetectionStrategy.STATUS_ONLY);
+	}
+
+	private StatusUpdater createWith(StatusChangeDetectionStrategy statusChangeDetectionStrategy) {
+		return new StatusUpdater(this.repository,
 				InstanceWebClient.builder()
 					.filter(rewriteEndpointUrl())
 					.filter(retry(0, singletonMap(Endpoint.HEALTH, 1)))
 					.filter(timeout(Duration.ofSeconds(2), emptyMap()))
 					.build(),
-				new ApiMediaTypeHandler());
+				new ApiMediaTypeHandler(), statusChangeDetectionStrategy.asPredicate());
 	}
 
 	@AfterEach
@@ -269,6 +274,9 @@ class StatusUpdaterTest {
 
 	@Test
 	void should_update_status_details() {
+		// given
+		this.updater = createWith(StatusChangeDetectionStrategy.FULL);
+
 		// 1st pass -> initial details
 		shouldUpdateStatusDetails(singletonMap("foo", "bar"));
 

--- a/spring-boot-admin-server/src/test/resources/server-config-test.properties
+++ b/spring-boot-admin-server/src/test/resources/server-config-test.properties
@@ -1,6 +1,6 @@
 spring.boot.admin.contextPath=/admin
 
-spring.boot.admin.monitor.status-mismatch-strategy=status_only
+spring.boot.admin.monitor.status-change-detection-strategy=status_only
 
 spring.boot.admin.instance-auth.default-user-name=admin
 spring.boot.admin.instance-auth.default-password=topsecret

--- a/spring-boot-admin-server/src/test/resources/server-config-test.properties
+++ b/spring-boot-admin-server/src/test/resources/server-config-test.properties
@@ -1,5 +1,7 @@
 spring.boot.admin.contextPath=/admin
 
+spring.boot.admin.monitor.status-mismatch-strategy=status_only
+
 spring.boot.admin.instance-auth.default-user-name=admin
 spring.boot.admin.instance-auth.default-password=topsecret
 


### PR DESCRIPTION
Fixes https://github.com/codecentric/spring-boot-admin/issues/5476.

Introduced the `spring.boot.admin.monitor.status-mismatch-strategy` configuration property to allow the selection of the mismatch strategy to use for status update events.

- The default value (`FULL`) will resolve to `equals` as per `4.1.1` implementation (backwards compatibility)
- The `STATUS_ONLY` value allows to revert the comparison/mismatch behaviour as per version <= `4.1.0` by checking only the status code
- Proper overloaded method(s) and constructor(s) have been added in order to not break the existing API
- Abstract away the configuration property from the domain model objects through a `BiPredicate`