### PR TITLE
fix(#5525): Make StatusInfo payload respect the sorting coming from the health payload for the provided details

### DIFF
--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/domain/values/StatusInfo.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/domain/values/StatusInfo.java
@@ -58,7 +58,7 @@ public final class StatusInfo implements Serializable {
 	private StatusInfo(String status, @Nullable Map<String, ?> details) {
 		Assert.hasText(status, "'status' must not be empty.");
 		this.status = status.toUpperCase();
-		this.details = (details != null && !details.isEmpty()) ? new LinkedHashMap<>(details) : Collections.emptyMap();
+		this.details = (details != null) ? new LinkedHashMap<>(details) : Collections.emptyMap();
 	}
 
 	public static StatusInfo valueOf(String statusCode, @Nullable Map<String, ?> details) {

--- a/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/domain/values/StatusInfo.java
+++ b/spring-boot-admin-server/src/main/java/de/codecentric/boot/admin/server/domain/values/StatusInfo.java
@@ -19,7 +19,7 @@ package de.codecentric.boot.admin.server.domain.values;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -58,7 +58,7 @@ public final class StatusInfo implements Serializable {
 	private StatusInfo(String status, @Nullable Map<String, ?> details) {
 		Assert.hasText(status, "'status' must not be empty.");
 		this.status = status.toUpperCase();
-		this.details = (details != null) ? new HashMap<>(details) : Collections.emptyMap();
+		this.details = (details != null && !details.isEmpty()) ? new LinkedHashMap<>(details) : Collections.emptyMap();
 	}
 
 	public static StatusInfo valueOf(String statusCode, @Nullable Map<String, ?> details) {

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/domain/values/StatusInfoTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/domain/values/StatusInfoTest.java
@@ -17,10 +17,13 @@
 package de.codecentric.boot.admin.server.domain.values;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static de.codecentric.boot.admin.server.domain.values.StatusInfo.STATUS_DOWN;
 import static de.codecentric.boot.admin.server.domain.values.StatusInfo.STATUS_OFFLINE;
@@ -117,13 +120,25 @@ class StatusInfoTest {
 		assertThat(restricted.isRestricted()).isTrue();
 	}
 
-	@Test
-	void when_first_level_key_is_components() {
+	@ParameterizedTest
+	@ValueSource(strings = { "components", "details" })
+	void when_first_level_key_expected_nested_details(String key) {
+		Map<String, Object> details = singletonMap("foo", "bar");
 		Map<String, Object> map = new HashMap<>();
 		map.put("status", "UP");
-		map.put("components", singletonMap("foo", "bar"));
+		map.put(key, details);
 
-		assertThat(StatusInfo.from(map)).isEqualTo(StatusInfo.ofUp(singletonMap("foo", "bar")));
+		assertThat(StatusInfo.from(map)).isEqualTo(StatusInfo.ofUp(details));
+	}
+
+	@Test
+	void should_preserve_details_order() {
+		Map<String, Object> details = new LinkedHashMap<>();
+		details.put("a", "x");
+		details.put("c", "z");
+		details.put("b", "y");
+
+		assertThat(StatusInfo.valueOf("UP", details).getDetails()).isEqualTo(details);
 	}
 
 	@Test

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/domain/values/StatusInfoTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/domain/values/StatusInfoTest.java
@@ -138,7 +138,7 @@ class StatusInfoTest {
 		details.put("c", "z");
 		details.put("b", "y");
 
-		assertThat(StatusInfo.valueOf("UP", details).getDetails()).isEqualTo(details);
+		assertThat(StatusInfo.valueOf("UP", details).getDetails()).containsExactlyEntriesOf(details);
 	}
 
 	@Test

--- a/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/notify/MailNotifierTest.java
+++ b/spring-boot-admin-server/src/test/java/de/codecentric/boot/admin/server/notify/MailNotifierTest.java
@@ -19,7 +19,7 @@ package de.codecentric.boot.admin.server.notify;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Properties;
 
@@ -93,9 +93,9 @@ class MailNotifierTest {
 
 	@Test
 	void should_send_mail_using_default_template() throws IOException, MessagingException {
-		Map<String, Object> details = new HashMap<>();
-		details.put("Simple Value", 1234);
+		Map<String, Object> details = new LinkedHashMap<>();
 		details.put("Complex Value", singletonMap("Nested Simple Value", "99!"));
+		details.put("Simple Value", 1234);
 
 		StepVerifier.create(notifier.notify(
 				new InstanceStatusChangedEvent(instance.getId(), instance.getVersion(), StatusInfo.ofDown(details))))


### PR DESCRIPTION
Fixes https://github.com/codecentric/spring-boot-admin/issues/5525