### PR TITLE
feat(#5504): customizable browser notifications

### DIFF
--- a/spring-boot-admin-server-ui/src/main/frontend/global.d.ts
+++ b/spring-boot-admin-server-ui/src/main/frontend/global.d.ts
@@ -73,6 +73,7 @@ declare global {
     externalViews: ExternalView[];
     viewSettings: ViewSettings[];
     enableToasts: boolean;
+    browserNotificationTimeout: number;
     hideInstanceUrl: boolean;
     disableInstanceUrl: boolean;
     allowUnsafeHtml: boolean;

--- a/spring-boot-admin-server-ui/src/main/frontend/notifications.spec.ts
+++ b/spring-boot-admin-server-ui/src/main/frontend/notifications.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+import Application from '@/services/application';
+import {
+  buildInstanceDetailsUrl,
+  findChangedInstanceId,
+} from '@/notifications';
+
+const createApplication = (
+  name: string,
+  status: string,
+  instanceStatuses: string[],
+) => {
+  const instances = instanceStatuses.map((instanceStatus, index) => ({
+    id: `instance-${index}`,
+    statusInfo: { status: instanceStatus },
+    registration: {
+      name,
+      healthUrl: `http://localhost:${8080 + index}/actuator/health`,
+    },
+  }));
+
+  return new Application({
+    name,
+    status,
+    instances,
+  });
+};
+
+describe('notifications', () => {
+  describe('buildInstanceDetailsUrl', () => {
+    it('builds instance details path', () => {
+      expect(buildInstanceDetailsUrl('abc123')).toBe('/instances/abc123/details');
+    });
+  });
+
+  describe('findChangedInstanceId', () => {
+    it('returns instance whose status changed', () => {
+      const application = createApplication('app', 'DOWN', ['UP', 'DOWN']);
+      const oldApplication = createApplication('app', 'UP', ['UP', 'UP']);
+
+      expect(findChangedInstanceId(application, oldApplication)).toBe(
+        'instance-1',
+      );
+    });
+
+    it('returns sole instance id when only one instance exists', () => {
+      const application = createApplication('app', 'DOWN', ['DOWN']);
+      const oldApplication = createApplication('app', 'UP', ['UP']);
+
+      expect(findChangedInstanceId(application, oldApplication)).toBe(
+        'instance-0',
+      );
+    });
+
+    it('returns undefined when multiple instances changed', () => {
+      const application = createApplication('app', 'DOWN', ['DOWN', 'DOWN']);
+      const oldApplication = createApplication('app', 'UP', ['UP', 'UP']);
+
+      expect(
+        findChangedInstanceId(application, oldApplication),
+      ).toBeUndefined();
+    });
+  });
+});

--- a/spring-boot-admin-server-ui/src/main/frontend/notifications.spec.ts
+++ b/spring-boot-admin-server-ui/src/main/frontend/notifications.spec.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import Application from '@/services/application';
 import {
   buildInstanceDetailsUrl,
   findChangedInstanceId,
 } from '@/notifications';
+import Application from '@/services/application';
 
 const createApplication = (
   name: string,
@@ -30,7 +30,9 @@ const createApplication = (
 describe('notifications', () => {
   describe('buildInstanceDetailsUrl', () => {
     it('builds instance details path', () => {
-      expect(buildInstanceDetailsUrl('abc123')).toBe('/instances/abc123/details');
+      expect(buildInstanceDetailsUrl('abc123')).toBe(
+        '/instances/abc123/details',
+      );
     });
   });
 

--- a/spring-boot-admin-server-ui/src/main/frontend/notifications.ts
+++ b/spring-boot-admin-server-ui/src/main/frontend/notifications.ts
@@ -17,8 +17,8 @@ import { groupBy, values } from 'lodash-es';
 import { Subject, bufferTime, filter } from 'rxjs';
 
 import { HealthStatus } from './HealthStatus';
-import Application from './services/application';
 import sbaConfig from './sba-config';
+import Application from './services/application';
 
 let granted = false;
 

--- a/spring-boot-admin-server-ui/src/main/frontend/notifications.ts
+++ b/spring-boot-admin-server-ui/src/main/frontend/notifications.ts
@@ -102,17 +102,23 @@ const notifyForBulkChange = ({ count, status, oldStatus }) => {
 
 const createNotification = (title, options: BrowserNotificationOptions) => {
   if (granted) {
-    const notification = new window.Notification(title, options);
-    if (options.url) {
+    const { timeout = 0, url, ...notificationOptions } = options;
+    const notification = new window.Notification(title, {
+      ...notificationOptions,
+      // Keep visible until the user dismisses when timeout is <= 0
+      requireInteraction: !(timeout > 0),
+    });
+    if (url) {
       notification.onclick = () => {
         window.focus();
-        window.open(options.url, '_self');
+        window.open(url, '_self');
       };
     }
-    if (options.timeout > 0) {
-      notification.onshow = () =>
-        setTimeout(() => notification.close(), options.timeout);
-    }
+    notification.onshow = () => {
+      if (timeout > 0) {
+        setTimeout(() => notification.close(), timeout);
+      }
+    };
   }
 };
 

--- a/spring-boot-admin-server-ui/src/main/frontend/notifications.ts
+++ b/spring-boot-admin-server-ui/src/main/frontend/notifications.ts
@@ -17,9 +17,44 @@ import { groupBy, values } from 'lodash-es';
 import { Subject, bufferTime, filter } from 'rxjs';
 
 import { HealthStatus } from './HealthStatus';
+import Application from './services/application';
 import sbaConfig from './sba-config';
 
 let granted = false;
+
+type BrowserNotificationOptions = NotificationOptions & {
+  timeout?: number;
+  url?: string;
+};
+
+export const buildInstanceDetailsUrl = (instanceId: string) =>
+  `/instances/${instanceId}/details`;
+
+export const findChangedInstanceId = (
+  application: Application,
+  oldApplication: Application,
+) => {
+  const changedInstanceIds = application.instances
+    .filter((instance) => {
+      const oldInstance = oldApplication.findInstance(instance.id);
+      return (
+        oldInstance &&
+        oldInstance.statusInfo.status !== instance.statusInfo.status
+      );
+    })
+    .map((instance) => instance.id);
+
+  if (changedInstanceIds.length === 1) {
+    return changedInstanceIds[0];
+  }
+  if (application.instances.length === 1) {
+    return application.instances[0].id;
+  }
+  return undefined;
+};
+
+const getNotificationTimeout = () =>
+  sbaConfig.uiSettings.browserNotificationTimeout ?? 5000;
 
 const requestPermissions = async () => {
   if ('Notification' in window) {
@@ -33,6 +68,9 @@ const requestPermissions = async () => {
 };
 
 const notifyForSingleChange = (application, oldApplication) => {
+  const instanceId = findChangedInstanceId(application, oldApplication);
+  const url = instanceId ? buildInstanceDetailsUrl(instanceId) : undefined;
+
   return createNotification(
     `${application.name} is now ${application.status}`,
     {
@@ -44,7 +82,8 @@ const notifyForSingleChange = (application, oldApplication) => {
           ? sbaConfig.uiSettings.favicon
           : sbaConfig.uiSettings.faviconDanger,
       renotify: true,
-      timeout: 5000,
+      timeout: getNotificationTimeout(),
+      url,
     },
   );
 };
@@ -57,14 +96,14 @@ const notifyForBulkChange = ({ count, status, oldStatus }) => {
       status === HealthStatus.UP
         ? sbaConfig.uiSettings.favicon
         : sbaConfig.uiSettings.faviconDanger,
-    timeout: 5000,
+    timeout: getNotificationTimeout(),
   });
 };
 
-const createNotification = (title, options) => {
+const createNotification = (title, options: BrowserNotificationOptions) => {
   if (granted) {
     const notification = new window.Notification(title, options);
-    if (options.url !== null) {
+    if (options.url) {
       notification.onclick = () => {
         window.focus();
         window.open(options.url, '_self');

--- a/spring-boot-admin-server-ui/src/main/frontend/notifications.ts
+++ b/spring-boot-admin-server-ui/src/main/frontend/notifications.ts
@@ -114,11 +114,10 @@ const createNotification = (title, options: BrowserNotificationOptions) => {
         window.open(url, '_self');
       };
     }
-    notification.onshow = () => {
-      if (timeout > 0) {
+    if (timeout > 0) {
+      notification.onshow = () =>
         setTimeout(() => notification.close(), timeout);
-      }
-    };
+    }
   }
 };
 

--- a/spring-boot-admin-server-ui/src/main/frontend/notifications.ts
+++ b/spring-boot-admin-server-ui/src/main/frontend/notifications.ts
@@ -106,7 +106,7 @@ const createNotification = (title, options: BrowserNotificationOptions) => {
     const notification = new window.Notification(title, {
       ...notificationOptions,
       // Keep visible until the user dismisses when timeout is <= 0
-      requireInteraction: !(timeout > 0),
+      requireInteraction: timeout <= 0,
     });
     if (url) {
       notification.onclick = () => {

--- a/spring-boot-admin-server-ui/src/main/frontend/sba-config.ts
+++ b/spring-boot-admin-server-ui/src/main/frontend/sba-config.ts
@@ -28,6 +28,7 @@ const DEFAULT_CONFIG: SBASettings = {
     },
     rememberMeEnabled: true,
     enableToasts: false,
+    browserNotificationTimeout: 5000,
     externalViews: [] as ExternalView[],
     favicon: 'assets/img/favicon.png',
     faviconDanger: 'assets/img/favicon-danger.png',

--- a/spring-boot-admin-server-ui/src/main/java/de/codecentric/boot/admin/server/ui/config/AdminServerUiAutoConfiguration.java
+++ b/spring-boot-admin-server-ui/src/main/java/de/codecentric/boot/admin/server/ui/config/AdminServerUiAutoConfiguration.java
@@ -104,8 +104,7 @@ public class AdminServerUiAutoConfiguration {
 			.favicon(this.adminUi.getFavicon())
 			.faviconDanger(this.adminUi.getFaviconDanger())
 			.enableToasts(this.adminUi.getEnableToasts())
-			.browserNotificationTimeout(
-					(int) this.adminUi.getBrowserNotificationTimeout().toMillis())
+			.browserNotificationTimeout(this.adminUi.getBrowserNotificationTimeout().toMillis())
 			.hideInstanceUrl(this.adminUi.getHideInstanceUrl())
 			.disableInstanceUrl(this.adminUi.getDisableInstanceUrl())
 			.notificationFilterEnabled(

--- a/spring-boot-admin-server-ui/src/main/java/de/codecentric/boot/admin/server/ui/config/AdminServerUiAutoConfiguration.java
+++ b/spring-boot-admin-server-ui/src/main/java/de/codecentric/boot/admin/server/ui/config/AdminServerUiAutoConfiguration.java
@@ -104,6 +104,7 @@ public class AdminServerUiAutoConfiguration {
 			.favicon(this.adminUi.getFavicon())
 			.faviconDanger(this.adminUi.getFaviconDanger())
 			.enableToasts(this.adminUi.getEnableToasts())
+			.browserNotificationTimeout(this.adminUi.getBrowserNotificationTimeout())
 			.hideInstanceUrl(this.adminUi.getHideInstanceUrl())
 			.disableInstanceUrl(this.adminUi.getDisableInstanceUrl())
 			.notificationFilterEnabled(

--- a/spring-boot-admin-server-ui/src/main/java/de/codecentric/boot/admin/server/ui/config/AdminServerUiAutoConfiguration.java
+++ b/spring-boot-admin-server-ui/src/main/java/de/codecentric/boot/admin/server/ui/config/AdminServerUiAutoConfiguration.java
@@ -104,7 +104,8 @@ public class AdminServerUiAutoConfiguration {
 			.favicon(this.adminUi.getFavicon())
 			.faviconDanger(this.adminUi.getFaviconDanger())
 			.enableToasts(this.adminUi.getEnableToasts())
-			.browserNotificationTimeout(this.adminUi.getBrowserNotificationTimeout())
+			.browserNotificationTimeout(
+					(int) this.adminUi.getBrowserNotificationTimeout().toMillis())
 			.hideInstanceUrl(this.adminUi.getHideInstanceUrl())
 			.disableInstanceUrl(this.adminUi.getDisableInstanceUrl())
 			.notificationFilterEnabled(

--- a/spring-boot-admin-server-ui/src/main/java/de/codecentric/boot/admin/server/ui/config/AdminServerUiProperties.java
+++ b/spring-boot-admin-server-ui/src/main/java/de/codecentric/boot/admin/server/ui/config/AdminServerUiProperties.java
@@ -132,10 +132,11 @@ public class AdminServerUiProperties {
 	private Boolean enableToasts = false;
 
 	/**
-	 * Auto-dismiss timeout in milliseconds for browser notifications triggered on
-	 * application status changes. Set to {@code 0} to disable auto-dismiss.
+	 * Auto-dismiss timeout for browser notifications triggered on application status
+	 * changes. Set to {@code 0} to disable auto-dismiss. Converted to milliseconds when
+	 * passed to the UI.
 	 */
-	private int browserNotificationTimeout = 5000;
+	private Duration browserNotificationTimeout = Duration.ofSeconds(5);
 
 	/**
 	 * Set to <code>true</code> to hide service URLs as well as actions that require them

--- a/spring-boot-admin-server-ui/src/main/java/de/codecentric/boot/admin/server/ui/config/AdminServerUiProperties.java
+++ b/spring-boot-admin-server-ui/src/main/java/de/codecentric/boot/admin/server/ui/config/AdminServerUiProperties.java
@@ -133,10 +133,11 @@ public class AdminServerUiProperties {
 
 	/**
 	 * Auto-dismiss timeout for browser notifications triggered on application status
-	 * changes. Set to {@code 0} to disable auto-dismiss. Converted to milliseconds when
+	 * changes. Values {@code <= 0} disable auto-dismiss. Converted to milliseconds when
 	 * passed to the UI.
 	 */
-	private Duration browserNotificationTimeout = Duration.ofSeconds(5);
+	@DurationUnit(ChronoUnit.MILLIS)
+	private Duration browserNotificationTimeout = Duration.ofMillis(5000);
 
 	/**
 	 * Set to <code>true</code> to hide service URLs as well as actions that require them

--- a/spring-boot-admin-server-ui/src/main/java/de/codecentric/boot/admin/server/ui/config/AdminServerUiProperties.java
+++ b/spring-boot-admin-server-ui/src/main/java/de/codecentric/boot/admin/server/ui/config/AdminServerUiProperties.java
@@ -132,6 +132,12 @@ public class AdminServerUiProperties {
 	private Boolean enableToasts = false;
 
 	/**
+	 * Auto-dismiss timeout in milliseconds for browser notifications triggered on
+	 * application status changes. Set to {@code 0} to disable auto-dismiss.
+	 */
+	private int browserNotificationTimeout = 5000;
+
+	/**
 	 * Set to <code>true</code> to hide service URLs as well as actions that require them
 	 * in UI (e.g. jump to /health or /actuator).
 	 */

--- a/spring-boot-admin-server-ui/src/main/java/de/codecentric/boot/admin/server/ui/web/UiController.java
+++ b/spring-boot-admin-server-ui/src/main/java/de/codecentric/boot/admin/server/ui/web/UiController.java
@@ -167,7 +167,7 @@ public class UiController {
 
 		private final Boolean enableToasts;
 
-		private final int browserNotificationTimeout;
+		private final long browserNotificationTimeout;
 
 		private final Boolean hideInstanceUrl;
 

--- a/spring-boot-admin-server-ui/src/main/java/de/codecentric/boot/admin/server/ui/web/UiController.java
+++ b/spring-boot-admin-server-ui/src/main/java/de/codecentric/boot/admin/server/ui/web/UiController.java
@@ -167,6 +167,8 @@ public class UiController {
 
 		private final Boolean enableToasts;
 
+		private final int browserNotificationTimeout;
+
 		private final Boolean hideInstanceUrl;
 
 		private final Boolean disableInstanceUrl;

--- a/spring-boot-admin-server-ui/src/test/java/de/codecentric/boot/admin/server/ui/web/UiControllerTest.java
+++ b/spring-boot-admin-server-ui/src/test/java/de/codecentric/boot/admin/server/ui/web/UiControllerTest.java
@@ -143,6 +143,21 @@ class UiControllerTest {
 	}
 
 	@Test
+	void should_expose_browser_notification_timeout_in_settings() throws Exception {
+		UiController.Settings uiSettings = UiController.Settings.builder()
+			.browserNotificationTimeout(10000)
+			.theme(new AdminServerUiProperties.UiTheme())
+			.build();
+		MockMvc mockMvc = setupControllerWithView("", UiExtensions.EMPTY, uiSettings);
+
+		mockMvc.perform(get("http://example/login"))
+			.andExpect(status().isOk())
+			.andExpect(model().attribute("uiSettings", uiSettings));
+
+		assertThat(uiSettings.getBrowserNotificationTimeout()).isEqualTo(10000);
+	}
+
+	@Test
 	void should_render_login_view_with_anonymous_user_model() throws Exception {
 		UiController.Settings uiSettings = UiController.Settings.builder()
 			.theme(new AdminServerUiProperties.UiTheme())

--- a/spring-boot-admin-server-ui/src/test/java/de/codecentric/boot/admin/server/ui/web/UiControllerTest.java
+++ b/spring-boot-admin-server-ui/src/test/java/de/codecentric/boot/admin/server/ui/web/UiControllerTest.java
@@ -145,7 +145,7 @@ class UiControllerTest {
 	@Test
 	void should_expose_browser_notification_timeout_in_settings() throws Exception {
 		UiController.Settings uiSettings = UiController.Settings.builder()
-			.browserNotificationTimeout(10000)
+			.browserNotificationTimeout(10000L)
 			.theme(new AdminServerUiProperties.UiTheme())
 			.build();
 		MockMvc mockMvc = setupControllerWithView("", UiExtensions.EMPTY, uiSettings);
@@ -154,7 +154,7 @@ class UiControllerTest {
 			.andExpect(status().isOk())
 			.andExpect(model().attribute("uiSettings", uiSettings));
 
-		assertThat(uiSettings.getBrowserNotificationTimeout()).isEqualTo(10000);
+		assertThat(uiSettings.getBrowserNotificationTimeout()).isEqualTo(10000L);
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
- Add `spring.boot.admin.ui.browser-notification-timeout` (default 5000ms; `0` disables auto-dismiss)
- Use configured timeout in browser notifications instead of hardcoded 5s
- Click notification to open instance details when the status change maps to a single instance

## Test plan
- [ ] Set `browser-notification-timeout: 0` — notification stays until dismissed
- [ ] Set `browser-notification-timeout: 10000` — notification auto-dismisses after 10s
- [ ] Single-instance app status change — click opens `/instances/{id}/details`
- [ ] `npm test -- --run notifications.spec.ts` passes